### PR TITLE
Make ReturnDescriptionCapitalRule Readonly for Consistency

### DIFF
--- a/src/Rules/ReturnDescriptionCapitalRule.php
+++ b/src/Rules/ReturnDescriptionCapitalRule.php
@@ -27,7 +27,7 @@ use PHPStan\Rules\RuleErrorBuilder;
  *
  * @implements Rule<ClassMethod>
  */
-final class ReturnDescriptionCapitalRule implements Rule
+final readonly class ReturnDescriptionCapitalRule implements Rule
 {
     private readonly Lexer $lexer;
 


### PR DESCRIPTION
- Updated class declaration from `final class` to `final readonly class`

Closes #65

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Applied internal code improvements to strengthen class immutability constraints, enhancing the reliability and maintainability of the codebase without affecting user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->