### PR TITLE
ConstantUsageRule — forbid magic numbers and strings outside constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@
 | `InnerAssignmentRule`         | Assignment inside conditions (`if ($x = foo())`) is forbidden                 |
 | `ModifiedControlVariableRule` | Loop control variable must not be modified inside the loop body               |
 | `UnnecessaryLocalRule`        | Local variable assigned and immediately returned/thrown must be inlined        |
+| `ConstantUsageRule`           | Magic numbers and strings must be defined as named constants                  |
 
 ### Naming
 
@@ -148,6 +149,13 @@ parameters:
             pattern: '^(id|[a-z]{3,})$'
         catchParamName:
             pattern: '^(e|ex|[a-z]{3,12})$'
+        constantUsage:
+            ignoreNumbers:
+                - 0
+                - 1
+            checkStrings: false
+            ignoreStrings:
+                - ''
 ```
 
 Default values match the defaults described in the rules table above. Omitting a parameter keeps the default. Diagnostic identifier for `AtclauseOrderRule`: `haspadar.atclauseOrder` (for targeted ignores, e.g. `@phpstan-ignore haspadar.atclauseOrder`).

--- a/rules.neon
+++ b/rules.neon
@@ -70,6 +70,13 @@ parameters:
             pattern: '^(id|[a-z]{3,})$'
         catchParamName:
             pattern: '^(e|ex|[a-z]{3,12})$'
+        constantUsage:
+            ignoreNumbers:
+                - 0
+                - 1
+            checkStrings: false
+            ignoreStrings:
+                - ''
 
 parametersSchema:
     haspadar: structure([
@@ -151,6 +158,11 @@ parametersSchema:
         ]),
         catchParamName: structure([
             pattern: string(),
+        ]),
+        constantUsage: structure([
+            ignoreNumbers: listOf(anyOf(int(), float())),
+            checkStrings: bool(),
+            ignoreStrings: listOf(string()),
         ]),
     ])
 
@@ -384,5 +396,14 @@ services:
             - phpstan.rules.rule
     -
         class: Haspadar\PHPStanRules\Rules\UnnecessaryLocalRule
+        tags:
+            - phpstan.rules.rule
+    -
+        class: Haspadar\PHPStanRules\Rules\ConstantUsageRule
+        arguments:
+            options:
+                ignoreNumbers: %haspadar.constantUsage.ignoreNumbers%
+                checkStrings: %haspadar.constantUsage.checkStrings%
+                ignoreStrings: %haspadar.constantUsage.ignoreStrings%
         tags:
             - phpstan.rules.rule

--- a/src/Rules.php
+++ b/src/Rules.php
@@ -57,6 +57,7 @@ final class Rules
             Rules\ParameterNameRule::class,
             Rules\CatchParameterNameRule::class,
             Rules\UnnecessaryLocalRule::class,
+            Rules\ConstantUsageRule::class,
         ];
     }
 }

--- a/src/Rules/AtclauseOrderRule.php
+++ b/src/Rules/AtclauseOrderRule.php
@@ -23,6 +23,10 @@ use PHPStan\ShouldNotHappenException;
  */
 final readonly class AtclauseOrderRule implements Rule
 {
+    private const int MINIMUM_TAGS_TO_CHECK = 2;
+
+    private const int NOT_FOUND = -1;
+
     /** @var list<string> */
     private array $tagOrder;
 
@@ -66,7 +70,7 @@ final readonly class AtclauseOrderRule implements Rule
 
         $relevant = $this->relevantTags($docComment->getText());
 
-        if (count($relevant) < 2) {
+        if (count($relevant) < self::MINIMUM_TAGS_TO_CHECK) {
             return [];
         }
 
@@ -96,7 +100,7 @@ final readonly class AtclauseOrderRule implements Rule
     private function detectViolations(array $tags, string $methodName): array
     {
         $errors = [];
-        $lastIndex = -1;
+        $lastIndex = self::NOT_FOUND;
         $lastTag = '';
 
         foreach ($tags as $tag) {

--- a/src/Rules/ConstantUsage/ExemptScalarCollector.php
+++ b/src/Rules/ConstantUsage/ExemptScalarCollector.php
@@ -6,6 +6,7 @@ namespace Haspadar\PHPStanRules\Rules\ConstantUsage;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\UnaryMinus;
 use PhpParser\Node\Param;
 use PhpParser\Node\Scalar;
 use PhpParser\Node\Stmt\Break_;
@@ -68,6 +69,12 @@ final class ExemptScalarCollector
 
         if ($default instanceof Scalar\Int_ || $default instanceof Scalar\Float_ || $default instanceof Scalar\String_) {
             return [$default];
+        }
+
+        if ($default instanceof UnaryMinus && self::isScalarLiteral($default->expr)) {
+            assert($default->expr instanceof Scalar\Int_ || $default->expr instanceof Scalar\Float_);
+
+            return [$default->expr];
         }
 
         if (!$default instanceof Array_) {

--- a/src/Rules/ConstantUsage/ExemptScalarCollector.php
+++ b/src/Rules/ConstantUsage/ExemptScalarCollector.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Rules\ConstantUsage;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Param;
+use PhpParser\Node\Scalar;
+use PhpParser\Node\Stmt\Break_;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\Continue_;
+use PhpParser\NodeFinder;
+
+/**
+ * Collects scalar literals that are exempt from the constant usage check.
+ * Scalars inside const declarations, PHP attributes, and parameter default
+ * values are collected and returned so the rule can skip them.
+ */
+final class ExemptScalarCollector
+{
+    /**
+     * Returns all scalar nodes inside exempt contexts for the given class.
+     *
+     * @return list<Scalar\Int_|Scalar\Float_|Scalar\String_>
+     */
+    public static function collect(NodeFinder $finder, Class_ $node): array
+    {
+        /** @var list<Node\Stmt\ClassConst|Node\AttributeGroup|Param|Break_|Continue_> $containers */
+        $containers = $finder->find(
+            $node,
+            static fn(Node $n): bool => $n instanceof Node\Stmt\ClassConst
+                || $n instanceof Node\AttributeGroup
+                || $n instanceof Param
+                || $n instanceof Break_
+                || $n instanceof Continue_,
+        );
+
+        $result = [];
+
+        foreach ($containers as $container) {
+            if ($container instanceof Param) {
+                $result = array_merge($result, self::paramDefaultScalars($container));
+
+                continue;
+            }
+
+            /** @var list<Scalar\Int_|Scalar\Float_|Scalar\String_> $scalars */
+            $scalars = $finder->find(
+                $container,
+                static fn(Node $n): bool => self::isScalarLiteral($n),
+            );
+            $result = array_merge($result, $scalars);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Extracts scalar nodes from a parameter default value.
+     *
+     * @return list<Scalar\Int_|Scalar\Float_|Scalar\String_>
+     */
+    private static function paramDefaultScalars(Param $param): array
+    {
+        $default = $param->default;
+
+        if ($default instanceof Scalar\Int_ || $default instanceof Scalar\Float_ || $default instanceof Scalar\String_) {
+            return [$default];
+        }
+
+        if (!$default instanceof Array_) {
+            return [];
+        }
+
+        /** @var list<Scalar\Int_|Scalar\Float_|Scalar\String_> $scalars */
+        $scalars = (new NodeFinder())->find(
+            $default,
+            static fn(Node $n): bool => self::isScalarLiteral($n),
+        );
+
+        return $scalars;
+    }
+
+    /**
+     * Checks whether a node is a scalar literal (int, float, or string).
+     */
+    private static function isScalarLiteral(?Node $node): bool
+    {
+        return $node instanceof Scalar\Int_
+            || $node instanceof Scalar\Float_
+            || $node instanceof Scalar\String_;
+    }
+}

--- a/src/Rules/ConstantUsageRule.php
+++ b/src/Rules/ConstantUsageRule.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Rules;
+
+use Haspadar\PHPStanRules\Rules\ConstantUsage\ExemptScalarCollector;
+use Override;
+use PhpParser\Node;
+use PhpParser\Node\ArrayItem;
+use PhpParser\Node\Expr\UnaryMinus;
+use PhpParser\Node\Scalar;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\NodeFinder;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * Detects magic numeric and string literals used outside constant declarations.
+ * Numbers and strings must be defined as named constants instead of being used
+ * inline. Literals inside const declarations, PHP attributes, array keys, and
+ * parameter default values are exempt. The ignore lists are configurable.
+ *
+ * @implements Rule<Class_>
+ */
+final readonly class ConstantUsageRule implements Rule
+{
+    private const int FLOAT_DECIMAL_PLACES = 10;
+
+    /** @var list<int|float> */
+    private array $ignoreNumbers;
+
+    private bool $checkStrings;
+
+    /** @var list<string> */
+    private array $ignoreStrings;
+
+    /**
+     * Constructs the rule with the given options.
+     *
+     * @param array{
+     *     ignoreNumbers?: list<int|float>,
+     *     checkStrings?: bool,
+     *     ignoreStrings?: list<string>
+     * } $options
+     */
+    public function __construct(array $options = [])
+    {
+        $this->ignoreNumbers = $options['ignoreNumbers'] ?? [0, 1];
+        $this->checkStrings = $options['checkStrings'] ?? false;
+        $this->ignoreStrings = $options['ignoreStrings'] ?? [''];
+    }
+
+    #[Override]
+    public function getNodeType(): string
+    {
+        return Class_::class;
+    }
+
+    /**
+     * Analyses the node and returns a list of errors.
+     *
+     * @psalm-param Class_ $node
+     * @return list<IdentifierRuleError>
+     */
+    #[Override]
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $finder = new NodeFinder();
+        $exempt = ExemptScalarCollector::collect($finder, $node);
+        $errors = $this->checkNumbers($finder, $node, $exempt);
+
+        if ($this->checkStrings) {
+            $errors = array_merge($errors, $this->checkStringLiterals($finder, $node, $exempt));
+        }
+
+        return $errors;
+    }
+
+    /**
+     * Finds magic number literals and returns errors for each.
+     *
+     * @param list<Scalar\Int_|Scalar\Float_|Scalar\String_> $exempt
+     * @return list<IdentifierRuleError>
+     */
+    private function checkNumbers(NodeFinder $finder, Class_ $node, array $exempt): array
+    {
+        /** @var list<Scalar\Int_|Scalar\Float_> $numbers */
+        $numbers = $finder->find(
+            $node,
+            static fn(Node $n): bool => $n instanceof Scalar\Int_ || $n instanceof Scalar\Float_,
+        );
+
+        $errors = [];
+
+        foreach ($numbers as $number) {
+            if (in_array($number, $exempt, true)) {
+                continue;
+            }
+
+            $value = $this->resolveNumericValue($finder, $node, $number);
+
+            if (in_array($value, $this->ignoreNumbers, true)) {
+                continue;
+            }
+
+            $errors[] = RuleErrorBuilder::message(
+                sprintf('Magic number %s found. Define a named constant instead.', $this->formatNumber($value)),
+            )
+                ->identifier('haspadar.constantUsage')
+                ->line($number->getStartLine())
+                ->build();
+        }
+
+        return $errors;
+    }
+
+    /**
+     * Finds magic string literals and returns errors for each.
+     *
+     * @param list<Scalar\Int_|Scalar\Float_|Scalar\String_> $exempt
+     * @return list<IdentifierRuleError>
+     */
+    private function checkStringLiterals(NodeFinder $finder, Class_ $node, array $exempt): array
+    {
+        /** @var list<ArrayItem> $items */
+        $items = $finder->findInstanceOf($node, ArrayItem::class);
+        $arrayKeys = [];
+
+        foreach ($items as $item) {
+            if ($item->key instanceof Scalar\String_) {
+                $arrayKeys[] = $item->key;
+            }
+        }
+
+        /** @var list<Scalar\String_> $strings */
+        $strings = $finder->findInstanceOf($node, Scalar\String_::class);
+        $errors = [];
+
+        foreach ($strings as $string) {
+            if (in_array($string, $exempt, true) || in_array($string, $arrayKeys, true)
+                || in_array($string->value, $this->ignoreStrings, true)) {
+                continue;
+            }
+
+            $errors[] = RuleErrorBuilder::message(
+                sprintf('Magic string "%s" found. Define a named constant instead.', $string->value),
+            )
+                ->identifier('haspadar.constantUsage')
+                ->line($string->getStartLine())
+                ->build();
+        }
+
+        return $errors;
+    }
+
+    /**
+     * Resolves the effective numeric value, accounting for unary minus.
+     */
+    private function resolveNumericValue(
+        NodeFinder $finder,
+        Class_ $node,
+        Scalar\Int_|Scalar\Float_ $number,
+    ): int|float {
+        /** @var list<UnaryMinus> $negations */
+        $negations = $finder->findInstanceOf($node, UnaryMinus::class);
+
+        foreach ($negations as $neg) {
+            if ($neg->expr === $number) {
+                return -$number->value;
+            }
+        }
+
+        return $number->value;
+    }
+
+    /**
+     * Formats a number for the error message.
+     */
+    private function formatNumber(int|float $value): string
+    {
+        if (is_float($value)) {
+            return rtrim(rtrim(number_format($value, self::FLOAT_DECIMAL_PLACES, '.', ''), '0'), '.');
+        }
+
+        return (string) $value;
+    }
+}

--- a/src/Rules/NoInlineCommentRule.php
+++ b/src/Rules/NoInlineCommentRule.php
@@ -26,6 +26,8 @@ use PHPStan\Rules\RuleErrorBuilder;
  */
 final readonly class NoInlineCommentRule implements Rule
 {
+    private const int DOUBLE_SLASH_LENGTH = 2;
+
     #[Override]
     public function getNodeType(): string
     {
@@ -99,7 +101,7 @@ final readonly class NoInlineCommentRule implements Rule
         $text = $comment->getText();
 
         if (str_starts_with($text, '//')) {
-            return str_starts_with(ltrim(substr($text, 2)), '@');
+            return str_starts_with(ltrim(substr($text, self::DOUBLE_SLASH_LENGTH)), '@');
         }
 
         if (str_starts_with($text, '#')) {

--- a/tests/Fixtures/Rules/ConstantUsageRule/ClassWithArrayKeys.php
+++ b/tests/Fixtures/Rules/ConstantUsageRule/ClassWithArrayKeys.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ConstantUsageRule;
+
+final class ClassWithArrayKeys
+{
+    /**
+     * @return array<string, string>
+     */
+    public function config(string $host, int $port): array
+    {
+        return ['host' => $host, 'port' => (string) $port];
+    }
+}

--- a/tests/Fixtures/Rules/ConstantUsageRule/ClassWithAttributes.php
+++ b/tests/Fixtures/Rules/ConstantUsageRule/ClassWithAttributes.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ConstantUsageRule;
+
+use Attribute;
+
+#[Attribute]
+final class ExampleAttribute
+{
+    public function __construct(
+        public readonly string $value,
+    ) {
+    }
+}
+
+#[ExampleAttribute('/api/users')]
+final class ClassWithAttributes
+{
+    #[ExampleAttribute('handler')]
+    public function handle(): void
+    {
+    }
+}

--- a/tests/Fixtures/Rules/ConstantUsageRule/ClassWithConstants.php
+++ b/tests/Fixtures/Rules/ConstantUsageRule/ClassWithConstants.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ConstantUsageRule;
+
+final class ClassWithConstants
+{
+    private const int MULTIPLIER = 42;
+
+    private const float PI = 3.14;
+
+    private const string STATUS_ACTIVE = 'active';
+
+    public function calculate(int $amount): int
+    {
+        return $amount * self::MULTIPLIER;
+    }
+}

--- a/tests/Fixtures/Rules/ConstantUsageRule/ClassWithDefaultIgnoreNumbers.php
+++ b/tests/Fixtures/Rules/ConstantUsageRule/ClassWithDefaultIgnoreNumbers.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ConstantUsageRule;
+
+final class ClassWithDefaultIgnoreNumbers
+{
+    public function magic(): int
+    {
+        return 42;
+    }
+
+    public function zero(): int
+    {
+        return 0;
+    }
+
+    public function one(): int
+    {
+        return 1;
+    }
+}

--- a/tests/Fixtures/Rules/ConstantUsageRule/ClassWithEmptyString.php
+++ b/tests/Fixtures/Rules/ConstantUsageRule/ClassWithEmptyString.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ConstantUsageRule;
+
+final class ClassWithEmptyString
+{
+    public function fallback(): string
+    {
+        return '';
+    }
+}

--- a/tests/Fixtures/Rules/ConstantUsageRule/ClassWithIgnoredNumbers.php
+++ b/tests/Fixtures/Rules/ConstantUsageRule/ClassWithIgnoredNumbers.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ConstantUsageRule;
+
+final class ClassWithIgnoredNumbers
+{
+    public function zero(): int
+    {
+        return 0;
+    }
+
+    public function one(): int
+    {
+        return 1;
+    }
+}

--- a/tests/Fixtures/Rules/ConstantUsageRule/ClassWithMagicNumbers.php
+++ b/tests/Fixtures/Rules/ConstantUsageRule/ClassWithMagicNumbers.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ConstantUsageRule;
+
+final class ClassWithMagicNumbers
+{
+    public function calculate(int $amount): int
+    {
+        return $amount * 42;
+    }
+
+    public function threshold(): float
+    {
+        return 3.14;
+    }
+}

--- a/tests/Fixtures/Rules/ConstantUsageRule/ClassWithMagicStrings.php
+++ b/tests/Fixtures/Rules/ConstantUsageRule/ClassWithMagicStrings.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ConstantUsageRule;
+
+final class ClassWithMagicStrings
+{
+    public function status(string $value): bool
+    {
+        return $value === 'active';
+    }
+
+    public function role(): string
+    {
+        return 'admin';
+    }
+}

--- a/tests/Fixtures/Rules/ConstantUsageRule/ClassWithNegativeNumber.php
+++ b/tests/Fixtures/Rules/ConstantUsageRule/ClassWithNegativeNumber.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ConstantUsageRule;
+
+final class ClassWithNegativeNumber
+{
+    public function offset(): int
+    {
+        return -42;
+    }
+}

--- a/tests/Fixtures/Rules/ConstantUsageRule/ClassWithNegativeParameterDefault.php
+++ b/tests/Fixtures/Rules/ConstantUsageRule/ClassWithNegativeParameterDefault.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ConstantUsageRule;
+
+final class ClassWithNegativeParameterDefault
+{
+    public function offset(int $value = -42): int
+    {
+        return $value;
+    }
+}

--- a/tests/Fixtures/Rules/ConstantUsageRule/ClassWithParameterDefaults.php
+++ b/tests/Fixtures/Rules/ConstantUsageRule/ClassWithParameterDefaults.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ConstantUsageRule;
+
+final class ClassWithParameterDefaults
+{
+    public function scalarDefault(int $limit = 10): int
+    {
+        return $limit;
+    }
+
+    /**
+     * Uses an array default with scalar values inside.
+     *
+     * @param list<int> $items
+     * @return list<int>
+     */
+    public function arrayDefault(array $items = [1, 2, 3]): array
+    {
+        return $items;
+    }
+}

--- a/tests/Fixtures/Rules/ConstantUsageRule/ClassWithStringsDisabled.php
+++ b/tests/Fixtures/Rules/ConstantUsageRule/ClassWithStringsDisabled.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ConstantUsageRule;
+
+final class ClassWithStringsDisabled
+{
+    public function role(): string
+    {
+        return 'admin';
+    }
+}

--- a/tests/Fixtures/Rules/ConstantUsageRule/SuppressedClass.php
+++ b/tests/Fixtures/Rules/ConstantUsageRule/SuppressedClass.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ConstantUsageRule;
+
+final class SuppressedClass
+{
+    public function magic(): int
+    {
+        return 42; // @phpstan-ignore haspadar.constantUsage
+    }
+}

--- a/tests/Unit/Rules/ConstantUsageRule/ConstantUsageRuleDefaultTest.php
+++ b/tests/Unit/Rules/ConstantUsageRule/ConstantUsageRuleDefaultTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\ConstantUsageRule;
+
+use Haspadar\PHPStanRules\Rules\ConstantUsageRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<ConstantUsageRule> */
+final class ConstantUsageRuleDefaultTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new ConstantUsageRule();
+    }
+
+    #[Test]
+    public function reportsOnlyNonIgnoredNumbersWithDefaults(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ConstantUsageRule/ClassWithDefaultIgnoreNumbers.php'],
+            [
+                ['Magic number 42 found. Define a named constant instead.', 11],
+            ],
+        );
+    }
+}

--- a/tests/Unit/Rules/ConstantUsageRule/ConstantUsageRuleStringsDisabledTest.php
+++ b/tests/Unit/Rules/ConstantUsageRule/ConstantUsageRuleStringsDisabledTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\ConstantUsageRule;
+
+use Haspadar\PHPStanRules\Rules\ConstantUsageRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<ConstantUsageRule> */
+final class ConstantUsageRuleStringsDisabledTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new ConstantUsageRule();
+    }
+
+    #[Test]
+    public function passesWhenStringCheckingIsDisabledByDefault(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ConstantUsageRule/ClassWithStringsDisabled.php'],
+            [],
+        );
+    }
+}

--- a/tests/Unit/Rules/ConstantUsageRule/ConstantUsageRuleTest.php
+++ b/tests/Unit/Rules/ConstantUsageRule/ConstantUsageRuleTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\ConstantUsageRule;
+
+use Haspadar\PHPStanRules\Rules\ConstantUsageRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<ConstantUsageRule> */
+final class ConstantUsageRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new ConstantUsageRule([
+            'ignoreNumbers' => [0, 1],
+            'checkStrings' => true,
+            'ignoreStrings' => [''],
+        ]);
+    }
+
+    #[Test]
+    public function reportsErrorWhenMagicNumberFound(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ConstantUsageRule/ClassWithMagicNumbers.php'],
+            [
+                ['Magic number 42 found. Define a named constant instead.', 11],
+                ['Magic number 3.14 found. Define a named constant instead.', 16],
+            ],
+        );
+    }
+
+    #[Test]
+    public function reportsErrorWhenMagicStringFound(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ConstantUsageRule/ClassWithMagicStrings.php'],
+            [
+                ['Magic string "active" found. Define a named constant instead.', 11],
+                ['Magic string "admin" found. Define a named constant instead.', 16],
+            ],
+        );
+    }
+
+    #[Test]
+    public function passesWhenLiteralsAreInConstants(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ConstantUsageRule/ClassWithConstants.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function passesWhenNumbersAreIgnored(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ConstantUsageRule/ClassWithIgnoredNumbers.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function passesWhenStringsAreArrayKeys(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ConstantUsageRule/ClassWithArrayKeys.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function passesWhenLiteralsAreInAttributes(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ConstantUsageRule/ClassWithAttributes.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function passesWhenEmptyStringIsIgnored(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ConstantUsageRule/ClassWithEmptyString.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function suppressesErrorWhenPhpstanIgnorePresent(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ConstantUsageRule/SuppressedClass.php'],
+            [],
+        );
+    }
+}

--- a/tests/Unit/Rules/ConstantUsageRule/ConstantUsageRuleTest.php
+++ b/tests/Unit/Rules/ConstantUsageRule/ConstantUsageRuleTest.php
@@ -98,4 +98,24 @@ final class ConstantUsageRuleTest extends RuleTestCase
             [],
         );
     }
+
+    #[Test]
+    public function passesWhenLiteralsAreParameterDefaults(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ConstantUsageRule/ClassWithParameterDefaults.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function reportsErrorWhenNegativeMagicNumberFound(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ConstantUsageRule/ClassWithNegativeNumber.php'],
+            [
+                ['Magic number -42 found. Define a named constant instead.', 11],
+            ],
+        );
+    }
 }

--- a/tests/Unit/Rules/ConstantUsageRule/ConstantUsageRuleTest.php
+++ b/tests/Unit/Rules/ConstantUsageRule/ConstantUsageRuleTest.php
@@ -118,4 +118,13 @@ final class ConstantUsageRuleTest extends RuleTestCase
             ],
         );
     }
+
+    #[Test]
+    public function passesWhenNegativeNumberIsParameterDefault(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ConstantUsageRule/ClassWithNegativeParameterDefault.php'],
+            [],
+        );
+    }
 }

--- a/tests/Unit/RulesTest.php
+++ b/tests/Unit/RulesTest.php
@@ -45,6 +45,7 @@ use Haspadar\PHPStanRules\Rules\ProhibitPublicStaticMethodsRule;
 use Haspadar\PHPStanRules\Rules\ReturnCountRule;
 use Haspadar\PHPStanRules\Rules\StatementCountRule;
 use Haspadar\PHPStanRules\Rules\TooManyMethodsRule;
+use Haspadar\PHPStanRules\Rules\ConstantUsageRule;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -95,6 +96,7 @@ final class RulesTest extends TestCase
                 ParameterNameRule::class,
                 CatchParameterNameRule::class,
                 UnnecessaryLocalRule::class,
+                ConstantUsageRule::class,
             ],
             (new Rules())->all(),
             'Rules::all() must list every registered rule class',


### PR DESCRIPTION
## Summary

- Add `ConstantUsageRule` that detects magic numeric and string literals used outside constant declarations
- Extract `ExemptScalarCollector` to identify scalars in exempt contexts (const declarations, attributes, parameter defaults, break/continue)
- Replace magic numbers with named constants in `AtclauseOrderRule` and `NoInlineCommentRule`

## Configuration

- `ignoreNumbers` — list of numbers to allow inline (default: `[0, 1]`)
- `checkStrings` — whether to check string literals (default: `false`)
- `ignoreStrings` — list of strings to allow inline (default: `['']`)

Closes #104

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new rule that detects and flags magic numbers and strings that should be replaced with named constants, helping improve code maintainability.
  * Configurable options to customize ignored values and control whether string literals are checked.
  * Rule intelligently exempts literals in class constants, attributes, parameter defaults, and array keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->