### PR TITLE
Forbid generic class name suffixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@
 | `VariableNameRule`                | `^[a-z][a-zA-Z]{2,19}$` | Local variable name must match the configured pattern         |
 | `ParameterNameRule`               | `^(id\|[a-z]{3,})$` | Method parameter name must match the configured pattern           |
 | `CatchParameterNameRule`          | `^(e\|ex\|[a-z]{3,12})$` | Catch parameter name must match the configured pattern       |
+| `ForbiddenClassSuffixRule`        | 12 suffixes | Class name must not end with a generic suffix (Manager, Helper, Util, ...) |
 
 ### PHPDoc style
 
@@ -165,6 +166,23 @@ parameters:
                 - TODO
                 - FIXME
                 - XXX
+        forbiddenClassSuffix:
+            forbiddenSuffixes:
+                - Manager
+                - Handler
+                - Processor
+                - Coordinator
+                - Helper
+                - Util
+                - Utils
+                - Utility
+                - Data
+                - Info
+                - Information
+                - Wrapper
+            allowedSuffixes:
+                - EventHandler
+                - CommandHandler
 ```
 
 Default values match the defaults described in the rules table above. Omitting a parameter keeps the default. Diagnostic identifier for `AtclauseOrderRule`: `haspadar.atclauseOrder` (for targeted ignores, e.g. `@phpstan-ignore haspadar.atclauseOrder`).

--- a/rules.neon
+++ b/rules.neon
@@ -84,6 +84,21 @@ parameters:
                 - TODO
                 - FIXME
                 - XXX
+        forbiddenClassSuffix:
+            forbiddenSuffixes:
+                - Manager
+                - Handler
+                - Processor
+                - Coordinator
+                - Helper
+                - Util
+                - Utils
+                - Utility
+                - Data
+                - Info
+                - Information
+                - Wrapper
+            allowedSuffixes: []
 
 parametersSchema:
     haspadar: structure([
@@ -176,6 +191,10 @@ parametersSchema:
         ]),
         todoComment: structure([
             keywords: listOf(string()),
+        ]),
+        forbiddenClassSuffix: structure([
+            forbiddenSuffixes: listOf(string()),
+            allowedSuffixes: listOf(string()),
         ]),
     ])
 
@@ -432,5 +451,13 @@ services:
         arguments:
             options:
                 keywords: %haspadar.todoComment.keywords%
+        tags:
+            - phpstan.rules.rule
+    -
+        class: Haspadar\PHPStanRules\Rules\ForbiddenClassSuffixRule
+        arguments:
+            options:
+                forbiddenSuffixes: %haspadar.forbiddenClassSuffix.forbiddenSuffixes%
+                allowedSuffixes: %haspadar.forbiddenClassSuffix.allowedSuffixes%
         tags:
             - phpstan.rules.rule

--- a/src/Rules.php
+++ b/src/Rules.php
@@ -60,6 +60,7 @@ final class Rules
             Rules\ConstantUsageRule::class,
             Rules\StringLiteralsConcatenationRule::class,
             Rules\TodoCommentRule::class,
+            Rules\ForbiddenClassSuffixRule::class,
         ];
     }
 }

--- a/src/Rules/ForbiddenClassSuffixRule.php
+++ b/src/Rules/ForbiddenClassSuffixRule.php
@@ -40,21 +40,27 @@ final readonly class ForbiddenClassSuffixRule implements Rule
      */
     public function __construct(array $options = [])
     {
-        $this->forbiddenSuffixes = $options['forbiddenSuffixes'] ?? [
-            'Manager',
-            'Handler',
-            'Processor',
-            'Coordinator',
-            'Helper',
-            'Util',
-            'Utils',
-            'Utility',
-            'Data',
-            'Info',
-            'Information',
-            'Wrapper',
-        ];
-        $this->allowedSuffixes = $options['allowedSuffixes'] ?? [];
+        $this->forbiddenSuffixes = array_values(array_filter(
+            $options['forbiddenSuffixes'] ?? [
+                'Manager',
+                'Handler',
+                'Processor',
+                'Coordinator',
+                'Helper',
+                'Util',
+                'Utils',
+                'Utility',
+                'Data',
+                'Info',
+                'Information',
+                'Wrapper',
+            ],
+            static fn(string $suffix): bool => $suffix !== '',
+        ));
+        $this->allowedSuffixes = array_values(array_filter(
+            $options['allowedSuffixes'] ?? [],
+            static fn(string $suffix): bool => $suffix !== '',
+        ));
     }
 
     #[Override]

--- a/src/Rules/ForbiddenClassSuffixRule.php
+++ b/src/Rules/ForbiddenClassSuffixRule.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Rules;
+
+use Override;
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\ShouldNotHappenException;
+
+/**
+ * Forbids generic class name suffixes that indicate unclear responsibility.
+ *
+ * Reports classes whose names end with a forbidden suffix such as Manager,
+ * Handler, Helper, Util, etc. Abstract classes, anonymous classes, and classes
+ * whose suffix appears in the allowed list are exempt.
+ *
+ * @implements Rule<Class_>
+ */
+final readonly class ForbiddenClassSuffixRule implements Rule
+{
+    /** @var list<string> */
+    private array $forbiddenSuffixes;
+
+    /** @var list<string> */
+    private array $allowedSuffixes;
+
+    /**
+     * Constructs the rule with the given options.
+     *
+     * @param array{
+     *     forbiddenSuffixes?: list<string>,
+     *     allowedSuffixes?: list<string>
+     * } $options
+     */
+    public function __construct(array $options = [])
+    {
+        $this->forbiddenSuffixes = $options['forbiddenSuffixes'] ?? [
+            'Manager',
+            'Handler',
+            'Processor',
+            'Coordinator',
+            'Helper',
+            'Util',
+            'Utils',
+            'Utility',
+            'Data',
+            'Info',
+            'Information',
+            'Wrapper',
+        ];
+        $this->allowedSuffixes = $options['allowedSuffixes'] ?? [];
+    }
+
+    #[Override]
+    public function getNodeType(): string
+    {
+        return Class_::class;
+    }
+
+    /**
+     * Analyses the node and returns a list of errors.
+     *
+     * @psalm-param Class_ $node
+     * @throws ShouldNotHappenException
+     * @return list<IdentifierRuleError>
+     */
+    #[Override]
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if ($node->isAbstract() || $node->isAnonymous() || $node->name === null) {
+            return [];
+        }
+
+        $className = $node->name->toString();
+        $matchedSuffix = $this->findForbiddenSuffix($className);
+
+        if ($matchedSuffix === '') {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message(
+                sprintf(
+                    "Class %s uses forbidden suffix '%s'. Rename to describe its responsibility.",
+                    $className,
+                    $matchedSuffix,
+                ),
+            )
+                ->identifier('haspadar.forbiddenClassSuffix')
+                ->build(),
+        ];
+    }
+
+    /**
+     * Returns the matched forbidden suffix or empty string if none matches.
+     */
+    private function findForbiddenSuffix(string $className): string
+    {
+        foreach ($this->forbiddenSuffixes as $suffix) {
+            if (!str_ends_with($className, $suffix)) {
+                continue;
+            }
+
+            if ($this->isAllowed($className)) {
+                continue;
+            }
+
+            return $suffix;
+        }
+
+        return '';
+    }
+
+    /**
+     * Checks whether the class name ends with an allowed suffix.
+     */
+    private function isAllowed(string $className): bool
+    {
+        foreach ($this->allowedSuffixes as $allowed) {
+            if (str_ends_with($className, $allowed)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/Fixtures/Rules/ForbiddenClassSuffixRule/AbstractClassWithSuffix.php
+++ b/tests/Fixtures/Rules/ForbiddenClassSuffixRule/AbstractClassWithSuffix.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ForbiddenClassSuffixRule;
+
+abstract class BaseManager
+{
+}

--- a/tests/Fixtures/Rules/ForbiddenClassSuffixRule/ClassWithAllowedSuffix.php
+++ b/tests/Fixtures/Rules/ForbiddenClassSuffixRule/ClassWithAllowedSuffix.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ForbiddenClassSuffixRule;
+
+final class EventHandler
+{
+}

--- a/tests/Fixtures/Rules/ForbiddenClassSuffixRule/ClassWithCleanName.php
+++ b/tests/Fixtures/Rules/ForbiddenClassSuffixRule/ClassWithCleanName.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ForbiddenClassSuffixRule;
+
+final class UserRepository
+{
+}

--- a/tests/Fixtures/Rules/ForbiddenClassSuffixRule/ClassWithDataSuffix.php
+++ b/tests/Fixtures/Rules/ForbiddenClassSuffixRule/ClassWithDataSuffix.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ForbiddenClassSuffixRule;
+
+final class OrderData
+{
+}

--- a/tests/Fixtures/Rules/ForbiddenClassSuffixRule/ClassWithHelperSuffix.php
+++ b/tests/Fixtures/Rules/ForbiddenClassSuffixRule/ClassWithHelperSuffix.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ForbiddenClassSuffixRule;
+
+final class StringHelper
+{
+}

--- a/tests/Fixtures/Rules/ForbiddenClassSuffixRule/ClassWithManagerSuffix.php
+++ b/tests/Fixtures/Rules/ForbiddenClassSuffixRule/ClassWithManagerSuffix.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ForbiddenClassSuffixRule;
+
+final class UserManager
+{
+}

--- a/tests/Fixtures/Rules/ForbiddenClassSuffixRule/ClassWithProcessorSuffix.php
+++ b/tests/Fixtures/Rules/ForbiddenClassSuffixRule/ClassWithProcessorSuffix.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ForbiddenClassSuffixRule;
+
+final class DataProcessor
+{
+}

--- a/tests/Fixtures/Rules/ForbiddenClassSuffixRule/SuppressedClass.php
+++ b/tests/Fixtures/Rules/ForbiddenClassSuffixRule/SuppressedClass.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ForbiddenClassSuffixRule;
+
+/** @phpstan-ignore haspadar.forbiddenClassSuffix */
+final class PaymentHandler
+{
+}

--- a/tests/Unit/Rules/ForbiddenClassSuffixRule/ForbiddenClassSuffixRuleAllowedSuffixTest.php
+++ b/tests/Unit/Rules/ForbiddenClassSuffixRule/ForbiddenClassSuffixRuleAllowedSuffixTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\ForbiddenClassSuffixRule;
+
+use Haspadar\PHPStanRules\Rules\ForbiddenClassSuffixRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<ForbiddenClassSuffixRule> */
+final class ForbiddenClassSuffixRuleAllowedSuffixTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new ForbiddenClassSuffixRule([
+            'allowedSuffixes' => ['EventHandler'],
+        ]);
+    }
+
+    #[Test]
+    public function passesWhenSuffixIsAllowed(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ForbiddenClassSuffixRule/ClassWithAllowedSuffix.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function reportsErrorForNonAllowedSuffix(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ForbiddenClassSuffixRule/ClassWithManagerSuffix.php'],
+            [
+                [
+                    "Class UserManager uses forbidden suffix 'Manager'. Rename to describe its responsibility.",
+                    7,
+                ],
+            ],
+        );
+    }
+}

--- a/tests/Unit/Rules/ForbiddenClassSuffixRule/ForbiddenClassSuffixRuleDefaultTest.php
+++ b/tests/Unit/Rules/ForbiddenClassSuffixRule/ForbiddenClassSuffixRuleDefaultTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\ForbiddenClassSuffixRule;
+
+use Haspadar\PHPStanRules\Rules\ForbiddenClassSuffixRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<ForbiddenClassSuffixRule> */
+final class ForbiddenClassSuffixRuleDefaultTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new ForbiddenClassSuffixRule();
+    }
+
+    #[Test]
+    public function reportsErrorWithDefaultSuffixes(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ForbiddenClassSuffixRule/ClassWithManagerSuffix.php'],
+            [
+                [
+                    "Class UserManager uses forbidden suffix 'Manager'. Rename to describe its responsibility.",
+                    7,
+                ],
+            ],
+        );
+    }
+
+    #[Test]
+    public function passesWithDefaultSuffixesWhenClean(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ForbiddenClassSuffixRule/ClassWithCleanName.php'],
+            [],
+        );
+    }
+}

--- a/tests/Unit/Rules/ForbiddenClassSuffixRule/ForbiddenClassSuffixRuleTest.php
+++ b/tests/Unit/Rules/ForbiddenClassSuffixRule/ForbiddenClassSuffixRuleTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\ForbiddenClassSuffixRule;
+
+use Haspadar\PHPStanRules\Rules\ForbiddenClassSuffixRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<ForbiddenClassSuffixRule> */
+final class ForbiddenClassSuffixRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new ForbiddenClassSuffixRule();
+    }
+
+    #[Test]
+    public function reportsErrorForManagerSuffix(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ForbiddenClassSuffixRule/ClassWithManagerSuffix.php'],
+            [
+                [
+                    "Class UserManager uses forbidden suffix 'Manager'. Rename to describe its responsibility.",
+                    7,
+                ],
+            ],
+        );
+    }
+
+    #[Test]
+    public function reportsErrorForHelperSuffix(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ForbiddenClassSuffixRule/ClassWithHelperSuffix.php'],
+            [
+                [
+                    "Class StringHelper uses forbidden suffix 'Helper'. Rename to describe its responsibility.",
+                    7,
+                ],
+            ],
+        );
+    }
+
+    #[Test]
+    public function reportsErrorForDataSuffix(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ForbiddenClassSuffixRule/ClassWithDataSuffix.php'],
+            [
+                [
+                    "Class OrderData uses forbidden suffix 'Data'. Rename to describe its responsibility.",
+                    7,
+                ],
+            ],
+        );
+    }
+
+    #[Test]
+    public function reportsErrorForProcessorSuffix(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ForbiddenClassSuffixRule/ClassWithProcessorSuffix.php'],
+            [
+                [
+                    "Class DataProcessor uses forbidden suffix 'Processor'. Rename to describe its responsibility.",
+                    7,
+                ],
+            ],
+        );
+    }
+
+    #[Test]
+    public function passesWhenClassHasCleanName(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ForbiddenClassSuffixRule/ClassWithCleanName.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function passesWhenClassIsAbstract(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ForbiddenClassSuffixRule/AbstractClassWithSuffix.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function passesWhenSuppressed(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ForbiddenClassSuffixRule/SuppressedClass.php'],
+            [],
+        );
+    }
+}

--- a/tests/Unit/RulesTest.php
+++ b/tests/Unit/RulesTest.php
@@ -48,6 +48,7 @@ use Haspadar\PHPStanRules\Rules\TooManyMethodsRule;
 use Haspadar\PHPStanRules\Rules\ConstantUsageRule;
 use Haspadar\PHPStanRules\Rules\StringLiteralsConcatenationRule;
 use Haspadar\PHPStanRules\Rules\TodoCommentRule;
+use Haspadar\PHPStanRules\Rules\ForbiddenClassSuffixRule;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -101,6 +102,7 @@ final class RulesTest extends TestCase
                 ConstantUsageRule::class,
                 StringLiteralsConcatenationRule::class,
                 TodoCommentRule::class,
+                ForbiddenClassSuffixRule::class,
             ],
             (new Rules())->all(),
             'Rules::all() must list every registered rule class',


### PR DESCRIPTION
## Summary

- Add `ForbiddenClassSuffixRule` — forbids class names ending with generic suffixes (Manager, Handler, Helper, Util, etc.)
- 12 forbidden suffixes by default, configurable via `forbiddenSuffixes` and `allowedSuffixes` options
- Abstract and anonymous classes are exempt

Closes #110

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable rule to detect classes with forbidden naming suffixes (e.g., `Manager`, `Helper`, `Util`, `Processor`).
  * Support for allowed suffix exceptions (e.g., `EventHandler`, `CommandHandler`) to exclude specific patterns from violation detection.

* **Documentation**
  * Added configuration documentation and examples for the new rule settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->