### PR TITLE
Add KeepInterfacesShortRule enforcing interface method limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
 | `ProhibitPublicStaticMethodsRule` | Classes must not have `public static` methods                                      |
 | `ConstructorInitializationRule`   | Constructor must only assign `$this->property` or call `parent::__construct()`     |
 | `BeImmutableRule`                | All non-static properties must be `readonly`                                       |
+| `KeepInterfacesShortRule`        | Interfaces must not declare too many methods (default: 10)                         |
 
 ### Error-prone patterns
 
@@ -171,6 +172,8 @@ parameters:
             excludedClasses:
                 - App\Entity\User
                 - App\Entity\Order
+        interfaceMethods:
+            maxMethods: 5
         forbiddenClassSuffix:
             forbiddenSuffixes:
                 - Manager

--- a/rules.neon
+++ b/rules.neon
@@ -86,6 +86,8 @@ parameters:
                 - XXX
         beImmutable:
             excludedClasses: []
+        interfaceMethods:
+            maxMethods: 10
         forbiddenClassSuffix:
             forbiddenSuffixes:
                 - Manager
@@ -196,6 +198,9 @@ parametersSchema:
         ]),
         beImmutable: structure([
             excludedClasses: listOf(string()),
+        ]),
+        interfaceMethods: structure([
+            maxMethods: int(),
         ]),
         forbiddenClassSuffix: structure([
             forbiddenSuffixes: listOf(string()),
@@ -471,5 +476,11 @@ services:
             options:
                 forbiddenSuffixes: %haspadar.forbiddenClassSuffix.forbiddenSuffixes%
                 allowedSuffixes: %haspadar.forbiddenClassSuffix.allowedSuffixes%
+        tags:
+            - phpstan.rules.rule
+    -
+        class: Haspadar\PHPStanRules\Rules\KeepInterfacesShortRule
+        arguments:
+            maxMethods: %haspadar.interfaceMethods.maxMethods%
         tags:
             - phpstan.rules.rule

--- a/src/Rules.php
+++ b/src/Rules.php
@@ -55,6 +55,7 @@ final class Rules
         Rules\TodoCommentRule::class,
         Rules\ForbiddenClassSuffixRule::class,
         Rules\BeImmutableRule::class,
+        Rules\KeepInterfacesShortRule::class,
     ];
 
     /**

--- a/src/Rules/KeepInterfacesShortRule.php
+++ b/src/Rules/KeepInterfacesShortRule.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Rules;
+
+use Override;
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Interface_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\ShouldNotHappenException;
+
+/**
+ * Reports an interface that declares more methods than the configured maximum.
+ *
+ * Counts all methods declared directly in the interface body.
+ * Methods inherited via `extends` are not counted — only own declarations.
+ * Enforces the Interface Segregation Principle: one interface = one narrow contract.
+ *
+ * @implements Rule<Interface_>
+ */
+final readonly class KeepInterfacesShortRule implements Rule
+{
+    /**
+     * Constructs the rule with the given method limit.
+     */
+    public function __construct(private int $maxMethods = 10) {}
+
+    #[Override]
+    public function getNodeType(): string
+    {
+        return Interface_::class;
+    }
+
+    /**
+     * Analyses the node and returns a list of errors.
+     *
+     * @psalm-param Interface_ $node
+     * @throws ShouldNotHappenException
+     * @return list<IdentifierRuleError>
+     */
+    #[Override]
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $count = count($node->getMethods());
+
+        if ($count <= $this->maxMethods) {
+            return [];
+        }
+
+        if ($node->name === null) {
+            throw new ShouldNotHappenException();
+        }
+
+        return [
+            RuleErrorBuilder::message(
+                sprintf(
+                    'Interface %s has %d methods. Maximum allowed is %d.',
+                    $node->name->toString(),
+                    $count,
+                    $this->maxMethods,
+                ),
+            )
+                ->identifier('haspadar.interfaceMethods')
+                ->build(),
+        ];
+    }
+}

--- a/src/Rules/KeepInterfacesShortRule.php
+++ b/src/Rules/KeepInterfacesShortRule.php
@@ -43,9 +43,7 @@ final readonly class KeepInterfacesShortRule implements Rule
     #[Override]
     public function processNode(Node $node, Scope $scope): array
     {
-        if ($node->name === null) {
-            return [];
-        }
+        assert($node->name !== null);
 
         $count = count($node->getMethods());
 

--- a/src/Rules/KeepInterfacesShortRule.php
+++ b/src/Rules/KeepInterfacesShortRule.php
@@ -11,7 +11,6 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
-use PHPStan\ShouldNotHappenException;
 
 /**
  * Reports an interface that declares more methods than the configured maximum.
@@ -39,20 +38,19 @@ final readonly class KeepInterfacesShortRule implements Rule
      * Analyses the node and returns a list of errors.
      *
      * @psalm-param Interface_ $node
-     * @throws ShouldNotHappenException
      * @return list<IdentifierRuleError>
      */
     #[Override]
     public function processNode(Node $node, Scope $scope): array
     {
+        if ($node->name === null) {
+            return [];
+        }
+
         $count = count($node->getMethods());
 
         if ($count <= $this->maxMethods) {
             return [];
-        }
-
-        if ($node->name === null) {
-            throw new ShouldNotHappenException();
         }
 
         return [

--- a/tests/Fixtures/Rules/KeepInterfacesShortRule/ExactDefaultInterface.php
+++ b/tests/Fixtures/Rules/KeepInterfacesShortRule/ExactDefaultInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\KeepInterfacesShortRule;
+
+interface ExactDefaultInterface
+{
+    public function one(): void;
+
+    public function two(): void;
+
+    public function three(): void;
+
+    public function four(): void;
+
+    public function five(): void;
+
+    public function six(): void;
+
+    public function seven(): void;
+
+    public function eight(): void;
+
+    public function nine(): void;
+
+    public function ten(): void;
+}

--- a/tests/Fixtures/Rules/KeepInterfacesShortRule/ExactInterface.php
+++ b/tests/Fixtures/Rules/KeepInterfacesShortRule/ExactInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\KeepInterfacesShortRule;
+
+interface ExactInterface
+{
+    public function one(): void;
+
+    public function two(): void;
+
+    public function three(): void;
+}

--- a/tests/Fixtures/Rules/KeepInterfacesShortRule/LongDefaultInterface.php
+++ b/tests/Fixtures/Rules/KeepInterfacesShortRule/LongDefaultInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\KeepInterfacesShortRule;
+
+interface LongDefaultInterface
+{
+    public function one(): void;
+
+    public function two(): void;
+
+    public function three(): void;
+
+    public function four(): void;
+
+    public function five(): void;
+
+    public function six(): void;
+
+    public function seven(): void;
+
+    public function eight(): void;
+
+    public function nine(): void;
+
+    public function ten(): void;
+
+    public function eleven(): void;
+}

--- a/tests/Fixtures/Rules/KeepInterfacesShortRule/LongInterface.php
+++ b/tests/Fixtures/Rules/KeepInterfacesShortRule/LongInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\KeepInterfacesShortRule;
+
+interface LongInterface
+{
+    public function one(): void;
+
+    public function two(): void;
+
+    public function three(): void;
+
+    public function four(): void;
+}

--- a/tests/Fixtures/Rules/KeepInterfacesShortRule/ShortInterface.php
+++ b/tests/Fixtures/Rules/KeepInterfacesShortRule/ShortInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\KeepInterfacesShortRule;
+
+interface ShortInterface
+{
+    public function one(): void;
+
+    public function two(): void;
+}

--- a/tests/Fixtures/Rules/KeepInterfacesShortRule/SuppressedInterface.php
+++ b/tests/Fixtures/Rules/KeepInterfacesShortRule/SuppressedInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\KeepInterfacesShortRule;
+
+/** @phpstan-ignore haspadar.interfaceMethods */
+interface SuppressedInterface
+{
+    public function one(): void;
+
+    public function two(): void;
+
+    public function three(): void;
+
+    public function four(): void;
+}

--- a/tests/Unit/Rules/KeepInterfacesShortRule/KeepInterfacesShortRuleDefaultLimitTest.php
+++ b/tests/Unit/Rules/KeepInterfacesShortRule/KeepInterfacesShortRuleDefaultLimitTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\KeepInterfacesShortRule;
+
+use Haspadar\PHPStanRules\Rules\KeepInterfacesShortRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<KeepInterfacesShortRule> */
+final class KeepInterfacesShortRuleDefaultLimitTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new KeepInterfacesShortRule();
+    }
+
+    #[Test]
+    public function reportsErrorWhenInterfaceExceedsDefaultLimit(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/KeepInterfacesShortRule/LongDefaultInterface.php'],
+            [
+                ['Interface LongDefaultInterface has 11 methods. Maximum allowed is 10.', 7],
+            ],
+        );
+    }
+
+    #[Test]
+    public function passesWhenInterfaceIsExactlyAtDefaultLimit(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/KeepInterfacesShortRule/ExactDefaultInterface.php'],
+            [],
+        );
+    }
+}

--- a/tests/Unit/Rules/KeepInterfacesShortRule/KeepInterfacesShortRuleTest.php
+++ b/tests/Unit/Rules/KeepInterfacesShortRule/KeepInterfacesShortRuleTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\KeepInterfacesShortRule;
+
+use Haspadar\PHPStanRules\Rules\KeepInterfacesShortRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<KeepInterfacesShortRule> */
+final class KeepInterfacesShortRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new KeepInterfacesShortRule(3);
+    }
+
+    #[Test]
+    public function passesWhenInterfaceFitsWithinLimit(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/KeepInterfacesShortRule/ShortInterface.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function reportsErrorWhenInterfaceExceedsLimit(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/KeepInterfacesShortRule/LongInterface.php'],
+            [
+                ['Interface LongInterface has 4 methods. Maximum allowed is 3.', 7],
+            ],
+        );
+    }
+
+    #[Test]
+    public function passesWhenInterfaceIsExactlyAtLimit(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/KeepInterfacesShortRule/ExactInterface.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function suppressesErrorWhenPhpstanIgnorePresent(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/KeepInterfacesShortRule/SuppressedInterface.php'],
+            [],
+        );
+    }
+}

--- a/tests/Unit/RulesTest.php
+++ b/tests/Unit/RulesTest.php
@@ -50,6 +50,7 @@ use Haspadar\PHPStanRules\Rules\StringLiteralsConcatenationRule;
 use Haspadar\PHPStanRules\Rules\TodoCommentRule;
 use Haspadar\PHPStanRules\Rules\ForbiddenClassSuffixRule;
 use Haspadar\PHPStanRules\Rules\BeImmutableRule;
+use Haspadar\PHPStanRules\Rules\KeepInterfacesShortRule;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -105,6 +106,7 @@ final class RulesTest extends TestCase
                 TodoCommentRule::class,
                 ForbiddenClassSuffixRule::class,
                 BeImmutableRule::class,
+                KeepInterfacesShortRule::class,
             ],
             (new Rules())->all(),
             'Rules::all() must list every registered rule class',


### PR DESCRIPTION
## Summary

- Add `KeepInterfacesShortRule` that limits the number of methods declared in an interface (default: 10)
- Enforces the Interface Segregation Principle: one interface = one narrow contract
- Configurable via `interfaceMethods.maxMethods` in `rules.neon`

Closes #114

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a design rule to limit methods on interfaces (default: 10) with configurable max.

* **Configuration**
  * New parameter to customize the maximum allowed methods per interface.

* **Documentation**
  * README updated to document the new rule and configuration example.

* **Tests**
  * Added unit tests and fixtures verifying rule behavior, limits, and suppression handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->