### PR TITLE
Fix regex delimiter collision in naming rules

### DIFF
--- a/src/Rules/CatchParameterNameRule.php
+++ b/src/Rules/CatchParameterNameRule.php
@@ -22,10 +22,24 @@ use PHPStan\ShouldNotHappenException;
  */
 final readonly class CatchParameterNameRule implements Rule
 {
+    /** @var non-empty-string */
+    private string $compiledPattern;
+
     /**
      * Constructs the rule with the given pattern.
+     *
+     * @throws ShouldNotHappenException
      */
-    public function __construct(private string $pattern = '^(e|ex|[a-z]{3,12})$') {}
+    public function __construct(private string $pattern = '^(e|ex|[a-z]{3,12})$')
+    {
+        $this->compiledPattern = '~' . str_replace('~', '\~', $this->pattern) . '~';
+
+        if (@preg_match($this->compiledPattern, '') === false) {
+            throw new ShouldNotHappenException(
+                sprintf('Invalid catch parameter name pattern "%s".', $this->pattern),
+            );
+        }
+    }
 
     #[Override]
     public function getNodeType(): string
@@ -49,7 +63,7 @@ final readonly class CatchParameterNameRule implements Rule
             return [];
         }
 
-        if (preg_match('/' . $this->pattern . '/', $name) === 1) {
+        if (preg_match($this->compiledPattern, $name) === 1) {
             return [];
         }
 

--- a/src/Rules/CatchParameterNameRule.php
+++ b/src/Rules/CatchParameterNameRule.php
@@ -32,13 +32,7 @@ final readonly class CatchParameterNameRule implements Rule
      */
     public function __construct(private string $pattern = '^(e|ex|[a-z]{3,12})$')
     {
-        $this->compiledPattern = '~' . str_replace('~', '\~', $this->pattern) . '~';
-
-        if (@preg_match($this->compiledPattern, '') === false) {
-            throw new ShouldNotHappenException(
-                sprintf('Invalid catch parameter name pattern "%s".', $this->pattern),
-            );
-        }
+        $this->compiledPattern = (new CompiledPattern())->from($this->pattern, 'catch parameter name');
     }
 
     #[Override]

--- a/src/Rules/CompiledPattern.php
+++ b/src/Rules/CompiledPattern.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Rules;
+
+use PHPStan\ShouldNotHappenException;
+
+/**
+ * Compiles a user-provided regex pattern into a safe delimited form.
+ * Uses ~ as delimiter, escaping any ~ in the pattern.
+ * Validates the pattern at compile time and throws on invalid regex.
+ */
+final class CompiledPattern
+{
+    /**
+     * Compiles the given pattern with a safe delimiter.
+     *
+     * @throws ShouldNotHappenException
+     * @return non-empty-string
+     */
+    public function from(string $pattern, string $context): string
+    {
+        $compiled = '~' . str_replace('~', '\~', $pattern) . '~';
+
+        if (@preg_match($compiled, '') === false) {
+            throw new ShouldNotHappenException(
+                sprintf('Invalid %s pattern "%s".', $context, $pattern),
+            );
+        }
+
+        return $compiled;
+    }
+}

--- a/src/Rules/ParameterNameRule.php
+++ b/src/Rules/ParameterNameRule.php
@@ -33,13 +33,7 @@ final readonly class ParameterNameRule implements Rule
      */
     public function __construct(private string $pattern = '^(id|[a-z]{3,})$')
     {
-        $this->compiledPattern = '~' . str_replace('~', '\~', $this->pattern) . '~';
-
-        if (@preg_match($this->compiledPattern, '') === false) {
-            throw new ShouldNotHappenException(
-                sprintf('Invalid parameter name pattern "%s".', $this->pattern),
-            );
-        }
+        $this->compiledPattern = (new CompiledPattern())->from($this->pattern, 'parameter name');
     }
 
     #[Override]

--- a/src/Rules/ParameterNameRule.php
+++ b/src/Rules/ParameterNameRule.php
@@ -23,10 +23,24 @@ use PHPStan\ShouldNotHappenException;
  */
 final readonly class ParameterNameRule implements Rule
 {
+    /** @var non-empty-string */
+    private string $compiledPattern;
+
     /**
      * Constructs the rule with the given pattern.
+     *
+     * @throws ShouldNotHappenException
      */
-    public function __construct(private string $pattern = '^(id|[a-z]{3,})$') {}
+    public function __construct(private string $pattern = '^(id|[a-z]{3,})$')
+    {
+        $this->compiledPattern = '~' . str_replace('~', '\~', $this->pattern) . '~';
+
+        if (@preg_match($this->compiledPattern, '') === false) {
+            throw new ShouldNotHappenException(
+                sprintf('Invalid parameter name pattern "%s".', $this->pattern),
+            );
+        }
+    }
 
     #[Override]
     public function getNodeType(): string
@@ -47,7 +61,7 @@ final readonly class ParameterNameRule implements Rule
         $errors = [];
 
         foreach ($this->parameterNames($node) as [$name, $line]) {
-            if (preg_match('/' . $this->pattern . '/', $name) === 1) {
+            if (preg_match($this->compiledPattern, $name) === 1) {
                 continue;
             }
 

--- a/src/Rules/VariableNameRule.php
+++ b/src/Rules/VariableNameRule.php
@@ -40,13 +40,7 @@ final readonly class VariableNameRule implements Rule
         array $options = [],
     ) {
         $this->allowedNames = $options['allowedNames'] ?? ['id', 'i', 'j'];
-        $this->compiledPattern = '~' . str_replace('~', '\~', $this->pattern) . '~';
-
-        if (@preg_match($this->compiledPattern, '') === false) {
-            throw new ShouldNotHappenException(
-                sprintf('Invalid variable name pattern "%s".', $this->pattern),
-            );
-        }
+        $this->compiledPattern = (new CompiledPattern())->from($this->pattern, 'variable name');
     }
 
     #[Override]

--- a/src/Rules/VariableNameRule.php
+++ b/src/Rules/VariableNameRule.php
@@ -26,16 +26,27 @@ final readonly class VariableNameRule implements Rule
     /** @var list<string> */
     private array $allowedNames;
 
+    /** @var non-empty-string */
+    private string $compiledPattern;
+
     /**
      * Constructs the rule with the given pattern and options.
      *
      * @param array{allowedNames?: list<string>} $options
+     * @throws ShouldNotHappenException
      */
     public function __construct(
         private string $pattern = '^[a-z][a-zA-Z]{2,19}$',
         array $options = [],
     ) {
         $this->allowedNames = $options['allowedNames'] ?? ['id', 'i', 'j'];
+        $this->compiledPattern = '~' . str_replace('~', '\~', $this->pattern) . '~';
+
+        if (@preg_match($this->compiledPattern, '') === false) {
+            throw new ShouldNotHappenException(
+                sprintf('Invalid variable name pattern "%s".', $this->pattern),
+            );
+        }
     }
 
     #[Override]
@@ -73,7 +84,7 @@ final readonly class VariableNameRule implements Rule
                 continue;
             }
 
-            if (preg_match('/' . $this->pattern . '/', $name) === 1) {
+            if (preg_match($this->compiledPattern, $name) === 1) {
                 continue;
             }
 

--- a/tests/Unit/Rules/CatchParameterNameRule/CatchParameterNameRuleInvalidPatternTest.php
+++ b/tests/Unit/Rules/CatchParameterNameRule/CatchParameterNameRuleInvalidPatternTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\CatchParameterNameRule;
+
+use Haspadar\PHPStanRules\Rules\CatchParameterNameRule;
+use PHPStan\ShouldNotHappenException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/** @covers CatchParameterNameRule */
+final class CatchParameterNameRuleInvalidPatternTest extends TestCase
+{
+    #[Test]
+    public function throwsExceptionWhenPatternIsInvalid(): void
+    {
+        $this->expectException(ShouldNotHappenException::class);
+
+        new CatchParameterNameRule('[invalid');
+    }
+}

--- a/tests/Unit/Rules/CatchParameterNameRule/CatchParameterNameRuleInvalidPatternTest.php
+++ b/tests/Unit/Rules/CatchParameterNameRule/CatchParameterNameRuleInvalidPatternTest.php
@@ -16,6 +16,7 @@ final class CatchParameterNameRuleInvalidPatternTest extends TestCase
     public function throwsExceptionWhenPatternIsInvalid(): void
     {
         $this->expectException(ShouldNotHappenException::class);
+        $this->expectExceptionMessage('Invalid catch parameter name pattern "[invalid".');
 
         new CatchParameterNameRule('[invalid');
     }

--- a/tests/Unit/Rules/ParameterNameRule/ParameterNameRuleInvalidPatternTest.php
+++ b/tests/Unit/Rules/ParameterNameRule/ParameterNameRuleInvalidPatternTest.php
@@ -16,6 +16,7 @@ final class ParameterNameRuleInvalidPatternTest extends TestCase
     public function throwsExceptionWhenPatternIsInvalid(): void
     {
         $this->expectException(ShouldNotHappenException::class);
+        $this->expectExceptionMessage('Invalid parameter name pattern "[invalid".');
 
         new ParameterNameRule('[invalid');
     }

--- a/tests/Unit/Rules/ParameterNameRule/ParameterNameRuleInvalidPatternTest.php
+++ b/tests/Unit/Rules/ParameterNameRule/ParameterNameRuleInvalidPatternTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\ParameterNameRule;
+
+use Haspadar\PHPStanRules\Rules\ParameterNameRule;
+use PHPStan\ShouldNotHappenException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/** @covers ParameterNameRule */
+final class ParameterNameRuleInvalidPatternTest extends TestCase
+{
+    #[Test]
+    public function throwsExceptionWhenPatternIsInvalid(): void
+    {
+        $this->expectException(ShouldNotHappenException::class);
+
+        new ParameterNameRule('[invalid');
+    }
+}

--- a/tests/Unit/Rules/VariableNameRule/VariableNameRuleInvalidPatternTest.php
+++ b/tests/Unit/Rules/VariableNameRule/VariableNameRuleInvalidPatternTest.php
@@ -16,6 +16,7 @@ final class VariableNameRuleInvalidPatternTest extends TestCase
     public function throwsExceptionWhenPatternIsInvalid(): void
     {
         $this->expectException(ShouldNotHappenException::class);
+        $this->expectExceptionMessage('Invalid variable name pattern "[invalid".');
 
         new VariableNameRule('[invalid');
     }

--- a/tests/Unit/Rules/VariableNameRule/VariableNameRuleInvalidPatternTest.php
+++ b/tests/Unit/Rules/VariableNameRule/VariableNameRuleInvalidPatternTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\VariableNameRule;
+
+use Haspadar\PHPStanRules\Rules\VariableNameRule;
+use PHPStan\ShouldNotHappenException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/** @covers VariableNameRule */
+final class VariableNameRuleInvalidPatternTest extends TestCase
+{
+    #[Test]
+    public function throwsExceptionWhenPatternIsInvalid(): void
+    {
+        $this->expectException(ShouldNotHappenException::class);
+
+        new VariableNameRule('[invalid');
+    }
+}


### PR DESCRIPTION
## Summary

- Use `~` delimiter instead of `/` for regex patterns in VariableNameRule, ParameterNameRule, CatchParameterNameRule
- Validate and compile pattern at construction time, throw exception on invalid regex
- Escape `~` in user-provided patterns to prevent delimiter collision

## Test plan

- [x] Invalid pattern tests for all 3 rules
- [x] All existing tests pass
- [x] All piqule checks green
- [x] Mutation testing MSI 100%

Closes #100

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Naming rules now validate regex patterns at initialization, surfacing invalid configurations early.

* **New Features**
  * Pattern validation is precompiled at construction to avoid rebuilding regexes repeatedly, improving runtime efficiency.

* **Tests**
  * Added unit tests asserting exceptions for invalid regex patterns in catch-parameter, parameter, and variable naming rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->