### PR TITLE
Add UnnecessaryLocalRule to detect assign-then-return pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@
 | `IllegalThrowsRule`           | Declaring `@throws Exception` or other broad types in PHPDoc is forbidden     |
 | `InnerAssignmentRule`         | Assignment inside conditions (`if ($x = foo())`) is forbidden                 |
 | `ModifiedControlVariableRule` | Loop control variable must not be modified inside the loop body               |
+| `UnnecessaryLocalRule`        | Local variable assigned and immediately returned/thrown must be inlined        |
 
 ### Naming
 

--- a/rules.neon
+++ b/rules.neon
@@ -382,3 +382,7 @@ services:
             pattern: %haspadar.catchParamName.pattern%
         tags:
             - phpstan.rules.rule
+    -
+        class: Haspadar\PHPStanRules\Rules\UnnecessaryLocalRule
+        tags:
+            - phpstan.rules.rule

--- a/src/Rules.php
+++ b/src/Rules.php
@@ -56,6 +56,7 @@ final class Rules
             Rules\VariableNameRule::class,
             Rules\ParameterNameRule::class,
             Rules\CatchParameterNameRule::class,
+            Rules\UnnecessaryLocalRule::class,
         ];
     }
 }

--- a/src/Rules/UnnecessaryLocalRule.php
+++ b/src/Rules/UnnecessaryLocalRule.php
@@ -45,6 +45,10 @@ final readonly class UnnecessaryLocalRule implements Rule
     #[Override]
     public function processNode(Node $node, Scope $scope): array
     {
+        if ($node->byRef) {
+            return [];
+        }
+
         if ($node->stmts === null) {
             return [];
         }

--- a/src/Rules/UnnecessaryLocalRule.php
+++ b/src/Rules/UnnecessaryLocalRule.php
@@ -136,14 +136,16 @@ final readonly class UnnecessaryLocalRule implements Rule
      */
     private function matchesReturnOrThrow(Node\Stmt $stmt, string $name): ?string
     {
-        if ($stmt instanceof Return_ && $stmt->expr instanceof Variable) {
+        if ($stmt instanceof Return_ && $stmt->expr instanceof Variable && is_string($stmt->expr->name)) {
             if ($stmt->expr->name === $name) {
                 return 'returned';
             }
         }
 
         if ($stmt instanceof Expression && $stmt->expr instanceof Throw_) {
-            if ($stmt->expr->expr instanceof Variable && $stmt->expr->expr->name === $name) {
+            if ($stmt->expr->expr instanceof Variable && is_string(
+                $stmt->expr->expr->name,
+            ) && $stmt->expr->expr->name === $name) {
                 return 'thrown';
             }
         }

--- a/src/Rules/UnnecessaryLocalRule.php
+++ b/src/Rules/UnnecessaryLocalRule.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Rules;
+
+use Override;
+use PhpParser\Comment\Doc;
+use PhpParser\Node;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\Throw_;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Expression;
+use PhpParser\Node\Stmt\Return_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\ShouldNotHappenException;
+
+/**
+ * Reports local variables that are assigned and immediately returned or thrown.
+ * Such variables add unnecessary complexity. The expression should be
+ * returned or thrown directly. Variables with @var PHPDoc are excluded
+ * because they carry type information.
+ *
+ * @implements Rule<ClassMethod>
+ */
+final readonly class UnnecessaryLocalRule implements Rule
+{
+    #[Override]
+    public function getNodeType(): string
+    {
+        return ClassMethod::class;
+    }
+
+    /**
+     * Analyses the node and returns a list of errors.
+     *
+     * @psalm-param ClassMethod $node
+     * @throws ShouldNotHappenException
+     * @return list<IdentifierRuleError>
+     */
+    #[Override]
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if ($node->stmts === null) {
+            return [];
+        }
+
+        $errors = [];
+
+        foreach ($this->findUnnecessaryPairs(array_values($node->stmts)) as [$name, $line, $kind]) {
+            $errors[] = RuleErrorBuilder::message(
+                sprintf(
+                    'Variable $%s is assigned and immediately %s. %s the expression directly.',
+                    $name,
+                    $kind,
+                    $kind === 'returned' ? 'Return' : 'Throw',
+                ),
+            )
+                ->identifier('haspadar.unnecessaryLocal')
+                ->line($line)
+                ->build();
+        }
+
+        return $errors;
+    }
+
+    /**
+     * Finds assign-then-return/throw pairs in a flat statement list.
+     *
+     * @param list<Node\Stmt> $stmts
+     * @return list<array{string, int, string}>
+     */
+    private function findUnnecessaryPairs(array $stmts): array
+    {
+        $pairs = [];
+
+        foreach ($stmts as $idx => $current) {
+            if (!array_key_exists($idx + 1, $stmts)) {
+                continue;
+            }
+
+            $assigned = $this->extractAssignment($current);
+
+            if ($assigned === null) {
+                continue;
+            }
+
+            [$name, $line] = $assigned;
+
+            $kind = $this->matchesReturnOrThrow($stmts[$idx + 1], $name);
+
+            if ($kind === null) {
+                continue;
+            }
+
+            if ($this->hasVarPhpDoc($current)) {
+                continue;
+            }
+
+            $pairs[] = [$name, $line, $kind];
+        }
+
+        return $pairs;
+    }
+
+    /**
+     * Extracts variable name and line from an assignment expression statement.
+     *
+     * @return array{string, int}|null
+     */
+    private function extractAssignment(Node\Stmt $stmt): ?array
+    {
+        if (!$stmt instanceof Expression) {
+            return null;
+        }
+
+        if (!$stmt->expr instanceof Assign) {
+            return null;
+        }
+
+        $var = $stmt->expr->var;
+
+        if (!$var instanceof Variable || !is_string($var->name)) {
+            return null;
+        }
+
+        return [$var->name, $stmt->getStartLine()];
+    }
+
+    /**
+     * Checks if the statement is a return or throw of the given variable name.
+     */
+    private function matchesReturnOrThrow(Node\Stmt $stmt, string $name): ?string
+    {
+        if ($stmt instanceof Return_ && $stmt->expr instanceof Variable) {
+            if ($stmt->expr->name === $name) {
+                return 'returned';
+            }
+        }
+
+        if ($stmt instanceof Expression && $stmt->expr instanceof Throw_) {
+            if ($stmt->expr->expr instanceof Variable && $stmt->expr->expr->name === $name) {
+                return 'thrown';
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Checks if the statement has a @var PHPDoc comment.
+     */
+    private function hasVarPhpDoc(Node\Stmt $stmt): bool
+    {
+        $docComment = $stmt->getDocComment();
+
+        if (!$docComment instanceof Doc) {
+            return false;
+        }
+
+        return str_contains($docComment->getText(), '@var');
+    }
+}

--- a/tests/Fixtures/Rules/UnnecessaryLocalRule/AbstractMethod.php
+++ b/tests/Fixtures/Rules/UnnecessaryLocalRule/AbstractMethod.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\UnnecessaryLocalRule;
+
+abstract class AbstractMethod
+{
+    abstract public function run(): int;
+}

--- a/tests/Fixtures/Rules/UnnecessaryLocalRule/ByReferenceMethod.php
+++ b/tests/Fixtures/Rules/UnnecessaryLocalRule/ByReferenceMethod.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\UnnecessaryLocalRule;
+
+final class ByReferenceMethod
+{
+    /** @var int */
+    private int $value = 42;
+
+    public function &run(): int
+    {
+        $result = &$this->value;
+        return $result;
+    }
+}

--- a/tests/Fixtures/Rules/UnnecessaryLocalRule/InsideClosure.php
+++ b/tests/Fixtures/Rules/UnnecessaryLocalRule/InsideClosure.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\UnnecessaryLocalRule;
+
+final class InsideClosure
+{
+    public function run(): \Closure
+    {
+        return function (): int {
+            $result = 42;
+            return $result;
+        };
+    }
+}

--- a/tests/Fixtures/Rules/UnnecessaryLocalRule/InsideIfBlock.php
+++ b/tests/Fixtures/Rules/UnnecessaryLocalRule/InsideIfBlock.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\UnnecessaryLocalRule;
+
+final class InsideIfBlock
+{
+    public function run(bool $flag): int
+    {
+        if ($flag) {
+            $result = 42;
+            return $result;
+        }
+
+        return 0;
+    }
+}

--- a/tests/Fixtures/Rules/UnnecessaryLocalRule/MultipleReturns.php
+++ b/tests/Fixtures/Rules/UnnecessaryLocalRule/MultipleReturns.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\UnnecessaryLocalRule;
+
+final class MultipleReturns
+{
+    public function run(bool $flag): int
+    {
+        if ($flag) {
+            return 0;
+        }
+
+        $result = $this->calculate();
+        return $result;
+    }
+
+    private function calculate(): int
+    {
+        return 42;
+    }
+}

--- a/tests/Fixtures/Rules/UnnecessaryLocalRule/SuppressedUnnecessary.php
+++ b/tests/Fixtures/Rules/UnnecessaryLocalRule/SuppressedUnnecessary.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\UnnecessaryLocalRule;
+
+final class SuppressedUnnecessary
+{
+    public function run(): int
+    {
+        $result = $this->calculate(); // @phpstan-ignore haspadar.unnecessaryLocal
+        return $result;
+    }
+
+    private function calculate(): int
+    {
+        return 42;
+    }
+}

--- a/tests/Fixtures/Rules/UnnecessaryLocalRule/UnnecessaryBeforeReturn.php
+++ b/tests/Fixtures/Rules/UnnecessaryLocalRule/UnnecessaryBeforeReturn.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\UnnecessaryLocalRule;
+
+final class UnnecessaryBeforeReturn
+{
+    public function run(): int
+    {
+        $result = $this->calculate();
+        return $result;
+    }
+
+    private function calculate(): int
+    {
+        return 42;
+    }
+}

--- a/tests/Fixtures/Rules/UnnecessaryLocalRule/UnnecessaryBeforeThrow.php
+++ b/tests/Fixtures/Rules/UnnecessaryLocalRule/UnnecessaryBeforeThrow.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\UnnecessaryLocalRule;
+
+final class UnnecessaryBeforeThrow
+{
+    public function run(): void
+    {
+        $exception = new \RuntimeException('fail');
+        throw $exception;
+    }
+}

--- a/tests/Fixtures/Rules/UnnecessaryLocalRule/UsedElsewhere.php
+++ b/tests/Fixtures/Rules/UnnecessaryLocalRule/UsedElsewhere.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\UnnecessaryLocalRule;
+
+final class UsedElsewhere
+{
+    public function run(): int
+    {
+        $result = $this->calculate();
+        $this->log($result);
+        return $result;
+    }
+
+    private function calculate(): int
+    {
+        return 42;
+    }
+
+    private function log(int $value): void
+    {
+        echo $value;
+    }
+}

--- a/tests/Fixtures/Rules/UnnecessaryLocalRule/ValidDirectReturn.php
+++ b/tests/Fixtures/Rules/UnnecessaryLocalRule/ValidDirectReturn.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\UnnecessaryLocalRule;
+
+final class ValidDirectReturn
+{
+    public function run(): int
+    {
+        return $this->calculate();
+    }
+
+    private function calculate(): int
+    {
+        return 42;
+    }
+}

--- a/tests/Fixtures/Rules/UnnecessaryLocalRule/VariableVariable.php
+++ b/tests/Fixtures/Rules/UnnecessaryLocalRule/VariableVariable.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\UnnecessaryLocalRule;
+
+final class VariableVariable
+{
+    /**
+     * @param non-empty-string $name
+     */
+    public function run(string $name): mixed
+    {
+        $$name = 42;
+        return $$name;
+    }
+}

--- a/tests/Fixtures/Rules/UnnecessaryLocalRule/WithVarPhpDoc.php
+++ b/tests/Fixtures/Rules/UnnecessaryLocalRule/WithVarPhpDoc.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\UnnecessaryLocalRule;
+
+final class WithVarPhpDoc
+{
+    public function run(): int
+    {
+        /** @var int $result */
+        $result = $this->calculate();
+        return $result;
+    }
+
+    private function calculate(): mixed
+    {
+        return 42;
+    }
+}

--- a/tests/Unit/Rules/UnnecessaryLocalRule/UnnecessaryLocalRuleTest.php
+++ b/tests/Unit/Rules/UnnecessaryLocalRule/UnnecessaryLocalRuleTest.php
@@ -121,4 +121,13 @@ final class UnnecessaryLocalRuleTest extends RuleTestCase
             [],
         );
     }
+
+    #[Test]
+    public function passesWhenAssignAndReturnAreInsideNestedBlock(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/UnnecessaryLocalRule/InsideIfBlock.php'],
+            [],
+        );
+    }
 }

--- a/tests/Unit/Rules/UnnecessaryLocalRule/UnnecessaryLocalRuleTest.php
+++ b/tests/Unit/Rules/UnnecessaryLocalRule/UnnecessaryLocalRuleTest.php
@@ -94,4 +94,22 @@ final class UnnecessaryLocalRuleTest extends RuleTestCase
             [],
         );
     }
+
+    #[Test]
+    public function passesWhenMethodReturnsByReference(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/UnnecessaryLocalRule/ByReferenceMethod.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function passesWhenVariableVariableIsUsed(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/UnnecessaryLocalRule/VariableVariable.php'],
+            [],
+        );
+    }
 }

--- a/tests/Unit/Rules/UnnecessaryLocalRule/UnnecessaryLocalRuleTest.php
+++ b/tests/Unit/Rules/UnnecessaryLocalRule/UnnecessaryLocalRuleTest.php
@@ -112,4 +112,13 @@ final class UnnecessaryLocalRuleTest extends RuleTestCase
             [],
         );
     }
+
+    #[Test]
+    public function passesWhenMethodIsAbstract(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/UnnecessaryLocalRule/AbstractMethod.php'],
+            [],
+        );
+    }
 }

--- a/tests/Unit/Rules/UnnecessaryLocalRule/UnnecessaryLocalRuleTest.php
+++ b/tests/Unit/Rules/UnnecessaryLocalRule/UnnecessaryLocalRuleTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\UnnecessaryLocalRule;
+
+use Haspadar\PHPStanRules\Rules\UnnecessaryLocalRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<UnnecessaryLocalRule> */
+final class UnnecessaryLocalRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new UnnecessaryLocalRule();
+    }
+
+    #[Test]
+    public function passesWhenReturnIsDirectExpression(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/UnnecessaryLocalRule/ValidDirectReturn.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function reportsErrorWhenVariableIsAssignedAndImmediatelyReturned(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/UnnecessaryLocalRule/UnnecessaryBeforeReturn.php'],
+            [
+                ['Variable $result is assigned and immediately returned. Return the expression directly.', 11],
+            ],
+        );
+    }
+
+    #[Test]
+    public function reportsErrorWhenVariableIsAssignedAndImmediatelyThrown(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/UnnecessaryLocalRule/UnnecessaryBeforeThrow.php'],
+            [
+                ['Variable $exception is assigned and immediately thrown. Throw the expression directly.', 11],
+            ],
+        );
+    }
+
+    #[Test]
+    public function passesWhenVariableIsUsedElsewhere(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/UnnecessaryLocalRule/UsedElsewhere.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function passesWhenVariableHasVarPhpDoc(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/UnnecessaryLocalRule/WithVarPhpDoc.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function reportsErrorForUnnecessaryReturnInMultipleReturns(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/UnnecessaryLocalRule/MultipleReturns.php'],
+            [
+                ['Variable $result is assigned and immediately returned. Return the expression directly.', 15],
+            ],
+        );
+    }
+
+    #[Test]
+    public function suppressesErrorWhenPhpstanIgnorePresent(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/UnnecessaryLocalRule/SuppressedUnnecessary.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function passesWhenUnnecessaryVariableIsInsideClosure(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/UnnecessaryLocalRule/InsideClosure.php'],
+            [],
+        );
+    }
+}

--- a/tests/Unit/RulesTest.php
+++ b/tests/Unit/RulesTest.php
@@ -34,6 +34,7 @@ use Haspadar\PHPStanRules\Rules\ClassConstantTypeHintRule;
 use Haspadar\PHPStanRules\Rules\AbbreviationAsWordInNameRule;
 use Haspadar\PHPStanRules\Rules\NoInlineCommentRule;
 use Haspadar\PHPStanRules\Rules\CatchParameterNameRule;
+use Haspadar\PHPStanRules\Rules\UnnecessaryLocalRule;
 use Haspadar\PHPStanRules\Rules\ParameterNameRule;
 use Haspadar\PHPStanRules\Rules\VariableNameRule;
 use Haspadar\PHPStanRules\Rules\NoLineCommentBeforeDeclarationRule;
@@ -93,6 +94,7 @@ final class RulesTest extends TestCase
                 VariableNameRule::class,
                 ParameterNameRule::class,
                 CatchParameterNameRule::class,
+                UnnecessaryLocalRule::class,
             ],
             (new Rules())->all(),
             'Rules::all() must list every registered rule class',


### PR DESCRIPTION
## Summary
- Add `UnnecessaryLocalRule` that reports local variables assigned and immediately returned or thrown
- Variables with `@var` PHPDoc are excluded (they carry type information)
- Register rule in `rules.neon`, add to README, add tests and fixtures

Closes #102

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a PHPStan rule that flags local variables assigned and immediately returned or thrown, recommending direct return/throw.

* **Documentation**
  * Updated README with the new rule entry and description.

* **Tests**
  * Added comprehensive fixtures and unit tests covering valid, failing, suppressed, and edge-case scenarios to validate the rule.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->