### PR TITLE
Reduced Return Count in PHPDoc Punctuation Rules

### DIFF
--- a/src/Rules/PhpDocPunctuationClassRule.php
+++ b/src/Rules/PhpDocPunctuationClassRule.php
@@ -41,18 +41,9 @@ final readonly class PhpDocPunctuationClassRule implements Rule
     {
         /** @var Class_ $node */
         $docComment = $node->getDocComment();
+        $summary = $docComment !== null ? SummaryExtractor::extract($docComment->getText()) : null;
 
-        if ($docComment === null) {
-            return [];
-        }
-
-        $summary = SummaryExtractor::extract($docComment->getText());
-
-        if ($summary === null) {
-            return [];
-        }
-
-        if ($this->endsWithPunctuation($summary)) {
+        if ($summary === null || $this->endsWithPunctuation($summary)) {
             return [];
         }
 

--- a/src/Rules/PhpDocPunctuationMethodRule.php
+++ b/src/Rules/PhpDocPunctuationMethodRule.php
@@ -47,18 +47,9 @@ final readonly class PhpDocPunctuationMethodRule implements Rule
 
         /** @var ClassMethod $node */
         $docComment = $node->getDocComment();
+        $summary = $docComment !== null ? SummaryExtractor::extract($docComment->getText()) : null;
 
-        if ($docComment === null) {
-            return [];
-        }
-
-        $summary = SummaryExtractor::extract($docComment->getText());
-
-        if ($summary === null) {
-            return [];
-        }
-
-        if ($this->endsWithPunctuation($summary)) {
+        if ($summary === null || $this->endsWithPunctuation($summary)) {
             return [];
         }
 


### PR DESCRIPTION
- Refactored processNode in both PHPDoc punctuation rules to merge early-return conditions

Closes #49

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal control flow logic for improved code maintainability and clarity. Existing functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->