### PR TITLE
StringLiteralsConcatenationRule — forbid string literal concatenation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@
 | `ModifiedControlVariableRule` | Loop control variable must not be modified inside the loop body               |
 | `UnnecessaryLocalRule`        | Local variable assigned and immediately returned/thrown must be inlined        |
 | `ConstantUsageRule`           | Magic numbers and strings must be defined as named constants                  |
+| `StringLiteralsConcatenationRule` | String literal concatenation via `.` or `.=` is forbidden                |
 
 ### Naming
 
@@ -156,6 +157,8 @@ parameters:
             checkStrings: false
             ignoreStrings:
                 - ''
+        stringConcat:
+            allowMixed: false
 ```
 
 Default values match the defaults described in the rules table above. Omitting a parameter keeps the default. Diagnostic identifier for `AtclauseOrderRule`: `haspadar.atclauseOrder` (for targeted ignores, e.g. `@phpstan-ignore haspadar.atclauseOrder`).

--- a/rules.neon
+++ b/rules.neon
@@ -77,6 +77,8 @@ parameters:
             checkStrings: false
             ignoreStrings:
                 - ''
+        stringConcat:
+            allowMixed: false
 
 parametersSchema:
     haspadar: structure([
@@ -163,6 +165,9 @@ parametersSchema:
             ignoreNumbers: listOf(anyOf(int(), float())),
             checkStrings: bool(),
             ignoreStrings: listOf(string()),
+        ]),
+        stringConcat: structure([
+            allowMixed: bool(),
         ]),
     ])
 
@@ -405,5 +410,12 @@ services:
                 ignoreNumbers: %haspadar.constantUsage.ignoreNumbers%
                 checkStrings: %haspadar.constantUsage.checkStrings%
                 ignoreStrings: %haspadar.constantUsage.ignoreStrings%
+        tags:
+            - phpstan.rules.rule
+    -
+        class: Haspadar\PHPStanRules\Rules\StringLiteralsConcatenationRule
+        arguments:
+            options:
+                allowMixed: %haspadar.stringConcat.allowMixed%
         tags:
             - phpstan.rules.rule

--- a/src/Rules.php
+++ b/src/Rules.php
@@ -58,6 +58,7 @@ final class Rules
             Rules\CatchParameterNameRule::class,
             Rules\UnnecessaryLocalRule::class,
             Rules\ConstantUsageRule::class,
+            Rules\StringLiteralsConcatenationRule::class,
         ];
     }
 }

--- a/src/Rules/AtclauseOrderRule.php
+++ b/src/Rules/AtclauseOrderRule.php
@@ -39,7 +39,7 @@ final readonly class AtclauseOrderRule implements Rule
     {
         $tags = $options['tagOrder'] ?? ['@param', '@return', '@throws'];
         $this->tagOrder = array_map(
-            static fn(string $tag): string => str_starts_with($tag, '@') ? $tag : '@' . $tag,
+            static fn(string $tag): string => str_starts_with($tag, '@') ? $tag : sprintf('@%s', $tag),
             $tags,
         );
     }

--- a/src/Rules/CompiledPattern.php
+++ b/src/Rules/CompiledPattern.php
@@ -21,7 +21,7 @@ final class CompiledPattern
      */
     public function from(string $pattern, string $context): string
     {
-        $compiled = '~' . str_replace('~', '\~', $pattern) . '~';
+        $compiled = sprintf('~%s~', str_replace('~', '\~', $pattern));
 
         if (@preg_match($compiled, '') === false) {
             throw new ShouldNotHappenException(

--- a/src/Rules/StringLiteralsConcatenationRule.php
+++ b/src/Rules/StringLiteralsConcatenationRule.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Rules;
+
+use Override;
+use PhpParser\Node;
+use PhpParser\Node\Expr\AssignOp\Concat as ConcatAssign;
+use PhpParser\Node\Expr\BinaryOp\Concat;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\NodeFinder;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * Forbids concatenation of string literals using the dot operator.
+ * When allowMixed is false (default), any concatenation expression
+ * containing a string literal is reported. When allowMixed is true,
+ * only concatenation where both sides contain string literals is reported.
+ *
+ * @implements Rule<ClassMethod>
+ */
+final readonly class StringLiteralsConcatenationRule implements Rule
+{
+    private bool $allowMixed;
+
+    /**
+     * Constructs the rule with the given options.
+     *
+     * @param array{allowMixed?: bool} $options
+     */
+    public function __construct(array $options = [])
+    {
+        $this->allowMixed = $options['allowMixed'] ?? false;
+    }
+
+    #[Override]
+    public function getNodeType(): string
+    {
+        return ClassMethod::class;
+    }
+
+    /**
+     * Analyses the node and returns a list of errors.
+     *
+     * @psalm-param ClassMethod $node
+     * @return list<IdentifierRuleError>
+     */
+    #[Override]
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if ($node->stmts === null) {
+            return [];
+        }
+
+        $finder = new NodeFinder();
+
+        /** @var list<Concat|ConcatAssign> $concats */
+        $concats = $finder->find(
+            $node->stmts,
+            static fn(Node $n): bool => $n instanceof Concat || $n instanceof ConcatAssign,
+        );
+
+        $nested = $this->collectNestedConcats($concats);
+        $errors = [];
+
+        foreach ($concats as $concat) {
+            if (in_array($concat, $nested, true)) {
+                continue;
+            }
+
+            if ($this->isViolation($concat)) {
+                $errors[] = RuleErrorBuilder::message(
+                    sprintf(
+                        'String literal concatenation found on line %d. Use sprintf() or string interpolation instead.',
+                        $concat->getStartLine(),
+                    ),
+                )
+                    ->identifier('haspadar.stringConcat')
+                    ->line($concat->getStartLine())
+                    ->build();
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * Collects concat nodes that are children of other concat nodes.
+     *
+     * @param list<Concat|ConcatAssign> $concats
+     * @return list<Concat|ConcatAssign>
+     */
+    private function collectNestedConcats(array $concats): array
+    {
+        $nested = [];
+
+        foreach ($concats as $concat) {
+            if ($concat instanceof Concat && $concat->left instanceof Concat) {
+                $nested[] = $concat->left;
+            }
+
+            if ($concat instanceof Concat && $concat->right instanceof Concat) {
+                $nested[] = $concat->right;
+            }
+        }
+
+        return $nested;
+    }
+
+    /**
+     * Checks whether the concatenation expression violates the rule.
+     */
+    private function isViolation(Concat|ConcatAssign $concat): bool
+    {
+        if ($this->allowMixed) {
+            return $this->bothSidesContainLiteral($concat);
+        }
+
+        return $this->containsStringLiteral($concat);
+    }
+
+    /**
+     * Checks whether both sides of a concat contain a string literal.
+     */
+    private function bothSidesContainLiteral(Concat|ConcatAssign $concat): bool
+    {
+        if ($concat instanceof ConcatAssign) {
+            return $this->containsStringLiteral($concat->var)
+                && $this->containsStringLiteral($concat->expr);
+        }
+
+        return $this->containsStringLiteral($concat->left)
+            && $this->containsStringLiteral($concat->right);
+    }
+
+    /**
+     * Checks whether an expression contains a string literal.
+     */
+    private function containsStringLiteral(Node $node): bool
+    {
+        if ($node instanceof String_) {
+            return true;
+        }
+
+        $found = (new NodeFinder())->findFirst(
+            $node,
+            static fn(Node $n): bool => $n instanceof String_,
+        );
+
+        return $found !== null;
+    }
+}

--- a/tests/Fixtures/Rules/StringLiteralsConcatenationRule/ClassWithAbstractMethod.php
+++ b/tests/Fixtures/Rules/StringLiteralsConcatenationRule/ClassWithAbstractMethod.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\StringLiteralsConcatenationRule;
+
+abstract class ClassWithAbstractMethod
+{
+    abstract public function message(): string;
+}

--- a/tests/Fixtures/Rules/StringLiteralsConcatenationRule/ClassWithAllowedMixed.php
+++ b/tests/Fixtures/Rules/StringLiteralsConcatenationRule/ClassWithAllowedMixed.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\StringLiteralsConcatenationRule;
+
+final class ClassWithAllowedMixed
+{
+    public function greet(string $name): string
+    {
+        return "Hello, " . $name;
+    }
+}

--- a/tests/Fixtures/Rules/StringLiteralsConcatenationRule/ClassWithChainedConcat.php
+++ b/tests/Fixtures/Rules/StringLiteralsConcatenationRule/ClassWithChainedConcat.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\StringLiteralsConcatenationRule;
+
+final class ClassWithChainedConcat
+{
+    public function message(string $name): string
+    {
+        return "Hello, " . $name . "!";
+    }
+}

--- a/tests/Fixtures/Rules/StringLiteralsConcatenationRule/ClassWithConcatAssign.php
+++ b/tests/Fixtures/Rules/StringLiteralsConcatenationRule/ClassWithConcatAssign.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\StringLiteralsConcatenationRule;
+
+final class ClassWithConcatAssign
+{
+    public function build(): string
+    {
+        $text = '';
+        $text .= "done";
+
+        return $text;
+    }
+}

--- a/tests/Fixtures/Rules/StringLiteralsConcatenationRule/ClassWithConcatAssignMixed.php
+++ b/tests/Fixtures/Rules/StringLiteralsConcatenationRule/ClassWithConcatAssignMixed.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\StringLiteralsConcatenationRule;
+
+final class ClassWithConcatAssignMixed
+{
+    public function build(): string
+    {
+        $text = 'start';
+        $text .= "done";
+
+        return $text;
+    }
+}

--- a/tests/Fixtures/Rules/StringLiteralsConcatenationRule/ClassWithLiteralConcat.php
+++ b/tests/Fixtures/Rules/StringLiteralsConcatenationRule/ClassWithLiteralConcat.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\StringLiteralsConcatenationRule;
+
+final class ClassWithLiteralConcat
+{
+    public function message(): string
+    {
+        return "Hello" . " world";
+    }
+}

--- a/tests/Fixtures/Rules/StringLiteralsConcatenationRule/ClassWithMixedConcat.php
+++ b/tests/Fixtures/Rules/StringLiteralsConcatenationRule/ClassWithMixedConcat.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\StringLiteralsConcatenationRule;
+
+final class ClassWithMixedConcat
+{
+    public function greet(string $name): string
+    {
+        return "Hello, " . $name;
+    }
+}

--- a/tests/Fixtures/Rules/StringLiteralsConcatenationRule/ClassWithRightNestedConcat.php
+++ b/tests/Fixtures/Rules/StringLiteralsConcatenationRule/ClassWithRightNestedConcat.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\StringLiteralsConcatenationRule;
+
+final class ClassWithRightNestedConcat
+{
+    /**
+     * Parenthesized right-hand concat to exercise the right-nested branch.
+     *
+     * @param non-empty-string $name
+     */
+    public function greet(string $name): string
+    {
+        return $name . ("!" . "!");
+    }
+}

--- a/tests/Fixtures/Rules/StringLiteralsConcatenationRule/ClassWithSprintfUsage.php
+++ b/tests/Fixtures/Rules/StringLiteralsConcatenationRule/ClassWithSprintfUsage.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\StringLiteralsConcatenationRule;
+
+final class ClassWithSprintfUsage
+{
+    public function greet(string $name): string
+    {
+        return sprintf('Hello, %s', $name);
+    }
+}

--- a/tests/Fixtures/Rules/StringLiteralsConcatenationRule/ClassWithVariableConcat.php
+++ b/tests/Fixtures/Rules/StringLiteralsConcatenationRule/ClassWithVariableConcat.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\StringLiteralsConcatenationRule;
+
+final class ClassWithVariableConcat
+{
+    public function combine(string $first, string $last): string
+    {
+        return $first . $last;
+    }
+}

--- a/tests/Fixtures/Rules/StringLiteralsConcatenationRule/SuppressedClass.php
+++ b/tests/Fixtures/Rules/StringLiteralsConcatenationRule/SuppressedClass.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\StringLiteralsConcatenationRule;
+
+final class SuppressedClass
+{
+    public function message(): string
+    {
+        return "Hello" . " world"; // @phpstan-ignore haspadar.stringConcat
+    }
+}

--- a/tests/Unit/Rules/StringLiteralsConcatenationRule/StringLiteralsConcatenationRuleAllowMixedTest.php
+++ b/tests/Unit/Rules/StringLiteralsConcatenationRule/StringLiteralsConcatenationRuleAllowMixedTest.php
@@ -36,4 +36,13 @@ final class StringLiteralsConcatenationRuleAllowMixedTest extends RuleTestCase
             ],
         );
     }
+
+    #[Test]
+    public function passesWhenConcatAssignMixedAllowed(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/StringLiteralsConcatenationRule/ClassWithConcatAssignMixed.php'],
+            [],
+        );
+    }
 }

--- a/tests/Unit/Rules/StringLiteralsConcatenationRule/StringLiteralsConcatenationRuleAllowMixedTest.php
+++ b/tests/Unit/Rules/StringLiteralsConcatenationRule/StringLiteralsConcatenationRuleAllowMixedTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\StringLiteralsConcatenationRule;
+
+use Haspadar\PHPStanRules\Rules\StringLiteralsConcatenationRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<StringLiteralsConcatenationRule> */
+final class StringLiteralsConcatenationRuleAllowMixedTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new StringLiteralsConcatenationRule(['allowMixed' => true]);
+    }
+
+    #[Test]
+    public function passesWhenMixedConcatAllowed(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/StringLiteralsConcatenationRule/ClassWithAllowedMixed.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function reportsLiteralConcatEvenWhenMixedAllowed(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/StringLiteralsConcatenationRule/ClassWithLiteralConcat.php'],
+            [
+                ['String literal concatenation found on line 11. Use sprintf() or string interpolation instead.', 11],
+            ],
+        );
+    }
+}

--- a/tests/Unit/Rules/StringLiteralsConcatenationRule/StringLiteralsConcatenationRuleDefaultTest.php
+++ b/tests/Unit/Rules/StringLiteralsConcatenationRule/StringLiteralsConcatenationRuleDefaultTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\StringLiteralsConcatenationRule;
+
+use Haspadar\PHPStanRules\Rules\StringLiteralsConcatenationRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<StringLiteralsConcatenationRule> */
+final class StringLiteralsConcatenationRuleDefaultTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new StringLiteralsConcatenationRule();
+    }
+
+    #[Test]
+    public function reportsLiteralConcatWithDefaultOptions(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/StringLiteralsConcatenationRule/ClassWithLiteralConcat.php'],
+            [
+                ['String literal concatenation found on line 11. Use sprintf() or string interpolation instead.', 11],
+            ],
+        );
+    }
+
+    #[Test]
+    public function reportsMixedConcatWithDefaultOptions(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/StringLiteralsConcatenationRule/ClassWithMixedConcat.php'],
+            [
+                ['String literal concatenation found on line 11. Use sprintf() or string interpolation instead.', 11],
+            ],
+        );
+    }
+}

--- a/tests/Unit/Rules/StringLiteralsConcatenationRule/StringLiteralsConcatenationRuleTest.php
+++ b/tests/Unit/Rules/StringLiteralsConcatenationRule/StringLiteralsConcatenationRuleTest.php
@@ -87,4 +87,24 @@ final class StringLiteralsConcatenationRuleTest extends RuleTestCase
             [],
         );
     }
+
+    #[Test]
+    public function passesWhenMethodIsAbstract(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/StringLiteralsConcatenationRule/ClassWithAbstractMethod.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function reportsOneErrorForRightNestedConcat(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/StringLiteralsConcatenationRule/ClassWithRightNestedConcat.php'],
+            [
+                ['String literal concatenation found on line 16. Use sprintf() or string interpolation instead.', 16],
+            ],
+        );
+    }
 }

--- a/tests/Unit/Rules/StringLiteralsConcatenationRule/StringLiteralsConcatenationRuleTest.php
+++ b/tests/Unit/Rules/StringLiteralsConcatenationRule/StringLiteralsConcatenationRuleTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\StringLiteralsConcatenationRule;
+
+use Haspadar\PHPStanRules\Rules\StringLiteralsConcatenationRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<StringLiteralsConcatenationRule> */
+final class StringLiteralsConcatenationRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new StringLiteralsConcatenationRule();
+    }
+
+    #[Test]
+    public function reportsErrorWhenLiteralsConcatenated(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/StringLiteralsConcatenationRule/ClassWithLiteralConcat.php'],
+            [
+                ['String literal concatenation found on line 11. Use sprintf() or string interpolation instead.', 11],
+            ],
+        );
+    }
+
+    #[Test]
+    public function reportsErrorWhenMixedConcatenation(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/StringLiteralsConcatenationRule/ClassWithMixedConcat.php'],
+            [
+                ['String literal concatenation found on line 11. Use sprintf() or string interpolation instead.', 11],
+            ],
+        );
+    }
+
+    #[Test]
+    public function reportsErrorWhenConcatAssignUsed(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/StringLiteralsConcatenationRule/ClassWithConcatAssign.php'],
+            [
+                ['String literal concatenation found on line 12. Use sprintf() or string interpolation instead.', 12],
+            ],
+        );
+    }
+
+    #[Test]
+    public function reportsOneErrorForChainedConcat(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/StringLiteralsConcatenationRule/ClassWithChainedConcat.php'],
+            [
+                ['String literal concatenation found on line 11. Use sprintf() or string interpolation instead.', 11],
+            ],
+        );
+    }
+
+    #[Test]
+    public function passesWhenVariablesConcatenated(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/StringLiteralsConcatenationRule/ClassWithVariableConcat.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function passesWhenSprintfUsed(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/StringLiteralsConcatenationRule/ClassWithSprintfUsage.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function suppressesErrorWhenPhpstanIgnorePresent(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/StringLiteralsConcatenationRule/SuppressedClass.php'],
+            [],
+        );
+    }
+}

--- a/tests/Unit/RulesTest.php
+++ b/tests/Unit/RulesTest.php
@@ -46,6 +46,7 @@ use Haspadar\PHPStanRules\Rules\ReturnCountRule;
 use Haspadar\PHPStanRules\Rules\StatementCountRule;
 use Haspadar\PHPStanRules\Rules\TooManyMethodsRule;
 use Haspadar\PHPStanRules\Rules\ConstantUsageRule;
+use Haspadar\PHPStanRules\Rules\StringLiteralsConcatenationRule;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -97,6 +98,7 @@ final class RulesTest extends TestCase
                 CatchParameterNameRule::class,
                 UnnecessaryLocalRule::class,
                 ConstantUsageRule::class,
+                StringLiteralsConcatenationRule::class,
             ],
             (new Rules())->all(),
             'Rules::all() must list every registered rule class',


### PR DESCRIPTION
## Summary

- Add `StringLiteralsConcatenationRule` that forbids `.` and `.=` operators when a string literal is involved
- Replace existing string concatenation with `sprintf()` in `AtclauseOrderRule` and `CompiledPattern`
- Configurable `allowMixed` option: `false` (strict, default) or `true` (only literal+literal)

Closes #106

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `StringLiteralsConcatenationRule` to detect string concatenation using `.` and `.=` operators
  * Added `allowMixed` configuration option (defaults to false) to control detection behavior

* **Documentation**
  * Updated README with rule documentation and configuration examples

* **Tests**
  * Added comprehensive test suite covering various concatenation scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->