### PR TITLE
Implement ParameterNameRule — parameter names must match pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@
 |-----------------------------------|---------|----------------------------------------------------------------------------|
 | `AbbreviationAsWordInNameRule`    | 4       | Identifier must not contain more than N consecutive capital letters         |
 | `VariableNameRule`                | `^[a-z][a-zA-Z]{2,19}$` | Local variable name must match the configured pattern         |
+| `ParameterNameRule`               | `^(id\|[a-z]{3,})$` | Method parameter name must match the configured pattern           |
 
 ### PHPDoc style
 
@@ -141,6 +142,8 @@ parameters:
                 - i
                 - j
                 - db
+        parameterName:
+            pattern: '^(id|[a-z]{3,})$'
 ```
 
 Default values match the defaults described in the rules table above. Omitting a parameter keeps the default. Diagnostic identifier for `AtclauseOrderRule`: `haspadar.atclauseOrder` (for targeted ignores, e.g. `@phpstan-ignore haspadar.atclauseOrder`).

--- a/rules-ignore.neon
+++ b/rules-ignore.neon
@@ -12,3 +12,5 @@ parameters:
             identifier: haspadar.returnCount
         -
             identifier: haspadar.cyclomaticComplexity
+        -
+            identifier: haspadar.parameterName

--- a/rules.neon
+++ b/rules.neon
@@ -66,6 +66,8 @@ parameters:
                 - id
                 - i
                 - j
+        parameterName:
+            pattern: '^(id|[a-z]{3,})$'
 
 parametersSchema:
     haspadar: structure([
@@ -141,6 +143,9 @@ parametersSchema:
         variableName: structure([
             pattern: string(),
             allowedNames: listOf(string()),
+        ]),
+        parameterName: structure([
+            pattern: string(),
         ]),
     ])
 
@@ -358,5 +363,11 @@ services:
             pattern: %haspadar.variableName.pattern%
             options:
                 allowedNames: %haspadar.variableName.allowedNames%
+        tags:
+            - phpstan.rules.rule
+    -
+        class: Haspadar\PHPStanRules\Rules\ParameterNameRule
+        arguments:
+            pattern: %haspadar.parameterName.pattern%
         tags:
             - phpstan.rules.rule

--- a/src/Rules.php
+++ b/src/Rules.php
@@ -54,6 +54,7 @@ final class Rules
             Rules\NoInlineCommentRule::class,
             Rules\AbbreviationAsWordInNameRule::class,
             Rules\VariableNameRule::class,
+            Rules\ParameterNameRule::class,
         ];
     }
 }

--- a/src/Rules/ParameterNameRule.php
+++ b/src/Rules/ParameterNameRule.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Rules;
+
+use Override;
+use PhpParser\Node;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\ShouldNotHappenException;
+
+/**
+ * Checks that method parameter names match a configurable regex pattern.
+ * Validates parameters of class methods, including promoted properties.
+ * Skips closures and arrow functions.
+ *
+ * @implements Rule<ClassMethod>
+ */
+final readonly class ParameterNameRule implements Rule
+{
+    /**
+     * Constructs the rule with the given pattern.
+     */
+    public function __construct(private string $pattern = '^(id|[a-z]{3,})$') {}
+
+    #[Override]
+    public function getNodeType(): string
+    {
+        return ClassMethod::class;
+    }
+
+    /**
+     * Analyses the node and returns a list of errors.
+     *
+     * @psalm-param ClassMethod $node
+     * @throws ShouldNotHappenException
+     * @return list<IdentifierRuleError>
+     */
+    #[Override]
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $errors = [];
+
+        foreach ($node->params as $param) {
+            if (!$param->var instanceof Variable || !is_string($param->var->name)) {
+                continue;
+            }
+
+            $name = $param->var->name;
+
+            if (preg_match('/' . $this->pattern . '/', $name) === 1) {
+                continue;
+            }
+
+            $errors[] = RuleErrorBuilder::message(
+                sprintf('Parameter $%s does not match pattern /%s/.', $name, $this->pattern),
+            )
+                ->identifier('haspadar.parameterName')
+                ->line($param->getStartLine())
+                ->build();
+        }
+
+        return $errors;
+    }
+}

--- a/src/Rules/ParameterNameRule.php
+++ b/src/Rules/ParameterNameRule.php
@@ -46,13 +46,7 @@ final readonly class ParameterNameRule implements Rule
     {
         $errors = [];
 
-        foreach ($node->params as $param) {
-            if (!$param->var instanceof Variable || !is_string($param->var->name)) {
-                continue;
-            }
-
-            $name = $param->var->name;
-
+        foreach ($this->parameterNames($node) as [$name, $line]) {
             if (preg_match('/' . $this->pattern . '/', $name) === 1) {
                 continue;
             }
@@ -61,10 +55,28 @@ final readonly class ParameterNameRule implements Rule
                 sprintf('Parameter $%s does not match pattern /%s/.', $name, $this->pattern),
             )
                 ->identifier('haspadar.parameterName')
-                ->line($param->getStartLine())
+                ->line($line)
                 ->build();
         }
 
         return $errors;
+    }
+
+    /**
+     * Extracts parameter names and their line numbers from a method node.
+     *
+     * @return list<array{string, int}>
+     */
+    private function parameterNames(ClassMethod $node): array
+    {
+        $names = [];
+
+        foreach ($node->params as $param) {
+            if ($param->var instanceof Variable && is_string($param->var->name)) {
+                $names[] = [$param->var->name, $param->getStartLine()];
+            }
+        }
+
+        return $names;
     }
 }

--- a/tests/Fixtures/Rules/ParameterNameRule/ArrowFunctionParameter.php
+++ b/tests/Fixtures/Rules/ParameterNameRule/ArrowFunctionParameter.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ParameterNameRule;
+
+final class ArrowFunctionParameter
+{
+    public function run(): int
+    {
+        $handler = static fn(int $x): int => $x + 1;
+
+        return $handler(1);
+    }
+}

--- a/tests/Fixtures/Rules/ParameterNameRule/CamelCaseName.php
+++ b/tests/Fixtures/Rules/ParameterNameRule/CamelCaseName.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ParameterNameRule;
+
+final class CamelCaseName
+{
+    public function run(string $userName): void
+    {
+        echo $userName;
+    }
+}

--- a/tests/Fixtures/Rules/ParameterNameRule/ClosureParameter.php
+++ b/tests/Fixtures/Rules/ParameterNameRule/ClosureParameter.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ParameterNameRule;
+
+final class ClosureParameter
+{
+    public function run(): void
+    {
+        $handler = static function (string $x): string {
+            return $x;
+        };
+        echo $handler('test');
+    }
+}

--- a/tests/Fixtures/Rules/ParameterNameRule/MultipleParameters.php
+++ b/tests/Fixtures/Rules/ParameterNameRule/MultipleParameters.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ParameterNameRule;
+
+final class MultipleParameters
+{
+    public function run(string $x, int $value, bool $ok): void
+    {
+        echo $x . $value . $ok;
+    }
+}

--- a/tests/Fixtures/Rules/ParameterNameRule/NameWithDigit.php
+++ b/tests/Fixtures/Rules/ParameterNameRule/NameWithDigit.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ParameterNameRule;
+
+final class NameWithDigit
+{
+    public function run(int $item2): void
+    {
+        echo $item2;
+    }
+}

--- a/tests/Fixtures/Rules/ParameterNameRule/NameWithUnderscore.php
+++ b/tests/Fixtures/Rules/ParameterNameRule/NameWithUnderscore.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ParameterNameRule;
+
+final class NameWithUnderscore
+{
+    public function run(string $user_name): void
+    {
+        echo $user_name;
+    }
+}

--- a/tests/Fixtures/Rules/ParameterNameRule/PromotedProperty.php
+++ b/tests/Fixtures/Rules/ParameterNameRule/PromotedProperty.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ParameterNameRule;
+
+final class PromotedProperty
+{
+    public function __construct(private string $nm)
+    {
+    }
+
+    public function run(): string
+    {
+        return $this->nm;
+    }
+}

--- a/tests/Fixtures/Rules/ParameterNameRule/ShortName.php
+++ b/tests/Fixtures/Rules/ParameterNameRule/ShortName.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ParameterNameRule;
+
+final class ShortName
+{
+    public function run(string $fn): void
+    {
+        echo $fn;
+    }
+}

--- a/tests/Fixtures/Rules/ParameterNameRule/SuppressedShortName.php
+++ b/tests/Fixtures/Rules/ParameterNameRule/SuppressedShortName.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ParameterNameRule;
+
+final class SuppressedShortName
+{
+    /** @phpstan-ignore haspadar.parameterName */
+    public function run(string $fn): void
+    {
+        echo $fn;
+    }
+}

--- a/tests/Fixtures/Rules/ParameterNameRule/ValidNames.php
+++ b/tests/Fixtures/Rules/ParameterNameRule/ValidNames.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ParameterNameRule;
+
+final class ValidNames
+{
+    public function run(string $name, int $value, string $text): void
+    {
+        echo $name . $value . $text;
+    }
+}

--- a/tests/Unit/Rules/ParameterNameRule/ParameterNameRuleDefaultPatternTest.php
+++ b/tests/Unit/Rules/ParameterNameRule/ParameterNameRuleDefaultPatternTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\ParameterNameRule;
+
+use Haspadar\PHPStanRules\Rules\ParameterNameRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<ParameterNameRule> */
+final class ParameterNameRuleDefaultPatternTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new ParameterNameRule();
+    }
+
+    #[Test]
+    public function passesWhenParameterNamesMatchDefaultPattern(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ParameterNameRule/ValidNames.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function reportsErrorWhenNameIsTooShort(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ParameterNameRule/ShortName.php'],
+            [
+                ['Parameter $fn does not match pattern /^(id|[a-z]{3,})$/.', 9],
+            ],
+        );
+    }
+
+    #[Test]
+    public function reportsErrorWhenNameIsCamelCase(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ParameterNameRule/CamelCaseName.php'],
+            [
+                ['Parameter $userName does not match pattern /^(id|[a-z]{3,})$/.', 9],
+            ],
+        );
+    }
+}

--- a/tests/Unit/Rules/ParameterNameRule/ParameterNameRuleTest.php
+++ b/tests/Unit/Rules/ParameterNameRule/ParameterNameRuleTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\ParameterNameRule;
+
+use Haspadar\PHPStanRules\Rules\ParameterNameRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<ParameterNameRule> */
+final class ParameterNameRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new ParameterNameRule('^[a-z]{3,10}$');
+    }
+
+    #[Test]
+    public function passesWhenParameterNamesAreValid(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ParameterNameRule/ValidNames.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function reportsErrorWhenNameIsTooShort(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ParameterNameRule/ShortName.php'],
+            [
+                ['Parameter $fn does not match pattern /^[a-z]{3,10}$/.', 9],
+            ],
+        );
+    }
+
+    #[Test]
+    public function reportsErrorWhenNameIsCamelCase(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ParameterNameRule/CamelCaseName.php'],
+            [
+                ['Parameter $userName does not match pattern /^[a-z]{3,10}$/.', 9],
+            ],
+        );
+    }
+
+    #[Test]
+    public function reportsErrorWhenNameContainsDigit(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ParameterNameRule/NameWithDigit.php'],
+            [
+                ['Parameter $item2 does not match pattern /^[a-z]{3,10}$/.', 9],
+            ],
+        );
+    }
+
+    #[Test]
+    public function reportsErrorWhenNameContainsUnderscore(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ParameterNameRule/NameWithUnderscore.php'],
+            [
+                ['Parameter $user_name does not match pattern /^[a-z]{3,10}$/.', 9],
+            ],
+        );
+    }
+
+    #[Test]
+    public function suppressesErrorWhenPhpstanIgnorePresent(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ParameterNameRule/SuppressedShortName.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function reportsErrorForPromotedProperty(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ParameterNameRule/PromotedProperty.php'],
+            [
+                ['Parameter $nm does not match pattern /^[a-z]{3,10}$/.', 9],
+            ],
+        );
+    }
+
+    #[Test]
+    public function reportsErrorsForMultipleInvalidParameters(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ParameterNameRule/MultipleParameters.php'],
+            [
+                ['Parameter $x does not match pattern /^[a-z]{3,10}$/.', 9],
+                ['Parameter $ok does not match pattern /^[a-z]{3,10}$/.', 9],
+            ],
+        );
+    }
+
+    #[Test]
+    public function skipsClosureParameters(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ParameterNameRule/ClosureParameter.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function skipsArrowFunctionParameters(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ParameterNameRule/ArrowFunctionParameter.php'],
+            [],
+        );
+    }
+}

--- a/tests/Unit/RulesTest.php
+++ b/tests/Unit/RulesTest.php
@@ -33,6 +33,7 @@ use Haspadar\PHPStanRules\Rules\PhpDocMissingPropertyRule;
 use Haspadar\PHPStanRules\Rules\ClassConstantTypeHintRule;
 use Haspadar\PHPStanRules\Rules\AbbreviationAsWordInNameRule;
 use Haspadar\PHPStanRules\Rules\NoInlineCommentRule;
+use Haspadar\PHPStanRules\Rules\ParameterNameRule;
 use Haspadar\PHPStanRules\Rules\VariableNameRule;
 use Haspadar\PHPStanRules\Rules\NoLineCommentBeforeDeclarationRule;
 use Haspadar\PHPStanRules\Rules\NoPhpDocForOverriddenRule;
@@ -89,6 +90,7 @@ final class RulesTest extends TestCase
                 NoInlineCommentRule::class,
                 AbbreviationAsWordInNameRule::class,
                 VariableNameRule::class,
+                ParameterNameRule::class,
             ],
             (new Rules())->all(),
             'Rules::all() must list every registered rule class',


### PR DESCRIPTION
## Summary

- Add `ParameterNameRule` that validates method parameter names against a configurable regex pattern
- Default pattern `^(id|[a-z]{3,})$` enforces Qulice convention: lowercase letters, minimum 3 characters, or `id`
- Closures and arrow functions are automatically excluded (rule targets `ClassMethod` only)

Closes #96

## Test plan

- [ ] Valid parameter names (`$name`, `$value`, `$id`) produce no errors
- [ ] Short names (`$fn`), camelCase (`$userName`), digits (`$item2`), underscores (`$user_name`) are reported
- [ ] Promoted constructor properties are checked
- [ ] Multiple invalid parameters produce multiple errors
- [ ] `@phpstan-ignore haspadar.parameterName` suppresses the error
- [ ] Closure and arrow function parameters are not checked
- [ ] Default pattern works correctly
- [ ] Custom pattern override works correctly