### PR TITLE
Add VariableNameRule — enforce variable name pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@
 | Rule                              | Default | Description                                                                |
 |-----------------------------------|---------|----------------------------------------------------------------------------|
 | `AbbreviationAsWordInNameRule`    | 4       | Identifier must not contain more than N consecutive capital letters         |
+| `VariableNameRule`                | `^[a-z][a-zA-Z]{2,19}$` | Local variable name must match the configured pattern         |
 
 ### PHPDoc style
 
@@ -133,6 +134,13 @@ parameters:
             allowedAbbreviations:
                 - JSON
                 - HTTP
+        variableName:
+            pattern: '^[a-z][a-zA-Z]{2,9}$'
+            allowedNames:
+                - id
+                - i
+                - j
+                - db
 ```
 
 Default values match the defaults described in the rules table above. Omitting a parameter keeps the default. Diagnostic identifier for `AtclauseOrderRule`: `haspadar.atclauseOrder` (for targeted ignores, e.g. `@phpstan-ignore haspadar.atclauseOrder`).

--- a/rules.neon
+++ b/rules.neon
@@ -60,6 +60,12 @@ parameters:
         abbreviation:
             maxAllowedConsecutiveCapitals: 4
             allowedAbbreviations: []
+        variableName:
+            pattern: '^[a-z][a-zA-Z]{2,19}$'
+            allowedNames:
+                - id
+                - i
+                - j
 
 parametersSchema:
     haspadar: structure([
@@ -131,6 +137,10 @@ parametersSchema:
         abbreviation: structure([
             maxAllowedConsecutiveCapitals: int(),
             allowedAbbreviations: listOf(string()),
+        ]),
+        variableName: structure([
+            pattern: string(),
+            allowedNames: listOf(string()),
         ]),
     ])
 
@@ -340,5 +350,13 @@ services:
             maxAllowedConsecutiveCapitals: %haspadar.abbreviation.maxAllowedConsecutiveCapitals%
             options:
                 allowedAbbreviations: %haspadar.abbreviation.allowedAbbreviations%
+        tags:
+            - phpstan.rules.rule
+    -
+        class: Haspadar\PHPStanRules\Rules\VariableNameRule
+        arguments:
+            pattern: %haspadar.variableName.pattern%
+            options:
+                allowedNames: %haspadar.variableName.allowedNames%
         tags:
             - phpstan.rules.rule

--- a/src/Rules.php
+++ b/src/Rules.php
@@ -53,6 +53,7 @@ final class Rules
             Rules\NoLineCommentBeforeDeclarationRule::class,
             Rules\NoInlineCommentRule::class,
             Rules\AbbreviationAsWordInNameRule::class,
+            Rules\VariableNameRule::class,
         ];
     }
 }

--- a/src/Rules/VariableCollector.php
+++ b/src/Rules/VariableCollector.php
@@ -137,7 +137,7 @@ final class VariableCollector
      */
     private function toNameLine(Node\Expr $expr): array
     {
-        return $expr instanceof Variable && is_string($expr->name)
+        return $expr instanceof Variable && is_string($expr->name) && $expr->name !== 'this'
             ? [[$expr->name, $expr->getStartLine()]]
             : [];
     }

--- a/src/Rules/VariableCollector.php
+++ b/src/Rules/VariableCollector.php
@@ -59,19 +59,12 @@ final class VariableCollector
      */
     private function variablesFromNode(Node $found): array
     {
-        if ($found instanceof Assign || $found instanceof AssignRef) {
-            return $this->variablesFromTarget($found->var);
-        }
-
-        if ($found instanceof Foreach_) {
-            return $this->variablesFromForeach($found);
-        }
-
-        if ($found instanceof Static_) {
-            return $this->variablesFromStatic($found);
-        }
-
-        return [];
+        return match (true) {
+            $found instanceof Assign, $found instanceof AssignRef => $this->variablesFromTarget($found->var),
+            $found instanceof Foreach_ => $this->variablesFromForeach($found),
+            $found instanceof Static_ => $this->variablesFromStatic($found),
+            default => [],
+        };
     }
 
     /**

--- a/src/Rules/VariableCollector.php
+++ b/src/Rules/VariableCollector.php
@@ -13,7 +13,6 @@ use PhpParser\Node\Expr\List_;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
-use PhpParser\Node\Stmt\For_;
 use PhpParser\Node\Stmt\Foreach_;
 use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\Static_;
@@ -21,7 +20,7 @@ use PhpParser\NodeFinder;
 
 /**
  * Collects local variable names with line numbers from a method body.
- * Handles assignments, foreach, for, destructuring, and static variables.
+ * Handles assignments, foreach, destructuring, and static variables.
  * Excludes variables inside nested scopes (closures, arrow functions,
  * anonymous classes, nested functions).
  */
@@ -40,7 +39,6 @@ final class VariableCollector
             static fn(Node $n): bool => ($n instanceof Assign
                 || $n instanceof AssignRef
                 || $n instanceof Foreach_
-                || $n instanceof For_
                 || $n instanceof Static_)
                 && !self::isInsideScopeBoundary($n, $node),
         );
@@ -69,10 +67,6 @@ final class VariableCollector
             return $this->variablesFromForeach($found);
         }
 
-        if ($found instanceof For_) {
-            return $this->variablesFromFor($found);
-        }
-
         if ($found instanceof Static_) {
             return $this->variablesFromStatic($found);
         }
@@ -92,24 +86,6 @@ final class VariableCollector
             : [];
 
         return array_merge($result, $this->variablesFromTarget($node->valueVar));
-    }
-
-    /**
-     * Extracts variables from for-loop init expressions.
-     *
-     * @return list<array{string, int}>
-     */
-    private function variablesFromFor(For_ $node): array
-    {
-        $result = [];
-
-        foreach ($node->init as $init) {
-            if (($init instanceof Assign || $init instanceof AssignRef) && $init->var instanceof Variable) {
-                $result = array_merge($result, $this->toNameLine($init->var));
-            }
-        }
-
-        return $result;
     }
 
     /**

--- a/src/Rules/VariableCollector.php
+++ b/src/Rules/VariableCollector.php
@@ -87,11 +87,11 @@ final class VariableCollector
      */
     private function variablesFromForeach(Foreach_ $node): array
     {
-        $result = $this->toNameLine($node->valueVar);
+        $result = $node->keyVar !== null
+            ? $this->variablesFromTarget($node->keyVar)
+            : [];
 
-        return $node->keyVar !== null
-            ? array_merge($result, $this->toNameLine($node->keyVar))
-            : $result;
+        return array_merge($result, $this->variablesFromTarget($node->valueVar));
     }
 
     /**

--- a/src/Rules/VariableCollector.php
+++ b/src/Rules/VariableCollector.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\ArrowFunction;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\AssignRef;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Expr\List_;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\For_;
+use PhpParser\Node\Stmt\Foreach_;
+use PhpParser\Node\Stmt\Function_;
+use PhpParser\Node\Stmt\Static_;
+use PhpParser\NodeFinder;
+
+/**
+ * Collects local variable names with line numbers from a method body.
+ * Handles assignments, foreach, for, destructuring, and static variables.
+ * Excludes variables inside nested scopes (closures, arrow functions,
+ * anonymous classes, nested functions).
+ */
+final class VariableCollector
+{
+    /**
+     * Returns all local variable name-line pairs from the method body.
+     *
+     * @return list<array{string, int}>
+     */
+    public function collect(ClassMethod $node): array
+    {
+        /** @var list<Node> $nodes */
+        $nodes = (new NodeFinder())->find(
+            $node->stmts ?? [],
+            static fn(Node $n): bool => ($n instanceof Assign
+                || $n instanceof AssignRef
+                || $n instanceof Foreach_
+                || $n instanceof For_
+                || $n instanceof Static_)
+                && !self::isInsideScopeBoundary($n, $node),
+        );
+
+        $vars = [];
+
+        foreach ($nodes as $found) {
+            $vars = array_merge($vars, $this->variablesFromNode($found));
+        }
+
+        return $vars;
+    }
+
+    /**
+     * Extracts name-line pairs from an AST node.
+     *
+     * @return list<array{string, int}>
+     */
+    private function variablesFromNode(Node $found): array
+    {
+        if ($found instanceof Assign || $found instanceof AssignRef) {
+            return $this->variablesFromTarget($found->var);
+        }
+
+        if ($found instanceof Foreach_) {
+            return $this->variablesFromForeach($found);
+        }
+
+        if ($found instanceof For_) {
+            return $this->variablesFromFor($found);
+        }
+
+        if ($found instanceof Static_) {
+            return $this->variablesFromStatic($found);
+        }
+
+        return [];
+    }
+
+    /**
+     * Extracts variables from foreach key and value.
+     *
+     * @return list<array{string, int}>
+     */
+    private function variablesFromForeach(Foreach_ $node): array
+    {
+        $result = $this->toNameLine($node->valueVar);
+
+        return $node->keyVar !== null
+            ? array_merge($result, $this->toNameLine($node->keyVar))
+            : $result;
+    }
+
+    /**
+     * Extracts variables from for-loop init expressions.
+     *
+     * @return list<array{string, int}>
+     */
+    private function variablesFromFor(For_ $node): array
+    {
+        $result = [];
+
+        foreach ($node->init as $init) {
+            if (($init instanceof Assign || $init instanceof AssignRef) && $init->var instanceof Variable) {
+                $result = array_merge($result, $this->toNameLine($init->var));
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Extracts variables from static variable declarations.
+     *
+     * @return list<array{string, int}>
+     */
+    private function variablesFromStatic(Static_ $node): array
+    {
+        $result = [];
+
+        foreach ($node->vars as $staticVar) {
+            $result = array_merge($result, $this->toNameLine($staticVar->var));
+        }
+
+        return $result;
+    }
+
+    /**
+     * Extracts variables from an assignment target, handling destructuring.
+     *
+     * @return list<array{string, int}>
+     */
+    private function variablesFromTarget(Node $target): array
+    {
+        if ($target instanceof Variable) {
+            return $this->toNameLine($target);
+        }
+
+        if (!($target instanceof Node\Expr\Array_) && !($target instanceof List_)) {
+            return [];
+        }
+
+        $result = [];
+
+        foreach ($target->items as $item) {
+            if ($item !== null) {
+                $result = array_merge($result, $this->variablesFromTarget($item->value));
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Returns a single-element list with variable name and line, or empty.
+     *
+     * @return list<array{string, int}>
+     */
+    private function toNameLine(Node\Expr $expr): array
+    {
+        return $expr instanceof Variable && is_string($expr->name)
+            ? [[$expr->name, $expr->getStartLine()]]
+            : [];
+    }
+
+    /**
+     * Returns true if the node is nested inside a scope boundary.
+     */
+    private static function isInsideScopeBoundary(Node $target, ClassMethod $method): bool
+    {
+        return (new NodeFinder())->find(
+            $method->stmts ?? [],
+            static fn(Node $n): bool => ($n instanceof Closure
+                || $n instanceof ArrowFunction
+                || $n instanceof Function_
+                || $n instanceof Class_)
+                && (new NodeFinder())->findFirst([$n], static fn(Node $inner): bool => $inner === $target) !== null,
+        ) !== [];
+    }
+}

--- a/src/Rules/VariableNameRule.php
+++ b/src/Rules/VariableNameRule.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Rules;
+
+use Override;
+use PhpParser\Node;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\ShouldNotHappenException;
+
+/**
+ * Checks that local variable names match a configurable regex pattern.
+ * Validates assignments, foreach, for, destructuring, and static variables.
+ * Skips parameters, catch, $this, and nested scopes.
+ *
+ * @implements Rule<ClassMethod>
+ */
+final readonly class VariableNameRule implements Rule
+{
+    /** @var list<string> */
+    private array $allowedNames;
+
+    /**
+     * Constructs the rule with the given pattern and options.
+     *
+     * @param array{allowedNames?: list<string>} $options
+     */
+    public function __construct(
+        private string $pattern = '^[a-z][a-zA-Z]{2,19}$',
+        array $options = [],
+    ) {
+        $this->allowedNames = $options['allowedNames'] ?? ['id', 'i', 'j'];
+    }
+
+    #[Override]
+    public function getNodeType(): string
+    {
+        return ClassMethod::class;
+    }
+
+    /**
+     * Analyses the node and returns a list of errors.
+     *
+     * @psalm-param ClassMethod $node
+     * @throws ShouldNotHappenException
+     * @return list<IdentifierRuleError>
+     */
+    #[Override]
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $paramNames = $this->parameterNames($node);
+        $errors = [];
+        $checked = [];
+
+        foreach ((new VariableCollector())->collect($node) as [$name, $line]) {
+            if ($name === 'this' || in_array($name, $paramNames, true)) {
+                continue;
+            }
+
+            if (array_key_exists($name, $checked)) {
+                continue;
+            }
+
+            $checked[$name] = true;
+
+            if (in_array($name, $this->allowedNames, true)) {
+                continue;
+            }
+
+            if (preg_match('/' . $this->pattern . '/', $name) === 1) {
+                continue;
+            }
+
+            $errors[] = RuleErrorBuilder::message(
+                sprintf('Variable $%s does not match pattern /%s/.', $name, $this->pattern),
+            )
+                ->identifier('haspadar.variableName')
+                ->line($line)
+                ->build();
+        }
+
+        return $errors;
+    }
+
+    /**
+     * Returns parameter names for the given method node.
+     *
+     * @return list<string>
+     */
+    private function parameterNames(ClassMethod $node): array
+    {
+        $names = [];
+
+        foreach ($node->params as $param) {
+            if ($param->var instanceof Variable && is_string($param->var->name)) {
+                $names[] = $param->var->name;
+            }
+        }
+
+        return $names;
+    }
+}

--- a/tests/Fixtures/Rules/VariableNameRule/AllowedName.php
+++ b/tests/Fixtures/Rules/VariableNameRule/AllowedName.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\VariableNameRule;
+
+final class AllowedName
+{
+    public function run(): void
+    {
+        $db = 'connection';
+        echo $db;
+    }
+}

--- a/tests/Fixtures/Rules/VariableNameRule/ArrowFunctionVariable.php
+++ b/tests/Fixtures/Rules/VariableNameRule/ArrowFunctionVariable.php
@@ -4,14 +4,11 @@ declare(strict_types=1);
 
 namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\VariableNameRule;
 
-final class ValidNames
+final class ArrowFunctionVariable
 {
     public function run(): void
     {
-        $name = 'Alice';
-        $userId = 42;
-        $id = 1;
-        $i = 0;
-        $j = 0;
+        $handler = static fn() => $x = 1;
+        echo $handler();
     }
 }

--- a/tests/Fixtures/Rules/VariableNameRule/CatchVariable.php
+++ b/tests/Fixtures/Rules/VariableNameRule/CatchVariable.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\VariableNameRule;
 
-final class ValidNames
+final class CatchVariable
 {
     public function run(): void
     {
-        $name = 'Alice';
-        $userId = 42;
-        $id = 1;
-        $i = 0;
-        $j = 0;
+        try {
+            echo 'ok';
+        } catch (\Throwable $e) {
+            echo $e->getMessage();
+        }
     }
 }

--- a/tests/Fixtures/Rules/VariableNameRule/ClosureVariable.php
+++ b/tests/Fixtures/Rules/VariableNameRule/ClosureVariable.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\VariableNameRule;
+
+final class ClosureVariable
+{
+    public function run(): void
+    {
+        $handler = static function (): void {
+            $x = 1;
+            echo $x;
+        };
+        $handler();
+    }
+}

--- a/tests/Fixtures/Rules/VariableNameRule/DestructuringVariable.php
+++ b/tests/Fixtures/Rules/VariableNameRule/DestructuringVariable.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\VariableNameRule;
+
+final class DestructuringVariable
+{
+    public function run(): void
+    {
+        [$x, $name] = [1, 'Alice'];
+        echo $x . $name;
+    }
+}

--- a/tests/Fixtures/Rules/VariableNameRule/DuplicateAssignment.php
+++ b/tests/Fixtures/Rules/VariableNameRule/DuplicateAssignment.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\VariableNameRule;
+
+final class DuplicateAssignment
+{
+    public function run(): void
+    {
+        $x = 1;
+        $x = 2;
+        echo $x;
+    }
+}

--- a/tests/Fixtures/Rules/VariableNameRule/ForVariable.php
+++ b/tests/Fixtures/Rules/VariableNameRule/ForVariable.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\VariableNameRule;
+
+final class ForVariable
+{
+    public function run(): void
+    {
+        for ($i = 0; $i < 10; $i++) {
+            echo $i;
+        }
+    }
+}

--- a/tests/Fixtures/Rules/VariableNameRule/ForeachDestructuring.php
+++ b/tests/Fixtures/Rules/VariableNameRule/ForeachDestructuring.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\VariableNameRule;
+
+final class ForeachDestructuring
+{
+    /**
+     * @param list<array{int, string}> $rows
+     */
+    public function run(array $rows): void
+    {
+        foreach ($rows as [$x, $name]) {
+            echo $x . $name;
+        }
+    }
+}

--- a/tests/Fixtures/Rules/VariableNameRule/ForeachVariable.php
+++ b/tests/Fixtures/Rules/VariableNameRule/ForeachVariable.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\VariableNameRule;
+
+final class ForeachVariable
+{
+    /**
+     * @param list<string> $items
+     */
+    public function run(array $items): void
+    {
+        foreach ($items as $k => $v) {
+            echo $k . $v;
+        }
+    }
+}

--- a/tests/Fixtures/Rules/VariableNameRule/NameWithDigit.php
+++ b/tests/Fixtures/Rules/VariableNameRule/NameWithDigit.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\VariableNameRule;
+
+final class NameWithDigit
+{
+    public function run(): void
+    {
+        $item2 = 1;
+    }
+}

--- a/tests/Fixtures/Rules/VariableNameRule/NameWithUnderscore.php
+++ b/tests/Fixtures/Rules/VariableNameRule/NameWithUnderscore.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\VariableNameRule;
+
+final class NameWithUnderscore
+{
+    public function run(): void
+    {
+        $my_var = 1;
+    }
+}

--- a/tests/Fixtures/Rules/VariableNameRule/ParameterReassignment.php
+++ b/tests/Fixtures/Rules/VariableNameRule/ParameterReassignment.php
@@ -6,9 +6,9 @@ namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\VariableNameRule;
 
 final class ParameterReassignment
 {
-    public function run(string $name): void
+    public function run(string $n): void
     {
-        $name = strtoupper($name);
-        echo $name;
+        $n = strtoupper($n);
+        echo $n;
     }
 }

--- a/tests/Fixtures/Rules/VariableNameRule/ParameterReassignment.php
+++ b/tests/Fixtures/Rules/VariableNameRule/ParameterReassignment.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\VariableNameRule;
+
+final class ParameterReassignment
+{
+    public function run(string $name): void
+    {
+        $name = strtoupper($name);
+        echo $name;
+    }
+}

--- a/tests/Fixtures/Rules/VariableNameRule/PropertyAssignment.php
+++ b/tests/Fixtures/Rules/VariableNameRule/PropertyAssignment.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\VariableNameRule;
+
+final class PropertyAssignment
+{
+    public string $value = '';
+
+    public function run(): void
+    {
+        $this->value = 'test';
+    }
+}

--- a/tests/Fixtures/Rules/VariableNameRule/ShortName.php
+++ b/tests/Fixtures/Rules/VariableNameRule/ShortName.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\VariableNameRule;
+
+final class ShortName
+{
+    public function run(): void
+    {
+        $x = 1;
+    }
+}

--- a/tests/Fixtures/Rules/VariableNameRule/StaticVariable.php
+++ b/tests/Fixtures/Rules/VariableNameRule/StaticVariable.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\VariableNameRule;
+
+final class StaticVariable
+{
+    public function run(): void
+    {
+        static $x = 0;
+        echo $x;
+    }
+}

--- a/tests/Fixtures/Rules/VariableNameRule/SuppressedShortName.php
+++ b/tests/Fixtures/Rules/VariableNameRule/SuppressedShortName.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\VariableNameRule;
+
+final class SuppressedShortName
+{
+    public function run(): void
+    {
+        $x = 1; /** @phpstan-ignore haspadar.variableName */
+    }
+}

--- a/tests/Fixtures/Rules/VariableNameRule/TooLongName.php
+++ b/tests/Fixtures/Rules/VariableNameRule/TooLongName.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\VariableNameRule;
+
+final class TooLongName
+{
+    public function run(): void
+    {
+        $extremelyLongVariableName = 1;
+    }
+}

--- a/tests/Fixtures/Rules/VariableNameRule/ValidNames.php
+++ b/tests/Fixtures/Rules/VariableNameRule/ValidNames.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\VariableNameRule;
+
+final class ValidNames
+{
+    public function run(): void
+    {
+        $name = 'Alice';
+        $userId = 42;
+        $id = 1;
+        $i = 0;
+    }
+}

--- a/tests/Fixtures/Rules/VariableNameRule/ValidNamesCustom.php
+++ b/tests/Fixtures/Rules/VariableNameRule/ValidNamesCustom.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\VariableNameRule;
+
+final class ValidNamesCustom
+{
+    public function run(): void
+    {
+        $name = 'Alice';
+        $userId = 42;
+        $id = 1;
+    }
+}

--- a/tests/Unit/Rules/VariableNameRule/VariableNameRuleAllowedNamesTest.php
+++ b/tests/Unit/Rules/VariableNameRule/VariableNameRuleAllowedNamesTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\VariableNameRule;
+
+use Haspadar\PHPStanRules\Rules\VariableNameRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<VariableNameRule> */
+final class VariableNameRuleAllowedNamesTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new VariableNameRule('^[a-z][a-zA-Z]{2,9}$', ['allowedNames' => ['db']]);
+    }
+
+    #[Test]
+    public function passesWhenNameIsInAllowedNames(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/VariableNameRule/AllowedName.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function reportsErrorWhenNameIsNotInAllowedNames(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/VariableNameRule/ShortName.php'],
+            [
+                ['Variable $x does not match pattern /^[a-z][a-zA-Z]{2,9}$/.', 11],
+            ],
+        );
+    }
+}

--- a/tests/Unit/Rules/VariableNameRule/VariableNameRuleDefaultPatternTest.php
+++ b/tests/Unit/Rules/VariableNameRule/VariableNameRuleDefaultPatternTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\VariableNameRule;
+
+use Haspadar\PHPStanRules\Rules\VariableNameRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<VariableNameRule> */
+final class VariableNameRuleDefaultPatternTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new VariableNameRule();
+    }
+
+    #[Test]
+    public function passesWhenVariableNamesMatchDefaultPattern(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/VariableNameRule/ValidNames.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function reportsErrorWhenNameIsTooShortWithDefaultPattern(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/VariableNameRule/ShortName.php'],
+            [
+                ['Variable $x does not match pattern /^[a-z][a-zA-Z]{2,19}$/.', 11],
+            ],
+        );
+    }
+
+    #[Test]
+    public function passesWhenForVariableIsInDefaultAllowedNames(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/VariableNameRule/ForVariable.php'],
+            [],
+        );
+    }
+}

--- a/tests/Unit/Rules/VariableNameRule/VariableNameRuleTest.php
+++ b/tests/Unit/Rules/VariableNameRule/VariableNameRuleTest.php
@@ -161,4 +161,33 @@ final class VariableNameRuleTest extends RuleTestCase
             ],
         );
     }
+
+    #[Test]
+    public function skipsParameterReassignment(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/VariableNameRule/ParameterReassignment.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function reportsErrorOnceForDuplicateAssignment(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/VariableNameRule/DuplicateAssignment.php'],
+            [
+                ['Variable $x does not match pattern /^[a-z][a-zA-Z]{2,9}$/.', 11],
+            ],
+        );
+    }
+
+    #[Test]
+    public function skipsPropertyAssignment(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/VariableNameRule/PropertyAssignment.php'],
+            [],
+        );
+    }
 }

--- a/tests/Unit/Rules/VariableNameRule/VariableNameRuleTest.php
+++ b/tests/Unit/Rules/VariableNameRule/VariableNameRuleTest.php
@@ -134,6 +134,24 @@ final class VariableNameRuleTest extends RuleTestCase
     }
 
     #[Test]
+    public function skipsVariablesInsideArrowFunction(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/VariableNameRule/ArrowFunctionVariable.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function skipsVariablesInsideCatch(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/VariableNameRule/CatchVariable.php'],
+            [],
+        );
+    }
+
+    #[Test]
     public function reportsErrorForDestructuredForeachVariable(): void
     {
         $this->analyse(

--- a/tests/Unit/Rules/VariableNameRule/VariableNameRuleTest.php
+++ b/tests/Unit/Rules/VariableNameRule/VariableNameRuleTest.php
@@ -132,4 +132,15 @@ final class VariableNameRuleTest extends RuleTestCase
             ],
         );
     }
+
+    #[Test]
+    public function reportsErrorForDestructuredForeachVariable(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/VariableNameRule/ForeachDestructuring.php'],
+            [
+                ['Variable $x does not match pattern /^[a-z][a-zA-Z]{2,9}$/.', 14],
+            ],
+        );
+    }
 }

--- a/tests/Unit/Rules/VariableNameRule/VariableNameRuleTest.php
+++ b/tests/Unit/Rules/VariableNameRule/VariableNameRuleTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\VariableNameRule;
+
+use Haspadar\PHPStanRules\Rules\VariableNameRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<VariableNameRule> */
+final class VariableNameRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new VariableNameRule('^[a-z][a-zA-Z]{2,9}$', ['allowedNames' => ['id']]);
+    }
+
+    #[Test]
+    public function passesWhenVariableNamesAreValid(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/VariableNameRule/ValidNamesCustom.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function reportsErrorWhenNameIsTooShort(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/VariableNameRule/ShortName.php'],
+            [
+                ['Variable $x does not match pattern /^[a-z][a-zA-Z]{2,9}$/.', 11],
+            ],
+        );
+    }
+
+    #[Test]
+    public function reportsErrorWhenNameContainsDigit(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/VariableNameRule/NameWithDigit.php'],
+            [
+                ['Variable $item2 does not match pattern /^[a-z][a-zA-Z]{2,9}$/.', 11],
+            ],
+        );
+    }
+
+    #[Test]
+    public function reportsErrorWhenNameContainsUnderscore(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/VariableNameRule/NameWithUnderscore.php'],
+            [
+                ['Variable $my_var does not match pattern /^[a-z][a-zA-Z]{2,9}$/.', 11],
+            ],
+        );
+    }
+
+    #[Test]
+    public function reportsErrorWhenNameIsTooLong(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/VariableNameRule/TooLongName.php'],
+            [
+                ['Variable $extremelyLongVariableName does not match pattern /^[a-z][a-zA-Z]{2,9}$/.', 11],
+            ],
+        );
+    }
+
+    #[Test]
+    public function suppressesErrorWhenPhpstanIgnorePresent(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/VariableNameRule/SuppressedShortName.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function reportsErrorForInvalidForeachVariable(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/VariableNameRule/ForeachVariable.php'],
+            [
+                ['Variable $k does not match pattern /^[a-z][a-zA-Z]{2,9}$/.', 14],
+                ['Variable $v does not match pattern /^[a-z][a-zA-Z]{2,9}$/.', 14],
+            ],
+        );
+    }
+
+    #[Test]
+    public function reportsErrorForInvalidDestructuringVariable(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/VariableNameRule/DestructuringVariable.php'],
+            [
+                ['Variable $x does not match pattern /^[a-z][a-zA-Z]{2,9}$/.', 11],
+            ],
+        );
+    }
+
+    #[Test]
+    public function reportsErrorForInvalidStaticVariable(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/VariableNameRule/StaticVariable.php'],
+            [
+                ['Variable $x does not match pattern /^[a-z][a-zA-Z]{2,9}$/.', 11],
+            ],
+        );
+    }
+
+    #[Test]
+    public function skipsVariablesInsideClosure(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/VariableNameRule/ClosureVariable.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function reportsErrorWhenForVariableNotInAllowedNames(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/VariableNameRule/ForVariable.php'],
+            [
+                ['Variable $i does not match pattern /^[a-z][a-zA-Z]{2,9}$/.', 11],
+            ],
+        );
+    }
+}

--- a/tests/Unit/RulesTest.php
+++ b/tests/Unit/RulesTest.php
@@ -33,6 +33,7 @@ use Haspadar\PHPStanRules\Rules\PhpDocMissingPropertyRule;
 use Haspadar\PHPStanRules\Rules\ClassConstantTypeHintRule;
 use Haspadar\PHPStanRules\Rules\AbbreviationAsWordInNameRule;
 use Haspadar\PHPStanRules\Rules\NoInlineCommentRule;
+use Haspadar\PHPStanRules\Rules\VariableNameRule;
 use Haspadar\PHPStanRules\Rules\NoLineCommentBeforeDeclarationRule;
 use Haspadar\PHPStanRules\Rules\NoPhpDocForOverriddenRule;
 use Haspadar\PHPStanRules\Rules\ParamDescriptionCapitalRule;
@@ -87,6 +88,7 @@ final class RulesTest extends TestCase
                 NoLineCommentBeforeDeclarationRule::class,
                 NoInlineCommentRule::class,
                 AbbreviationAsWordInNameRule::class,
+                VariableNameRule::class,
             ],
             (new Rules())->all(),
             'Rules::all() must list every registered rule class',


### PR DESCRIPTION
## Summary

- Add `VariableNameRule` that checks local variable names against a configurable regex pattern
- Default pattern: `^[a-z][a-zA-Z]{2,19}$` (camelCase, 3–20 chars, no digits/underscores)
- Default `allowedNames: [id, i, j]` — exceptions that bypass pattern matching
- Extract `VariableCollector` helper for AST variable extraction logic

Closes #94

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a variable-name validation rule with configurable regex (default: ^[a-z][a-zA-Z]{2,19}$) and an exceptions list (default includes id, i, j); config supports custom pattern and allowed names (example: ^[a-z][a-zA-Z]{2,9}$ with db).

* **Documentation**
  * Updated rules reference and configuration examples to document the new rule, default pattern, and configurable pattern/allowed-names.

* **Tests**
  * Added fixtures and unit tests covering valid/invalid names, suppression, closures/arrow functions, destructuring, loops/static/catch, parameter/property cases, duplicates, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->