### PR TITLE
Prohibit Nullable Parameters in Methods and Functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 | `ConstructorInitializationRule`   | Constructor must only assign `$this->property` or call `parent::__construct()`     |
 | `BeImmutableRule`                | All non-static properties must be `readonly`                                       |
 | `KeepInterfacesShortRule`        | Interfaces must not declare too many methods (default: 10)                         |
-| `NeverAcceptNullArgumentsRule`   | Method and function parameters must not be nullable                                |
+| `NeverAcceptNullArgumentsRule`   | Method and standalone function parameters must not be nullable                     |
 
 ### Error-prone patterns
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@
 | `ConstructorInitializationRule`   | Constructor must only assign `$this->property` or call `parent::__construct()`     |
 | `BeImmutableRule`                | All non-static properties must be `readonly`                                       |
 | `KeepInterfacesShortRule`        | Interfaces must not declare too many methods (default: 10)                         |
+| `NeverAcceptNullArgumentsRule`   | Method and function parameters must not be nullable                                |
 
 ### Error-prone patterns
 

--- a/rules.neon
+++ b/rules.neon
@@ -484,3 +484,7 @@ services:
             maxMethods: %haspadar.interfaceMethods.maxMethods%
         tags:
             - phpstan.rules.rule
+    -
+        class: Haspadar\PHPStanRules\Rules\NeverAcceptNullArgumentsRule
+        tags:
+            - phpstan.rules.rule

--- a/src/Rules.php
+++ b/src/Rules.php
@@ -56,6 +56,7 @@ final class Rules
         Rules\ForbiddenClassSuffixRule::class,
         Rules\BeImmutableRule::class,
         Rules\KeepInterfacesShortRule::class,
+        Rules\NeverAcceptNullArgumentsRule::class,
     ];
 
     /**

--- a/src/Rules/ConstantUsage/ExemptScalarCollector.php
+++ b/src/Rules/ConstantUsage/ExemptScalarCollector.php
@@ -93,7 +93,7 @@ final class ExemptScalarCollector
     /**
      * Checks whether a node is a scalar literal (int, float, or string).
      */
-    private static function isScalarLiteral(?Node $node): bool
+    private static function isScalarLiteral(Node $node): bool
     {
         return $node instanceof Scalar\Int_
             || $node instanceof Scalar\Float_

--- a/src/Rules/NeverAcceptNullArgumentsRule.php
+++ b/src/Rules/NeverAcceptNullArgumentsRule.php
@@ -20,7 +20,6 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
-use PHPStan\ShouldNotHappenException;
 
 /**
  * Reports nullable parameters in methods and standalone functions.
@@ -47,7 +46,6 @@ final readonly class NeverAcceptNullArgumentsRule implements Rule
      * Analyses the node and returns a list of errors.
      *
      * @param Stmt $node
-     * @throws ShouldNotHappenException
      * @return list<IdentifierRuleError>
      */
     #[Override]
@@ -101,14 +99,10 @@ final readonly class NeverAcceptNullArgumentsRule implements Rule
 
     /**
      * Extracts the parameter name as a string.
-     *
-     * @throws ShouldNotHappenException
      */
     private function parameterName(Param $param): string
     {
-        if (!$param->var instanceof Variable || !is_string($param->var->name)) {
-            throw new ShouldNotHappenException();
-        }
+        assert($param->var instanceof Variable && is_string($param->var->name));
 
         return $param->var->name;
     }
@@ -117,16 +111,12 @@ final readonly class NeverAcceptNullArgumentsRule implements Rule
      * Returns a human-readable label for the enclosing function or method.
      *
      * @param ClassMethod|Function_ $node
-     * @throws ShouldNotHappenException
      */
     private function functionLabel(FunctionLike $node, Scope $scope): string
     {
         if ($node instanceof ClassMethod) {
             $classReflection = $scope->getClassReflection();
-
-            if ($classReflection === null) {
-                throw new ShouldNotHappenException();
-            }
+            assert($classReflection !== null);
 
             return sprintf('method %s::%s()', $classReflection->getName(), $node->name->toString());
         }

--- a/src/Rules/NeverAcceptNullArgumentsRule.php
+++ b/src/Rules/NeverAcceptNullArgumentsRule.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Rules;
+
+use Override;
+use PhpParser\Node;
+use PhpParser\Node\Expr\ConstFetch;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\FunctionLike;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\NullableType;
+use PhpParser\Node\Param;
+use PhpParser\Node\Stmt;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Function_;
+use PhpParser\Node\UnionType;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\ShouldNotHappenException;
+
+/**
+ * Reports nullable parameters in methods and standalone functions.
+ *
+ * Detects three patterns:
+ * - `?Type` (NullableType)
+ * - `Type|null` (UnionType containing null)
+ * - `$param = null` (null default value)
+ *
+ * Closures and arrow functions are excluded because they commonly
+ * use nullable parameters for optional callbacks.
+ *
+ * @implements Rule<Stmt>
+ */
+final readonly class NeverAcceptNullArgumentsRule implements Rule
+{
+    #[Override]
+    public function getNodeType(): string
+    {
+        return Stmt::class;
+    }
+
+    /**
+     * Analyses the node and returns a list of errors.
+     *
+     * @param Stmt $node
+     * @throws ShouldNotHappenException
+     * @return list<IdentifierRuleError>
+     */
+    #[Override]
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!$node instanceof ClassMethod && !$node instanceof Function_) {
+            return [];
+        }
+
+        $errors = [];
+
+        foreach ($node->params as $param) {
+            if (!$this->isNullable($param)) {
+                continue;
+            }
+
+            $errors[] = RuleErrorBuilder::message(
+                sprintf(
+                    'Parameter $%s in %s must not be nullable.',
+                    $this->parameterName($param),
+                    $this->functionLabel($node, $scope),
+                ),
+            )
+                ->identifier('haspadar.noNullArguments')
+                ->line($param->getStartLine())
+                ->build();
+        }
+
+        return $errors;
+    }
+
+    /**
+     * Returns true when the parameter accepts null via type or default value.
+     */
+    private function isNullable(Param $param): bool
+    {
+        if ($param->type instanceof NullableType) {
+            return true;
+        }
+
+        if ($param->type instanceof UnionType) {
+            foreach ($param->type->types as $type) {
+                if ($type instanceof Identifier && $type->toLowerString() === 'null') {
+                    return true;
+                }
+            }
+        }
+
+        return $param->default instanceof ConstFetch && $param->default->name->toLowerString() === 'null';
+    }
+
+    /**
+     * Extracts the parameter name as a string.
+     *
+     * @throws ShouldNotHappenException
+     */
+    private function parameterName(Param $param): string
+    {
+        if (!$param->var instanceof Variable || !is_string($param->var->name)) {
+            throw new ShouldNotHappenException();
+        }
+
+        return $param->var->name;
+    }
+
+    /**
+     * Returns a human-readable label for the enclosing function or method.
+     *
+     * @param ClassMethod|Function_ $node
+     * @throws ShouldNotHappenException
+     */
+    private function functionLabel(FunctionLike $node, Scope $scope): string
+    {
+        if ($node instanceof ClassMethod) {
+            $classReflection = $scope->getClassReflection();
+
+            if ($classReflection === null) {
+                throw new ShouldNotHappenException();
+            }
+
+            return sprintf('method %s::%s()', $classReflection->getName(), $node->name->toString());
+        }
+
+        return sprintf('function %s()', $node->namespacedName ?? $node->name->toString());
+    }
+}

--- a/tests/Fixtures/Rules/NeverAcceptNullArgumentsRule/ArrowFunctionWithNullableParam.php
+++ b/tests/Fixtures/Rules/NeverAcceptNullArgumentsRule/ArrowFunctionWithNullableParam.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NeverAcceptNullArgumentsRule;
+
+final class ArrowFunctionWithNullableParam
+{
+    public function run(): string
+    {
+        $fn = static fn(?string $name): string => $name ?? 'world';
+
+        return $fn('hello');
+    }
+}

--- a/tests/Fixtures/Rules/NeverAcceptNullArgumentsRule/ClosureWithNullableParam.php
+++ b/tests/Fixtures/Rules/NeverAcceptNullArgumentsRule/ClosureWithNullableParam.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NeverAcceptNullArgumentsRule;
+
+final class ClosureWithNullableParam
+{
+    public function run(): string
+    {
+        $fn = static function (?string $name): string {
+            return $name ?? 'world';
+        };
+
+        return $fn('hello');
+    }
+}

--- a/tests/Fixtures/Rules/NeverAcceptNullArgumentsRule/FunctionWithNullableParam.php
+++ b/tests/Fixtures/Rules/NeverAcceptNullArgumentsRule/FunctionWithNullableParam.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NeverAcceptNullArgumentsRule;
+
+function greetNullable(?string $name): string
+{
+    return $name ?? 'world';
+}

--- a/tests/Fixtures/Rules/NeverAcceptNullArgumentsRule/MethodWithNullDefault.php
+++ b/tests/Fixtures/Rules/NeverAcceptNullArgumentsRule/MethodWithNullDefault.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NeverAcceptNullArgumentsRule;
+
+final class MethodWithNullDefault
+{
+    public function greet(string $name = null): string
+    {
+        return $name ?? 'world';
+    }
+}

--- a/tests/Fixtures/Rules/NeverAcceptNullArgumentsRule/MethodWithNullableParam.php
+++ b/tests/Fixtures/Rules/NeverAcceptNullArgumentsRule/MethodWithNullableParam.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NeverAcceptNullArgumentsRule;
+
+final class MethodWithNullableParam
+{
+    public function greet(?string $name): string
+    {
+        return $name ?? 'world';
+    }
+}

--- a/tests/Fixtures/Rules/NeverAcceptNullArgumentsRule/MethodWithUnionNull.php
+++ b/tests/Fixtures/Rules/NeverAcceptNullArgumentsRule/MethodWithUnionNull.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NeverAcceptNullArgumentsRule;
+
+final class MethodWithUnionNull
+{
+    public function greet(string|null $name): string
+    {
+        return $name ?? 'world';
+    }
+}

--- a/tests/Fixtures/Rules/NeverAcceptNullArgumentsRule/MethodWithoutNullableParam.php
+++ b/tests/Fixtures/Rules/NeverAcceptNullArgumentsRule/MethodWithoutNullableParam.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NeverAcceptNullArgumentsRule;
+
+final class MethodWithoutNullableParam
+{
+    public function greet(string $name): string
+    {
+        return $name;
+    }
+}

--- a/tests/Fixtures/Rules/NeverAcceptNullArgumentsRule/SuppressedNullableParam.php
+++ b/tests/Fixtures/Rules/NeverAcceptNullArgumentsRule/SuppressedNullableParam.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NeverAcceptNullArgumentsRule;
+
+final class SuppressedNullableParam
+{
+    /** @phpstan-ignore haspadar.noNullArguments */
+    public function greet(?string $name): string
+    {
+        return $name ?? 'world';
+    }
+}

--- a/tests/Unit/Rules/NeverAcceptNullArgumentsRule/NeverAcceptNullArgumentsRuleTest.php
+++ b/tests/Unit/Rules/NeverAcceptNullArgumentsRule/NeverAcceptNullArgumentsRuleTest.php
@@ -80,6 +80,15 @@ final class NeverAcceptNullArgumentsRuleTest extends RuleTestCase
     }
 
     #[Test]
+    public function passesForArrowFunctionWithNullableParam(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NeverAcceptNullArgumentsRule/ArrowFunctionWithNullableParam.php'],
+            [],
+        );
+    }
+
+    #[Test]
     public function suppressesErrorWhenPhpstanIgnorePresent(): void
     {
         $this->analyse(

--- a/tests/Unit/Rules/NeverAcceptNullArgumentsRule/NeverAcceptNullArgumentsRuleTest.php
+++ b/tests/Unit/Rules/NeverAcceptNullArgumentsRule/NeverAcceptNullArgumentsRuleTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\NeverAcceptNullArgumentsRule;
+
+use Haspadar\PHPStanRules\Rules\NeverAcceptNullArgumentsRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<NeverAcceptNullArgumentsRule> */
+final class NeverAcceptNullArgumentsRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new NeverAcceptNullArgumentsRule();
+    }
+
+    #[Test]
+    public function passesWhenParameterIsNotNullable(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NeverAcceptNullArgumentsRule/MethodWithoutNullableParam.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function reportsErrorForNullableTypeParam(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NeverAcceptNullArgumentsRule/MethodWithNullableParam.php'],
+            [
+                ['Parameter $name in method Haspadar\PHPStanRules\Tests\Fixtures\Rules\NeverAcceptNullArgumentsRule\MethodWithNullableParam::greet() must not be nullable.', 9],
+            ],
+        );
+    }
+
+    #[Test]
+    public function reportsErrorForUnionNullParam(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NeverAcceptNullArgumentsRule/MethodWithUnionNull.php'],
+            [
+                ['Parameter $name in method Haspadar\PHPStanRules\Tests\Fixtures\Rules\NeverAcceptNullArgumentsRule\MethodWithUnionNull::greet() must not be nullable.', 9],
+            ],
+        );
+    }
+
+    #[Test]
+    public function reportsErrorForNullDefaultParam(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NeverAcceptNullArgumentsRule/MethodWithNullDefault.php'],
+            [
+                ['Parameter $name in method Haspadar\PHPStanRules\Tests\Fixtures\Rules\NeverAcceptNullArgumentsRule\MethodWithNullDefault::greet() must not be nullable.', 9],
+            ],
+        );
+    }
+
+    #[Test]
+    public function reportsErrorForNullableFunctionParam(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NeverAcceptNullArgumentsRule/FunctionWithNullableParam.php'],
+            [
+                ['Parameter $name in function Haspadar\PHPStanRules\Tests\Fixtures\Rules\NeverAcceptNullArgumentsRule\greetNullable() must not be nullable.', 7],
+            ],
+        );
+    }
+
+    #[Test]
+    public function passesForClosureWithNullableParam(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NeverAcceptNullArgumentsRule/ClosureWithNullableParam.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function suppressesErrorWhenPhpstanIgnorePresent(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NeverAcceptNullArgumentsRule/SuppressedNullableParam.php'],
+            [],
+        );
+    }
+}

--- a/tests/Unit/RulesTest.php
+++ b/tests/Unit/RulesTest.php
@@ -51,6 +51,7 @@ use Haspadar\PHPStanRules\Rules\TodoCommentRule;
 use Haspadar\PHPStanRules\Rules\ForbiddenClassSuffixRule;
 use Haspadar\PHPStanRules\Rules\BeImmutableRule;
 use Haspadar\PHPStanRules\Rules\KeepInterfacesShortRule;
+use Haspadar\PHPStanRules\Rules\NeverAcceptNullArgumentsRule;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -107,6 +108,7 @@ final class RulesTest extends TestCase
                 ForbiddenClassSuffixRule::class,
                 BeImmutableRule::class,
                 KeepInterfacesShortRule::class,
+                NeverAcceptNullArgumentsRule::class,
             ],
             (new Rules())->all(),
             'Rules::all() must list every registered rule class',


### PR DESCRIPTION
- Added NeverAcceptNullArgumentsRule to report ?Type, Type|null, and = null parameters
- Added tests and fixtures covering nullable type, union null, null default, closures, and suppression
- Updated README with the new rule in the Design section
- Removed unnecessary nullable from ExemptScalarCollector parameter

Closes #116

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new code analysis rule that enforces function and method parameters must not be nullable. The rule detects nullable types, union types containing null, and null default values. Violations can be suppressed using PHPStan ignore annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->