### PR TITLE
Implement CatchParameterNameRule

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@
 | `AbbreviationAsWordInNameRule`    | 4       | Identifier must not contain more than N consecutive capital letters         |
 | `VariableNameRule`                | `^[a-z][a-zA-Z]{2,19}$` | Local variable name must match the configured pattern         |
 | `ParameterNameRule`               | `^(id\|[a-z]{3,})$` | Method parameter name must match the configured pattern           |
+| `CatchParameterNameRule`          | `^(e\|ex\|[a-z]{3,12})$` | Catch parameter name must match the configured pattern       |
 
 ### PHPDoc style
 
@@ -144,6 +145,8 @@ parameters:
                 - db
         parameterName:
             pattern: '^(id|[a-z]{3,})$'
+        catchParamName:
+            pattern: '^(e|ex|[a-z]{3,12})$'
 ```
 
 Default values match the defaults described in the rules table above. Omitting a parameter keeps the default. Diagnostic identifier for `AtclauseOrderRule`: `haspadar.atclauseOrder` (for targeted ignores, e.g. `@phpstan-ignore haspadar.atclauseOrder`).

--- a/rules.neon
+++ b/rules.neon
@@ -68,6 +68,8 @@ parameters:
                 - j
         parameterName:
             pattern: '^(id|[a-z]{3,})$'
+        catchParamName:
+            pattern: '^(e|ex|[a-z]{3,12})$'
 
 parametersSchema:
     haspadar: structure([
@@ -145,6 +147,9 @@ parametersSchema:
             allowedNames: listOf(string()),
         ]),
         parameterName: structure([
+            pattern: string(),
+        ]),
+        catchParamName: structure([
             pattern: string(),
         ]),
     ])
@@ -369,5 +374,11 @@ services:
         class: Haspadar\PHPStanRules\Rules\ParameterNameRule
         arguments:
             pattern: %haspadar.parameterName.pattern%
+        tags:
+            - phpstan.rules.rule
+    -
+        class: Haspadar\PHPStanRules\Rules\CatchParameterNameRule
+        arguments:
+            pattern: %haspadar.catchParamName.pattern%
         tags:
             - phpstan.rules.rule

--- a/src/Rules.php
+++ b/src/Rules.php
@@ -55,6 +55,7 @@ final class Rules
             Rules\AbbreviationAsWordInNameRule::class,
             Rules\VariableNameRule::class,
             Rules\ParameterNameRule::class,
+            Rules\CatchParameterNameRule::class,
         ];
     }
 }

--- a/src/Rules/CatchParameterNameRule.php
+++ b/src/Rules/CatchParameterNameRule.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Rules;
+
+use Override;
+use PhpParser\Node;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Stmt\Catch_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\ShouldNotHappenException;
+
+/**
+ * Checks that catch block parameter names match a configurable regex pattern.
+ * Skips unnamed catch blocks (PHP 8.0+).
+ *
+ * @implements Rule<Catch_>
+ */
+final readonly class CatchParameterNameRule implements Rule
+{
+    /**
+     * Constructs the rule with the given pattern.
+     */
+    public function __construct(private string $pattern = '^(e|ex|[a-z]{3,12})$') {}
+
+    #[Override]
+    public function getNodeType(): string
+    {
+        return Catch_::class;
+    }
+
+    /**
+     * Analyses the node and returns a list of errors.
+     *
+     * @psalm-param Catch_ $node
+     * @throws ShouldNotHappenException
+     * @return list<IdentifierRuleError>
+     */
+    #[Override]
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $name = $this->extractName($node);
+
+        if ($name === null) {
+            return [];
+        }
+
+        if (preg_match('/' . $this->pattern . '/', $name) === 1) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message(
+                sprintf('Catch parameter $%s does not match pattern /%s/.', $name, $this->pattern),
+            )
+                ->identifier('haspadar.catchParamName')
+                ->build(),
+        ];
+    }
+
+    /**
+     * Extracts the catch parameter name, or null if unnamed.
+     */
+    private function extractName(Catch_ $node): ?string
+    {
+        if (!$node->var instanceof Variable || !is_string($node->var->name)) {
+            return null;
+        }
+
+        return $node->var->name;
+    }
+}

--- a/tests/Fixtures/Rules/CatchParameterNameRule/CamelCaseName.php
+++ b/tests/Fixtures/Rules/CatchParameterNameRule/CamelCaseName.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\CatchParameterNameRule;
+
+final class CamelCaseName
+{
+    public function run(): void
+    {
+        try {
+            echo 'ok';
+        } catch (\RuntimeException $myException) {
+            echo $myException->getMessage();
+        }
+    }
+}

--- a/tests/Fixtures/Rules/CatchParameterNameRule/MultipleCatchTypes.php
+++ b/tests/Fixtures/Rules/CatchParameterNameRule/MultipleCatchTypes.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\CatchParameterNameRule;
+
+final class MultipleCatchTypes
+{
+    public function run(): void
+    {
+        try {
+            echo 'ok';
+        } catch (\RuntimeException | \LogicException $x) {
+            echo $x->getMessage();
+        }
+    }
+}

--- a/tests/Fixtures/Rules/CatchParameterNameRule/NameWithDigit.php
+++ b/tests/Fixtures/Rules/CatchParameterNameRule/NameWithDigit.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\CatchParameterNameRule;
+
+final class NameWithDigit
+{
+    public function run(): void
+    {
+        try {
+            echo 'ok';
+        } catch (\Throwable $ex1) {
+            echo $ex1->getMessage();
+        }
+    }
+}

--- a/tests/Fixtures/Rules/CatchParameterNameRule/ShortName.php
+++ b/tests/Fixtures/Rules/CatchParameterNameRule/ShortName.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\CatchParameterNameRule;
+
+final class ShortName
+{
+    public function run(): void
+    {
+        try {
+            echo 'ok';
+        } catch (\Throwable $x) {
+            echo $x->getMessage();
+        }
+    }
+}

--- a/tests/Fixtures/Rules/CatchParameterNameRule/SuppressedShortName.php
+++ b/tests/Fixtures/Rules/CatchParameterNameRule/SuppressedShortName.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\CatchParameterNameRule;
+
+final class SuppressedShortName
+{
+    public function run(): void
+    {
+        try {
+            echo 'ok';
+        } catch (\Throwable $x) { /** @phpstan-ignore haspadar.catchParamName */
+            echo $x->getMessage();
+        }
+    }
+}

--- a/tests/Fixtures/Rules/CatchParameterNameRule/TooLongName.php
+++ b/tests/Fixtures/Rules/CatchParameterNameRule/TooLongName.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\CatchParameterNameRule;
+
+final class TooLongName
+{
+    public function run(): void
+    {
+        try {
+            echo 'ok';
+        } catch (\Throwable $veryverylongname) {
+            echo $veryverylongname->getMessage();
+        }
+    }
+}

--- a/tests/Fixtures/Rules/CatchParameterNameRule/UnnamedCatch.php
+++ b/tests/Fixtures/Rules/CatchParameterNameRule/UnnamedCatch.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\CatchParameterNameRule;
+
+final class UnnamedCatch
+{
+    public function run(): void
+    {
+        try {
+            echo 'ok';
+        } catch (\Throwable) {
+            echo 'error';
+        }
+    }
+}

--- a/tests/Fixtures/Rules/CatchParameterNameRule/ValidNames.php
+++ b/tests/Fixtures/Rules/CatchParameterNameRule/ValidNames.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\CatchParameterNameRule;
+
+final class ValidNames
+{
+    public function run(): void
+    {
+        try {
+            echo 'ok';
+        } catch (\RuntimeException $e) {
+            echo $e->getMessage();
+        } catch (\LogicException $ex) {
+            echo $ex->getMessage();
+        } catch (\Throwable $error) {
+            echo $error->getMessage();
+        }
+    }
+}

--- a/tests/Unit/Rules/CatchParameterNameRule/CatchParameterNameRuleDefaultPatternTest.php
+++ b/tests/Unit/Rules/CatchParameterNameRule/CatchParameterNameRuleDefaultPatternTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\CatchParameterNameRule;
+
+use Haspadar\PHPStanRules\Rules\CatchParameterNameRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<CatchParameterNameRule> */
+final class CatchParameterNameRuleDefaultPatternTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new CatchParameterNameRule();
+    }
+
+    #[Test]
+    public function passesWhenCatchParameterNamesMatchDefaultPattern(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/CatchParameterNameRule/ValidNames.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function reportsErrorWhenNameIsTooShort(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/CatchParameterNameRule/ShortName.php'],
+            [
+                ['Catch parameter $x does not match pattern /^(e|ex|[a-z]{3,12})$/.', 13],
+            ],
+        );
+    }
+
+    #[Test]
+    public function reportsErrorWhenNameIsCamelCase(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/CatchParameterNameRule/CamelCaseName.php'],
+            [
+                ['Catch parameter $myException does not match pattern /^(e|ex|[a-z]{3,12})$/.', 13],
+            ],
+        );
+    }
+}

--- a/tests/Unit/Rules/CatchParameterNameRule/CatchParameterNameRuleTest.php
+++ b/tests/Unit/Rules/CatchParameterNameRule/CatchParameterNameRuleTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\CatchParameterNameRule;
+
+use Haspadar\PHPStanRules\Rules\CatchParameterNameRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<CatchParameterNameRule> */
+final class CatchParameterNameRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new CatchParameterNameRule('^[a-z]{3,8}$');
+    }
+
+    #[Test]
+    public function passesWhenCatchParameterNamesAreValid(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/CatchParameterNameRule/ValidNames.php'],
+            [
+                ['Catch parameter $e does not match pattern /^[a-z]{3,8}$/.', 13],
+                ['Catch parameter $ex does not match pattern /^[a-z]{3,8}$/.', 15],
+            ],
+        );
+    }
+
+    #[Test]
+    public function reportsErrorWhenNameIsTooShort(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/CatchParameterNameRule/ShortName.php'],
+            [
+                ['Catch parameter $x does not match pattern /^[a-z]{3,8}$/.', 13],
+            ],
+        );
+    }
+
+    #[Test]
+    public function reportsErrorWhenNameIsCamelCase(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/CatchParameterNameRule/CamelCaseName.php'],
+            [
+                ['Catch parameter $myException does not match pattern /^[a-z]{3,8}$/.', 13],
+            ],
+        );
+    }
+
+    #[Test]
+    public function reportsErrorWhenNameContainsDigit(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/CatchParameterNameRule/NameWithDigit.php'],
+            [
+                ['Catch parameter $ex1 does not match pattern /^[a-z]{3,8}$/.', 13],
+            ],
+        );
+    }
+
+    #[Test]
+    public function reportsErrorWhenNameIsTooLong(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/CatchParameterNameRule/TooLongName.php'],
+            [
+                ['Catch parameter $veryverylongname does not match pattern /^[a-z]{3,8}$/.', 13],
+            ],
+        );
+    }
+
+    #[Test]
+    public function suppressesErrorWhenPhpstanIgnorePresent(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/CatchParameterNameRule/SuppressedShortName.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function skipsUnnamedCatch(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/CatchParameterNameRule/UnnamedCatch.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function reportsErrorForMultipleCatchTypes(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/CatchParameterNameRule/MultipleCatchTypes.php'],
+            [
+                ['Catch parameter $x does not match pattern /^[a-z]{3,8}$/.', 13],
+            ],
+        );
+    }
+}

--- a/tests/Unit/RulesTest.php
+++ b/tests/Unit/RulesTest.php
@@ -33,6 +33,7 @@ use Haspadar\PHPStanRules\Rules\PhpDocMissingPropertyRule;
 use Haspadar\PHPStanRules\Rules\ClassConstantTypeHintRule;
 use Haspadar\PHPStanRules\Rules\AbbreviationAsWordInNameRule;
 use Haspadar\PHPStanRules\Rules\NoInlineCommentRule;
+use Haspadar\PHPStanRules\Rules\CatchParameterNameRule;
 use Haspadar\PHPStanRules\Rules\ParameterNameRule;
 use Haspadar\PHPStanRules\Rules\VariableNameRule;
 use Haspadar\PHPStanRules\Rules\NoLineCommentBeforeDeclarationRule;
@@ -91,6 +92,7 @@ final class RulesTest extends TestCase
                 AbbreviationAsWordInNameRule::class,
                 VariableNameRule::class,
                 ParameterNameRule::class,
+                CatchParameterNameRule::class,
             ],
             (new Rules())->all(),
             'Rules::all() must list every registered rule class',


### PR DESCRIPTION
## Summary

- Add `CatchParameterNameRule` — validates catch parameter names against a configurable regex pattern
- Default pattern `^(e|ex|[a-z]{3,12})$` based on Qulice convention with `e` added for PHP idiom
- Configurable via `haspadar.catchParamName.pattern` in phpstan.neon

## Test plan

- [x] 11 tests across 2 test classes pass locally
- [x] All piqule checks green
- [x] Mutation testing MSI 100%

Closes #98

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added catch parameter naming validation to enforce consistent exception variable naming patterns (default: `e`, `ex`, or 3-12 lowercase letters).
  * Supports custom patterns via configuration and can be suppressed using PHPStan ignore directives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->