### PR TITLE
PHPDoc Enforcement Rule for Overridden Methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@
 | `PhpDocMissingPropertyRule`   | Every public property in a class must have a PHPDoc comment (configurable)              |
 | `ReturnDescriptionCapitalRule` | `@return` tag description must start with a capital letter                             |
 | `ParamDescriptionCapitalRule`  | `@param` tag descriptions must start with a capital letter                             |
+| `NoPhpDocForOverriddenRule`    | Overridden methods (`#[Override]`) must not have a PHPDoc comment                      |
 
 ---
 

--- a/rules.neon
+++ b/rules.neon
@@ -282,3 +282,7 @@ services:
         class: Haspadar\PHPStanRules\Rules\ParamDescriptionCapitalRule
         tags:
             - phpstan.rules.rule
+    -
+        class: Haspadar\PHPStanRules\Rules\NoPhpDocForOverriddenRule
+        tags:
+            - phpstan.rules.rule

--- a/src/Rules.php
+++ b/src/Rules.php
@@ -46,6 +46,7 @@ final class Rules
             Rules\PhpDocMissingPropertyRule::class,
             Rules\ReturnDescriptionCapitalRule::class,
             Rules\ParamDescriptionCapitalRule::class,
+            Rules\NoPhpDocForOverriddenRule::class,
         ];
     }
 }

--- a/src/Rules/NoPhpDocForOverriddenRule.php
+++ b/src/Rules/NoPhpDocForOverriddenRule.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Rules;
+
+use Override;
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * Checks that overridden methods do not have a PHPDoc comment.
+ * Overridden methods are detected by the presence of the #[Override] attribute.
+ * A method is considered overridden when it carries the #[Override] attribute (PHP 8.3+).
+ * Documentation is inherited from the parent declaration and must not be duplicated.
+ *
+ * @implements Rule<ClassMethod>
+ */
+final readonly class NoPhpDocForOverriddenRule implements Rule
+{
+    /** @psalm-suppress InvalidAttribute -- psalm/psalm#11723 */
+    #[Override]
+    public function getNodeType(): string
+    {
+        return ClassMethod::class;
+    }
+
+    /**
+     * @psalm-suppress InvalidAttribute -- psalm/psalm#11723
+     *
+     * @throws \PHPStan\ShouldNotHappenException
+     *
+     * @return list<IdentifierRuleError>
+     */
+    #[Override]
+    public function processNode(
+        Node $node,
+        Scope $scope,
+    ): array {
+        /** @var ClassMethod $node */
+        if (!$this->hasOverrideAttribute($node) || $node->getDocComment() === null) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message(
+                sprintf(
+                    'Overridden method %s() must not have a PHPDoc comment.',
+                    $node->name->toString(),
+                ),
+            )
+                ->identifier('haspadar.noPhpdocOverride')
+                ->build(),
+        ];
+    }
+
+    /** Returns true if the method has the #[Override] attribute */
+    private function hasOverrideAttribute(ClassMethod $node): bool
+    {
+        foreach ($node->attrGroups as $attrGroup) {
+            foreach ($attrGroup->attrs as $attr) {
+                if (in_array($attr->name->toString(), ['Override', '\Override'], true)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/Fixtures/Rules/NoPhpDocForOverriddenRule/ChildWithPhpDoc.php
+++ b/tests/Fixtures/Rules/NoPhpDocForOverriddenRule/ChildWithPhpDoc.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoPhpDocForOverriddenRule;
+
+/** A child class. */
+final class ChildWithPhpDoc extends OverriddenMethodWithPhpDoc
+{
+    /**
+     * Does something specific.
+     */
+    #[\Override]
+    public function doSomething(): void {}
+}

--- a/tests/Fixtures/Rules/NoPhpDocForOverriddenRule/ChildWithoutPhpDoc.php
+++ b/tests/Fixtures/Rules/NoPhpDocForOverriddenRule/ChildWithoutPhpDoc.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoPhpDocForOverriddenRule;
+
+/** A child class. */
+final class ChildWithoutPhpDoc extends OverriddenMethodWithPhpDoc
+{
+    #[\Override]
+    public function doSomething(): void {}
+}

--- a/tests/Fixtures/Rules/NoPhpDocForOverriddenRule/NonOverriddenMethodWithPhpDoc.php
+++ b/tests/Fixtures/Rules/NoPhpDocForOverriddenRule/NonOverriddenMethodWithPhpDoc.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoPhpDocForOverriddenRule;
+
+/** A standalone class. */
+final class NonOverriddenMethodWithPhpDoc
+{
+    /** Does something. */
+    public function doSomething(): void {}
+}

--- a/tests/Fixtures/Rules/NoPhpDocForOverriddenRule/OverriddenMethodWithPhpDoc.php
+++ b/tests/Fixtures/Rules/NoPhpDocForOverriddenRule/OverriddenMethodWithPhpDoc.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoPhpDocForOverriddenRule;
+
+/** A base class. */
+abstract class OverriddenMethodWithPhpDoc
+{
+    /** Does something. */
+    abstract public function doSomething(): void;
+}

--- a/tests/Fixtures/Rules/NoPhpDocForOverriddenRule/SuppressedOverriddenMethod.php
+++ b/tests/Fixtures/Rules/NoPhpDocForOverriddenRule/SuppressedOverriddenMethod.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoPhpDocForOverriddenRule;
+
+/** A child class with suppressed rule. */
+final class SuppressedOverriddenMethod extends OverriddenMethodWithPhpDoc
+{
+    /** Does something specific. */
+    // @phpstan-ignore haspadar.noPhpdocOverride
+    #[\Override]
+    public function doSomething(): void {}
+}

--- a/tests/Unit/Rules/NoPhpDocForOverriddenRule/NoPhpDocForOverriddenRuleTest.php
+++ b/tests/Unit/Rules/NoPhpDocForOverriddenRule/NoPhpDocForOverriddenRuleTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\NoPhpDocForOverriddenRule;
+
+use Haspadar\PHPStanRules\Rules\NoPhpDocForOverriddenRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<NoPhpDocForOverriddenRule> */
+final class NoPhpDocForOverriddenRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new NoPhpDocForOverriddenRule();
+    }
+
+    #[Test]
+    public function reportsErrorWhenOverriddenMethodHasPhpDoc(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/../../../Fixtures/Rules/NoPhpDocForOverriddenRule/OverriddenMethodWithPhpDoc.php',
+                __DIR__ . '/../../../Fixtures/Rules/NoPhpDocForOverriddenRule/ChildWithPhpDoc.php',
+            ],
+            [
+                ['Overridden method doSomething() must not have a PHPDoc comment.', 13],
+            ],
+            'Overridden method with PHPDoc must be reported',
+        );
+    }
+
+    #[Test]
+    public function passesWhenOverriddenMethodHasNoPhpDoc(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/../../../Fixtures/Rules/NoPhpDocForOverriddenRule/OverriddenMethodWithPhpDoc.php',
+                __DIR__ . '/../../../Fixtures/Rules/NoPhpDocForOverriddenRule/ChildWithoutPhpDoc.php',
+            ],
+            [],
+            'Overridden method without PHPDoc should pass',
+        );
+    }
+
+    #[Test]
+    public function passesWhenNonOverriddenMethodHasPhpDoc(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NoPhpDocForOverriddenRule/NonOverriddenMethodWithPhpDoc.php'],
+            [],
+            'Non-overridden method with PHPDoc should pass',
+        );
+    }
+
+    #[Test]
+    public function suppressesErrorWhenPhpstanIgnorePresent(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/../../../Fixtures/Rules/NoPhpDocForOverriddenRule/OverriddenMethodWithPhpDoc.php',
+                __DIR__ . '/../../../Fixtures/Rules/NoPhpDocForOverriddenRule/SuppressedOverriddenMethod.php',
+            ],
+            [],
+            'Suppressed error should pass',
+        );
+    }
+}

--- a/tests/Unit/RulesTest.php
+++ b/tests/Unit/RulesTest.php
@@ -28,6 +28,7 @@ use Haspadar\PHPStanRules\Rules\PhpDocEmptyMethodRule;
 use Haspadar\PHPStanRules\Rules\PhpDocMissingClassRule;
 use Haspadar\PHPStanRules\Rules\PhpDocMissingMethodRule;
 use Haspadar\PHPStanRules\Rules\PhpDocMissingPropertyRule;
+use Haspadar\PHPStanRules\Rules\NoPhpDocForOverriddenRule;
 use Haspadar\PHPStanRules\Rules\ParamDescriptionCapitalRule;
 use Haspadar\PHPStanRules\Rules\ReturnDescriptionCapitalRule;
 use Haspadar\PHPStanRules\Rules\ProhibitPublicStaticMethodsRule;
@@ -73,6 +74,7 @@ final class RulesTest extends TestCase
                 PhpDocMissingPropertyRule::class,
                 ReturnDescriptionCapitalRule::class,
                 ParamDescriptionCapitalRule::class,
+                NoPhpDocForOverriddenRule::class,
             ],
             (new Rules())->all(),
             'Rules::all() must list every registered rule class',


### PR DESCRIPTION
- Added `NoPhpDocForOverriddenRule` to report PHPDoc on methods marked with `#[Override]`
- Added test fixtures covering overridden with PHPDoc, without PHPDoc, non-overridden, and suppressed cases
- Updated `Rules::all()`, `rules.neon`, and `README.md` to register the new rule

Closes #73

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new PHPStan rule that enforces methods marked with the `#[Override]` attribute must not include PHPDoc comments, ensuring consistent documentation standards for overridden methods.

* **Documentation**
  * Updated the README to include documentation for the new rule in the PHPDoc style section.

* **Tests**
  * Added comprehensive test fixtures and test cases to validate the rule's behavior across various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->