### PR TITLE
TodoCommentRule — forbid TODO, FIXME, XXX comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@
 | `UnnecessaryLocalRule`        | Local variable assigned and immediately returned/thrown must be inlined        |
 | `ConstantUsageRule`           | Magic numbers and strings must be defined as named constants                  |
 | `StringLiteralsConcatenationRule` | String literal concatenation via `.` or `.=` is forbidden                |
+| `TodoCommentRule`             | TODO, FIXME, and XXX comments are forbidden in method bodies                  |
 
 ### Naming
 
@@ -159,6 +160,11 @@ parameters:
                 - ''
         stringConcat:
             allowMixed: false
+        todoComment:
+            keywords:
+                - TODO
+                - FIXME
+                - XXX
 ```
 
 Default values match the defaults described in the rules table above. Omitting a parameter keeps the default. Diagnostic identifier for `AtclauseOrderRule`: `haspadar.atclauseOrder` (for targeted ignores, e.g. `@phpstan-ignore haspadar.atclauseOrder`).

--- a/rules.neon
+++ b/rules.neon
@@ -79,6 +79,11 @@ parameters:
                 - ''
         stringConcat:
             allowMixed: false
+        todoComment:
+            keywords:
+                - TODO
+                - FIXME
+                - XXX
 
 parametersSchema:
     haspadar: structure([
@@ -168,6 +173,9 @@ parametersSchema:
         ]),
         stringConcat: structure([
             allowMixed: bool(),
+        ]),
+        todoComment: structure([
+            keywords: listOf(string()),
         ]),
     ])
 
@@ -417,5 +425,12 @@ services:
         arguments:
             options:
                 allowMixed: %haspadar.stringConcat.allowMixed%
+        tags:
+            - phpstan.rules.rule
+    -
+        class: Haspadar\PHPStanRules\Rules\TodoCommentRule
+        arguments:
+            options:
+                keywords: %haspadar.todoComment.keywords%
         tags:
             - phpstan.rules.rule

--- a/src/Rules.php
+++ b/src/Rules.php
@@ -59,6 +59,7 @@ final class Rules
             Rules\UnnecessaryLocalRule::class,
             Rules\ConstantUsageRule::class,
             Rules\StringLiteralsConcatenationRule::class,
+            Rules\TodoCommentRule::class,
         ];
     }
 }

--- a/src/Rules/TodoCommentRule.php
+++ b/src/Rules/TodoCommentRule.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Rules;
+
+use Override;
+use PhpParser\Comment;
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\NodeFinder;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * Forbids task-tracking comments inside method bodies.
+ *
+ * Scans all comment types (//, #, block, PHPDoc) attached to nodes inside
+ * a ClassMethod for configurable keywords (case-insensitive, word boundary).
+ *
+ * @implements Rule<ClassMethod>
+ */
+final readonly class TodoCommentRule implements Rule
+{
+    /** @var list<string> */
+    private array $keywords;
+
+    /**
+     * Constructs the rule with the given options.
+     *
+     * @param array{
+     *     keywords?: list<string>
+     * } $options
+     */
+    public function __construct(array $options = [])
+    {
+        $this->keywords = $options['keywords'] ?? ['TODO', 'FIXME', 'XXX'];
+    }
+
+    #[Override]
+    public function getNodeType(): string
+    {
+        return ClassMethod::class;
+    }
+
+    /**
+     * Analyses the node and returns a list of errors.
+     *
+     * @psalm-param ClassMethod $node
+     * @return list<IdentifierRuleError>
+     */
+    #[Override]
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if ($node->stmts === null) {
+            return [];
+        }
+
+        $errors = [];
+        $pattern = $this->buildPattern();
+        $allNodes = (new NodeFinder())->findInstanceOf($node->stmts, Node::class);
+
+        foreach ($allNodes as $child) {
+            foreach ($this->collectViolations($child, $pattern) as $error) {
+                $errors[] = $error;
+            }
+        }
+
+        $methodDoc = $node->getDocComment();
+
+        if ($methodDoc !== null && preg_match($pattern, $methodDoc->getText()) === 1) {
+            $errors[] = RuleErrorBuilder::message(
+                sprintf(
+                    'TODO comment found on line %d. Resolve the issue or create a ticket instead.',
+                    $methodDoc->getStartLine(),
+                ),
+            )
+                ->identifier('haspadar.todoComment')
+                ->line($methodDoc->getStartLine())
+                ->build();
+        }
+
+        return $errors;
+    }
+
+    /**
+     * Builds a case-insensitive regex pattern from the configured keywords.
+     *
+     * @return non-empty-string
+     */
+    private function buildPattern(): string
+    {
+        $escaped = array_map(
+            static fn(string $keyword): string => preg_quote($keyword, '/'),
+            $this->keywords,
+        );
+
+        return sprintf('/\b(%s)\b/i', implode('|', $escaped));
+    }
+
+    /**
+     * Returns errors for forbidden comments attached to a node.
+     *
+     * @param non-empty-string $pattern
+     * @return list<IdentifierRuleError>
+     */
+    private function collectViolations(Node $node, string $pattern): array
+    {
+        /** @var list<Comment> $comments */
+        $comments = $node->getAttribute('comments') ?? [];
+        $errors = [];
+
+        foreach ($comments as $comment) {
+            if (preg_match($pattern, $comment->getText()) === 1) {
+                $errors[] = RuleErrorBuilder::message(
+                    sprintf(
+                        'TODO comment found on line %d. Resolve the issue or create a ticket instead.',
+                        $comment->getStartLine(),
+                    ),
+                )
+                    ->identifier('haspadar.todoComment')
+                    ->line($comment->getStartLine())
+                    ->build();
+            }
+        }
+
+        return $errors;
+    }
+}

--- a/tests/Fixtures/Rules/TodoCommentRule/ClassWithAbstractMethod.php
+++ b/tests/Fixtures/Rules/TodoCommentRule/ClassWithAbstractMethod.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\TodoCommentRule;
+
+abstract class ClassWithAbstractMethod
+{
+    abstract public function execute(): void;
+}

--- a/tests/Fixtures/Rules/TodoCommentRule/ClassWithBlockTodo.php
+++ b/tests/Fixtures/Rules/TodoCommentRule/ClassWithBlockTodo.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\TodoCommentRule;
+
+final class ClassWithBlockTodo
+{
+    public function execute(): void
+    {
+        /* TODO: fix later */
+        $value = 1;
+    }
+}

--- a/tests/Fixtures/Rules/TodoCommentRule/ClassWithCleanComments.php
+++ b/tests/Fixtures/Rules/TodoCommentRule/ClassWithCleanComments.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\TodoCommentRule;
+
+final class ClassWithCleanComments
+{
+    public function execute(): string
+    {
+        $value = 'hello';
+
+        return $value;
+    }
+}

--- a/tests/Fixtures/Rules/TodoCommentRule/ClassWithCustomKeyword.php
+++ b/tests/Fixtures/Rules/TodoCommentRule/ClassWithCustomKeyword.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\TodoCommentRule;
+
+final class ClassWithCustomKeyword
+{
+    public function execute(): void
+    {
+        // HACK: workaround for upstream bug
+        $value = 1;
+    }
+}

--- a/tests/Fixtures/Rules/TodoCommentRule/ClassWithFixmeComment.php
+++ b/tests/Fixtures/Rules/TodoCommentRule/ClassWithFixmeComment.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\TodoCommentRule;
+
+final class ClassWithFixmeComment
+{
+    public function execute(): void
+    {
+        // FIXME: broken edge case
+        $value = 1;
+    }
+}

--- a/tests/Fixtures/Rules/TodoCommentRule/ClassWithHashTodo.php
+++ b/tests/Fixtures/Rules/TodoCommentRule/ClassWithHashTodo.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\TodoCommentRule;
+
+final class ClassWithHashTodo
+{
+    public function execute(): void
+    {
+        # TODO fix this
+        $value = 1;
+    }
+}

--- a/tests/Fixtures/Rules/TodoCommentRule/ClassWithTodoComment.php
+++ b/tests/Fixtures/Rules/TodoCommentRule/ClassWithTodoComment.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\TodoCommentRule;
+
+final class ClassWithTodoComment
+{
+    public function execute(): void
+    {
+        // TODO: refactor this method
+        $value = 1;
+    }
+}

--- a/tests/Fixtures/Rules/TodoCommentRule/ClassWithTodoInPhpDoc.php
+++ b/tests/Fixtures/Rules/TodoCommentRule/ClassWithTodoInPhpDoc.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\TodoCommentRule;
+
+final class ClassWithTodoInPhpDoc
+{
+    /** @todo implement validation */
+    public function execute(): void
+    {
+        $value = 1;
+    }
+}

--- a/tests/Fixtures/Rules/TodoCommentRule/ClassWithXxxComment.php
+++ b/tests/Fixtures/Rules/TodoCommentRule/ClassWithXxxComment.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\TodoCommentRule;
+
+final class ClassWithXxxComment
+{
+    public function execute(): void
+    {
+        // XXX temporary workaround
+        $value = 1;
+    }
+}

--- a/tests/Fixtures/Rules/TodoCommentRule/SuppressedClass.php
+++ b/tests/Fixtures/Rules/TodoCommentRule/SuppressedClass.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\TodoCommentRule;
+
+final class SuppressedClass
+{
+    public function execute(): void
+    {
+        $value = 1; // TODO: suppressed @phpstan-ignore haspadar.todoComment
+    }
+}

--- a/tests/Unit/Rules/TodoCommentRule/TodoCommentRuleCustomKeywordsTest.php
+++ b/tests/Unit/Rules/TodoCommentRule/TodoCommentRuleCustomKeywordsTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\TodoCommentRule;
+
+use Haspadar\PHPStanRules\Rules\TodoCommentRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<TodoCommentRule> */
+final class TodoCommentRuleCustomKeywordsTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new TodoCommentRule(['keywords' => ['HACK']]);
+    }
+
+    #[Test]
+    public function reportsErrorWhenHackCommentFound(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/TodoCommentRule/ClassWithCustomKeyword.php'],
+            [
+                ['TODO comment found on line 11. Resolve the issue or create a ticket instead.', 11],
+            ],
+        );
+    }
+
+    #[Test]
+    public function passesWhenTodoCommentNotInKeywords(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/TodoCommentRule/ClassWithTodoComment.php'],
+            [],
+        );
+    }
+}

--- a/tests/Unit/Rules/TodoCommentRule/TodoCommentRuleDefaultTest.php
+++ b/tests/Unit/Rules/TodoCommentRule/TodoCommentRuleDefaultTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\TodoCommentRule;
+
+use Haspadar\PHPStanRules\Rules\TodoCommentRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<TodoCommentRule> */
+final class TodoCommentRuleDefaultTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new TodoCommentRule();
+    }
+
+    #[Test]
+    public function reportsErrorWithDefaultKeywords(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/TodoCommentRule/ClassWithTodoComment.php'],
+            [
+                ['TODO comment found on line 11. Resolve the issue or create a ticket instead.', 11],
+            ],
+        );
+    }
+
+    #[Test]
+    public function passesWhenNoTodoComments(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/TodoCommentRule/ClassWithCleanComments.php'],
+            [],
+        );
+    }
+}

--- a/tests/Unit/Rules/TodoCommentRule/TodoCommentRuleTest.php
+++ b/tests/Unit/Rules/TodoCommentRule/TodoCommentRuleTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\TodoCommentRule;
+
+use Haspadar\PHPStanRules\Rules\TodoCommentRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<TodoCommentRule> */
+final class TodoCommentRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new TodoCommentRule();
+    }
+
+    #[Test]
+    public function reportsErrorWhenTodoCommentFound(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/TodoCommentRule/ClassWithTodoComment.php'],
+            [
+                ['TODO comment found on line 11. Resolve the issue or create a ticket instead.', 11],
+            ],
+        );
+    }
+
+    #[Test]
+    public function reportsErrorWhenFixmeCommentFound(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/TodoCommentRule/ClassWithFixmeComment.php'],
+            [
+                ['TODO comment found on line 11. Resolve the issue or create a ticket instead.', 11],
+            ],
+        );
+    }
+
+    #[Test]
+    public function reportsErrorWhenXxxCommentFound(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/TodoCommentRule/ClassWithXxxComment.php'],
+            [
+                ['TODO comment found on line 11. Resolve the issue or create a ticket instead.', 11],
+            ],
+        );
+    }
+
+    #[Test]
+    public function reportsErrorWhenTodoInPhpDoc(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/TodoCommentRule/ClassWithTodoInPhpDoc.php'],
+            [
+                ['TODO comment found on line 9. Resolve the issue or create a ticket instead.', 9],
+            ],
+        );
+    }
+
+    #[Test]
+    public function reportsErrorWhenHashTodoFound(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/TodoCommentRule/ClassWithHashTodo.php'],
+            [
+                ['TODO comment found on line 11. Resolve the issue or create a ticket instead.', 11],
+            ],
+        );
+    }
+
+    #[Test]
+    public function reportsErrorWhenBlockTodoFound(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/TodoCommentRule/ClassWithBlockTodo.php'],
+            [
+                ['TODO comment found on line 11. Resolve the issue or create a ticket instead.', 11],
+            ],
+        );
+    }
+
+    #[Test]
+    public function passesWhenCommentsClean(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/TodoCommentRule/ClassWithCleanComments.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function passesWhenMethodIsAbstract(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/TodoCommentRule/ClassWithAbstractMethod.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function suppressesErrorWhenPhpstanIgnorePresent(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/TodoCommentRule/SuppressedClass.php'],
+            [],
+        );
+    }
+}

--- a/tests/Unit/RulesTest.php
+++ b/tests/Unit/RulesTest.php
@@ -47,6 +47,7 @@ use Haspadar\PHPStanRules\Rules\StatementCountRule;
 use Haspadar\PHPStanRules\Rules\TooManyMethodsRule;
 use Haspadar\PHPStanRules\Rules\ConstantUsageRule;
 use Haspadar\PHPStanRules\Rules\StringLiteralsConcatenationRule;
+use Haspadar\PHPStanRules\Rules\TodoCommentRule;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -99,6 +100,7 @@ final class RulesTest extends TestCase
                 UnnecessaryLocalRule::class,
                 ConstantUsageRule::class,
                 StringLiteralsConcatenationRule::class,
+                TodoCommentRule::class,
             ],
             (new Rules())->all(),
             'Rules::all() must list every registered rule class',


### PR DESCRIPTION
## Summary

- Add `TodoCommentRule` that forbids TODO/FIXME/XXX comments inside method bodies
- Scans all comment types (`//`, `#`, `/* */`, `/** */`) with case-insensitive keyword matching
- Configurable keyword list via `todoComment.keywords` option (default: `["TODO", "FIXME", "XXX"]`)

Closes #108

## Test plan

- [ ] `vendor/bin/piqule check` passes all 14 checks
- [ ] `vendor/bin/piqule check infection` — MSI 100%
- [ ] CI green on GitHub Actions
- [ ] CodeRabbit review passes