### PR TITLE
Prohibit Nullable Return Types and Null Returns

### DIFF
--- a/.piqule/.gitignore
+++ b/.piqule/.gitignore
@@ -1,5 +1,6 @@
 php-cs-fixer/.php-cs-fixer.cache
 codecov/coverage-report/
+codecov/coverage.xml
 infection/*.log
 ast-metrics/reports/
 phpmetrics/phpmetrics.json

--- a/.piqule/_docker.sh
+++ b/.piqule/_docker.sh
@@ -8,7 +8,7 @@ fi
 
 PROJECT_ROOT="$(pwd)"
 
-IMAGE="${PIQULE_INFRA_IMAGE:-ghcr.io/haspadar/piqule-infra@sha256:e88f74183c5daf1c422006307b04222db8cd524f250330e83aa667c5ce919c23}"
+IMAGE="${PIQULE_INFRA_IMAGE:-ghcr.io/haspadar/piqule-infra@sha256:c8bba3dd36290d89d3c8f7cfad24071b3435fa447050ff70251bf053cea6a28c}"
 
 docker run --rm \
   --user "$(id -u):$(id -g)" \

--- a/.piqule/config.yaml
+++ b/.piqule/config.yaml
@@ -32,7 +32,7 @@ defaults:
   coderabbit.cloud: true
   coderabbit.cli: false
 
-  docker.image: "ghcr.io/haspadar/piqule-infra@sha256:e88f74183c5daf1c422006307b04222db8cd524f250330e83aa667c5ce919c23"
+  docker.image: "ghcr.io/haspadar/piqule-infra@sha256:c8bba3dd36290d89d3c8f7cfad24071b3435fa447050ff70251bf053cea6a28c"
 
   actionlint.cli: true
 
@@ -116,6 +116,8 @@ defaults:
   psalm.suppress.possibly_unused: []
 
   infection.cli: true
+  infection.min_msi: 50
+  infection.min_covered_msi: 80
   infection.php_options: "-d memory_limit=1G"
   infection.source.directories: ["../../src"]
   infection.timeout: 30

--- a/.piqule/infection/infection.json5
+++ b/.piqule/infection/infection.json5
@@ -15,6 +15,8 @@
 
   "initialTestsPhpOptions": "-d memory_limit=1G",
   "timeout": 30,
+  "minMsi": 50,
+  "minCoveredMsi": 80,
   "logs": {
     "text": "infection.log",
     "summary": "infection-summary.log",

--- a/.piqule/psalm/psalm.xml
+++ b/.piqule/psalm/psalm.xml
@@ -28,6 +28,5 @@
                 <directory name="../../src" />
             </errorLevel>
         </PossiblyUnusedMethod>
-
     </issueHandlers>
 </psalm>

--- a/.piqule/sonar/command.sh
+++ b/.piqule/sonar/command.sh
@@ -37,7 +37,7 @@ else
 fi
 
 PROJECT_ROOT="$(pwd)"
-IMAGE="${PIQULE_INFRA_IMAGE:-ghcr.io/haspadar/piqule-infra@sha256:e88f74183c5daf1c422006307b04222db8cd524f250330e83aa667c5ce919c23}"
+IMAGE="${PIQULE_INFRA_IMAGE:-ghcr.io/haspadar/piqule-infra@sha256:c8bba3dd36290d89d3c8f7cfad24071b3435fa447050ff70251bf053cea6a28c}"
 
 docker run --rm \
   --user "$(id -u):$(id -g)" \

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@
 | `BeImmutableRule`                | All non-static properties must be `readonly`                                       |
 | `KeepInterfacesShortRule`        | Interfaces must not declare too many methods (default: 10)                         |
 | `NeverAcceptNullArgumentsRule`   | Method and standalone function parameters must not be nullable                     |
+| `NeverReturnNullRule`            | Method and standalone function return types must not be nullable, `return null` is forbidden |
 
 ### Error-prone patterns
 

--- a/composer.lock
+++ b/composer.lock
@@ -8,11 +8,11 @@
     "packages": [
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.46",
+            "version": "2.1.47",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/a193923fc2d6325ef4e741cf3af8c3e8f54dbf25",
-                "reference": "a193923fc2d6325ef4e741cf3af8c3e8f54dbf25",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/79015445d8bd79e62b29140f12e5bfced1dcca65",
+                "reference": "79015445d8bd79e62b29140f12e5bfced1dcca65",
                 "shasum": ""
             },
             "require": {
@@ -57,7 +57,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-04-01T09:25:14+00:00"
+            "time": "2026-04-13T15:49:08+00:00"
         }
     ],
     "packages-dev": [
@@ -1530,6 +1530,75 @@
             "time": "2026-02-07T07:09:04+00:00"
         },
         {
+            "name": "ergebnis/agent-detector",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ergebnis/agent-detector.git",
+                "reference": "5b654a9f1ff8a5d2ce6a57568df5ae8801c87f64"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ergebnis/agent-detector/zipball/5b654a9f1ff8a5d2ce6a57568df5ae8801c87f64",
+                "reference": "5b654a9f1ff8a5d2ce6a57568df5ae8801c87f64",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0 || ~8.6.0"
+            },
+            "require-dev": {
+                "ergebnis/composer-normalize": "^2.50.0",
+                "ergebnis/license": "^2.7.0",
+                "ergebnis/php-cs-fixer-config": "^6.60.2",
+                "ergebnis/phpstan-rules": "^2.13.1",
+                "ergebnis/phpunit-slow-test-detector": "^2.24.0",
+                "ergebnis/rector-rules": "^1.16.0",
+                "fakerphp/faker": "^1.24.1",
+                "infection/infection": "^0.26.6",
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^2.1.46",
+                "phpstan/phpstan-deprecation-rules": "^2.0.4",
+                "phpstan/phpstan-phpunit": "^2.0.16",
+                "phpstan/phpstan-strict-rules": "^2.0.10",
+                "phpunit/phpunit": "^9.6.34",
+                "rector/rector": "^2.4.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.0-dev"
+                },
+                "composer-normalize": {
+                    "indent-size": 2,
+                    "indent-style": "space"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Ergebnis\\AgentDetector\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Andreas Möller",
+                    "email": "am@localheinz.com",
+                    "homepage": "https://localheinz.com"
+                }
+            ],
+            "description": "Provides a detector for detecting the presence of an agent.",
+            "homepage": "https://github.com/ergebnis/agent-detector",
+            "support": {
+                "issues": "https://github.com/ergebnis/agent-detector/issues",
+                "security": "https://github.com/ergebnis/agent-detector/blob/main/.github/SECURITY.md",
+                "source": "https://github.com/ergebnis/agent-detector"
+            },
+            "time": "2026-04-10T13:45:13+00:00"
+        },
+        {
             "name": "evenement/evenement",
             "version": "v3.0.2",
             "source": {
@@ -1695,22 +1764,23 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.94.2",
+            "version": "v3.95.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
-                "reference": "7787ceff91365ba7d623ec410b8f429cdebb4f63"
+                "reference": "a9727678fbd12997f1d9de8f4a37824ed9df1065"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/7787ceff91365ba7d623ec410b8f429cdebb4f63",
-                "reference": "7787ceff91365ba7d623ec410b8f429cdebb4f63",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/a9727678fbd12997f1d9de8f4a37824ed9df1065",
+                "reference": "a9727678fbd12997f1d9de8f4a37824ed9df1065",
                 "shasum": ""
             },
             "require": {
                 "clue/ndjson-react": "^1.3",
                 "composer/semver": "^3.4",
                 "composer/xdebug-handler": "^3.0.5",
+                "ergebnis/agent-detector": "^1.1.1",
                 "ext-filter": "*",
                 "ext-hash": "*",
                 "ext-json": "*",
@@ -1735,18 +1805,18 @@
                 "symfony/stopwatch": "^5.4.45 || ^6.4.24 || ^7.0 || ^8.0"
             },
             "require-dev": {
-                "facile-it/paraunit": "^1.3.1 || ^2.7.1",
-                "infection/infection": "^0.32.3",
-                "justinrainbow/json-schema": "^6.6.4",
+                "facile-it/paraunit": "^1.3.1 || ^2.8.0",
+                "infection/infection": "^0.32.6",
+                "justinrainbow/json-schema": "^6.8.0",
                 "keradus/cli-executor": "^2.3",
                 "mikey179/vfsstream": "^1.6.12",
                 "php-coveralls/php-coveralls": "^2.9.1",
-                "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.7",
-                "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.7",
-                "phpunit/phpunit": "^9.6.34 || ^10.5.63 || ^11.5.51",
+                "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.8",
+                "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.8",
+                "phpunit/phpunit": "^9.6.34 || ^10.5.63 || ^11.5.55",
                 "symfony/polyfill-php85": "^1.33",
-                "symfony/var-dumper": "^5.4.48 || ^6.4.32 || ^7.4.4 || ^8.0.4",
-                "symfony/yaml": "^5.4.45 || ^6.4.30 || ^7.4.1 || ^8.0.1"
+                "symfony/var-dumper": "^5.4.48 || ^6.4.32 || ^7.4.4 || ^8.0.8",
+                "symfony/yaml": "^5.4.45 || ^6.4.30 || ^7.4.1 || ^8.0.8"
             },
             "suggest": {
                 "ext-dom": "For handling output formats in XML",
@@ -1787,7 +1857,7 @@
             ],
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
-                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.94.2"
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.95.1"
             },
             "funding": [
                 {
@@ -1795,7 +1865,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-02-20T16:13:53+00:00"
+            "time": "2026-04-12T17:00:09+00:00"
         },
         {
             "name": "haspadar/piqule",
@@ -1803,32 +1873,30 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/haspadar/piqule.git",
-                "reference": "a36039c9efd52525fdf88e0ecda812aa5ac81f5a"
+                "reference": "c29f98262a5ff88f69035ff7e6c897be22a5c824"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/haspadar/piqule/zipball/a36039c9efd52525fdf88e0ecda812aa5ac81f5a",
-                "reference": "a36039c9efd52525fdf88e0ecda812aa5ac81f5a",
+                "url": "https://api.github.com/repos/haspadar/piqule/zipball/c29f98262a5ff88f69035ff7e6c897be22a5c824",
+                "reference": "c29f98262a5ff88f69035ff7e6c897be22a5c824",
                 "shasum": ""
             },
             "require": {
                 "friendsofphp/php-cs-fixer": "^3.91",
-                "haspadar/phpstan-rules": "^0.30.1",
+                "haspadar/phpstan-rules": ">=0.30.1 <1.0.0",
                 "infection/infection": "^0.32.0",
+                "kubawerlos/php-cs-fixer-custom-fixers": "^3.36",
                 "php": "~8.3.16 || ~8.4.3 || ~8.5.0",
                 "phpmd/phpmd": "^2.15",
                 "phpmetrics/phpmetrics": "^2.9",
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-strict-rules": "^2.0",
                 "phpunit/phpunit": "^12.0",
+                "slevomat/coding-standard": "^8.28",
                 "squizlabs/php_codesniffer": "^4.0",
                 "symfony/process": "^7.0",
                 "symfony/yaml": "^7.4",
                 "vimeo/psalm": "^6.14"
-            },
-            "require-dev": {
-                "kubawerlos/php-cs-fixer-custom-fixers": "^3.36",
-                "slevomat/coding-standard": "^8.28"
             },
             "suggest": {
                 "ext-xdebug": "Required to generate coverage reports and run Infection"
@@ -1858,7 +1926,7 @@
                 "issues": "https://github.com/haspadar/piqule/issues",
                 "source": "https://github.com/haspadar/piqule/tree/main"
             },
-            "time": "2026-04-09T09:04:53+00:00"
+            "time": "2026-04-15T12:06:33+00:00"
         },
         {
             "name": "infection/abstract-testframework-adapter",
@@ -3523,16 +3591,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "12.5.3",
+            "version": "12.5.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "b015312f28dd75b75d3422ca37dff2cd1a565e8d"
+                "reference": "876099a072646c7745f673d7aeab5382c4439691"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/b015312f28dd75b75d3422ca37dff2cd1a565e8d",
-                "reference": "b015312f28dd75b75d3422ca37dff2cd1a565e8d",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/876099a072646c7745f673d7aeab5382c4439691",
+                "reference": "876099a072646c7745f673d7aeab5382c4439691",
                 "shasum": ""
             },
             "require": {
@@ -3541,7 +3609,6 @@
                 "ext-xmlwriter": "*",
                 "nikic/php-parser": "^5.7.0",
                 "php": ">=8.3",
-                "phpunit/php-file-iterator": "^6.0",
                 "phpunit/php-text-template": "^5.0",
                 "sebastian/complexity": "^5.0",
                 "sebastian/environment": "^8.0.3",
@@ -3588,7 +3655,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/12.5.3"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/12.5.6"
             },
             "funding": [
                 {
@@ -3608,7 +3675,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-06T06:01:44+00:00"
+            "time": "2026-04-15T08:23:17+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -3869,16 +3936,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "12.5.17",
+            "version": "12.5.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "85b62adab1a340982df64e66daa4a4435eb5723b"
+                "reference": "c2364520611caa03567a8a020f2d59f3f90b115a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/85b62adab1a340982df64e66daa4a4435eb5723b",
-                "reference": "85b62adab1a340982df64e66daa4a4435eb5723b",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c2364520611caa03567a8a020f2d59f3f90b115a",
+                "reference": "c2364520611caa03567a8a020f2d59f3f90b115a",
                 "shasum": ""
             },
             "require": {
@@ -3892,13 +3959,13 @@
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
                 "php": ">=8.3",
-                "phpunit/php-code-coverage": "^12.5.3",
+                "phpunit/php-code-coverage": "^12.5.5",
                 "phpunit/php-file-iterator": "^6.0.1",
                 "phpunit/php-invoker": "^6.0.0",
                 "phpunit/php-text-template": "^5.0.0",
                 "phpunit/php-timer": "^8.0.0",
                 "sebastian/cli-parser": "^4.2.0",
-                "sebastian/comparator": "^7.1.4",
+                "sebastian/comparator": "^7.1.6",
                 "sebastian/diff": "^7.0.0",
                 "sebastian/environment": "^8.0.4",
                 "sebastian/exporter": "^7.0.2",
@@ -3947,7 +4014,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.5.17"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.5.20"
             },
             "funding": [
                 {
@@ -3955,7 +4022,7 @@
                     "type": "other"
                 }
             ],
-            "time": "2026-04-08T03:04:19+00:00"
+            "time": "2026-04-15T05:05:59+00:00"
         },
         {
             "name": "psr/clock",
@@ -5209,16 +5276,16 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "7.1.5",
+            "version": "7.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "c284f55811f43d555e51e8e5c166ac40d3e33c63"
+                "reference": "c769009dee98f494e0edc3fd4f4087501688f11e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/c284f55811f43d555e51e8e5c166ac40d3e33c63",
-                "reference": "c284f55811f43d555e51e8e5c166ac40d3e33c63",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/c769009dee98f494e0edc3fd4f4087501688f11e",
+                "reference": "c769009dee98f494e0edc3fd4f4087501688f11e",
                 "shasum": ""
             },
             "require": {
@@ -5277,7 +5344,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
                 "security": "https://github.com/sebastianbergmann/comparator/security/policy",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/7.1.5"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/7.1.6"
             },
             "funding": [
                 {
@@ -5297,7 +5364,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-08T04:43:00+00:00"
+            "time": "2026-04-14T08:23:15+00:00"
         },
         {
             "name": "sebastian/complexity",
@@ -6999,16 +7066,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.33.0",
+            "version": "v1.35.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638"
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/a3cc8b044a6ea513310cbd48ef7333b384945638",
-                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/141046a8f9477948ff284fa65be2095baafb94f2",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2",
                 "shasum": ""
             },
             "require": {
@@ -7058,7 +7125,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.35.0"
             },
             "funding": [
                 {
@@ -7078,20 +7145,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.33.0",
+            "version": "v1.35.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "380872130d3a5dd3ace2f4010d95125fde5d5c70"
+                "reference": "ad1b7b9092976d6c948b8a187cec9faaea9ec1df"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/380872130d3a5dd3ace2f4010d95125fde5d5c70",
-                "reference": "380872130d3a5dd3ace2f4010d95125fde5d5c70",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/ad1b7b9092976d6c948b8a187cec9faaea9ec1df",
+                "reference": "ad1b7b9092976d6c948b8a187cec9faaea9ec1df",
                 "shasum": ""
             },
             "require": {
@@ -7140,7 +7207,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.35.0"
             },
             "funding": [
                 {
@@ -7160,11 +7227,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-27T09:58:17+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.33.0",
+            "version": "v1.35.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
@@ -7225,7 +7292,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.35.0"
             },
             "funding": [
                 {
@@ -7249,16 +7316,16 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.33.0",
+            "version": "v1.35.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493"
+                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6d857f4d76bd4b343eac26d6b539585d2bc56493",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6a21eb99c6973357967f6ce3708cd55a6bec6315",
+                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315",
                 "shasum": ""
             },
             "require": {
@@ -7310,7 +7377,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.35.0"
             },
             "funding": [
                 {
@@ -7330,20 +7397,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-23T08:48:59+00:00"
+            "time": "2026-04-10T17:25:58+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.33.0",
+            "version": "v1.35.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608"
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
-                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
                 "shasum": ""
             },
             "require": {
@@ -7394,7 +7461,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.35.0"
             },
             "funding": [
                 {
@@ -7414,11 +7481,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-01-02T08:10:11+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/polyfill-php81",
-            "version": "v1.33.0",
+            "version": "v1.35.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php81.git",
@@ -7474,7 +7541,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php81/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-php81/tree/v1.35.0"
             },
             "funding": [
                 {
@@ -7498,16 +7565,16 @@
         },
         {
             "name": "symfony/polyfill-php84",
-            "version": "v1.33.0",
+            "version": "v1.35.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php84.git",
-                "reference": "d8ced4d875142b6a7426000426b8abc631d6b191"
+                "reference": "88486db2c389b290bf87ff1de7ebc1e13e42bb06"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/d8ced4d875142b6a7426000426b8abc631d6b191",
-                "reference": "d8ced4d875142b6a7426000426b8abc631d6b191",
+                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/88486db2c389b290bf87ff1de7ebc1e13e42bb06",
+                "reference": "88486db2c389b290bf87ff1de7ebc1e13e42bb06",
                 "shasum": ""
             },
             "require": {
@@ -7554,7 +7621,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php84/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-php84/tree/v1.35.0"
             },
             "funding": [
                 {
@@ -7574,20 +7641,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-24T13:30:11+00:00"
+            "time": "2026-04-10T18:47:49+00:00"
         },
         {
             "name": "symfony/polyfill-php85",
-            "version": "v1.33.0",
+            "version": "v1.35.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php85.git",
-                "reference": "d4e5fcd4ab3d998ab16c0db48e6cbb9a01993f91"
+                "reference": "2c408a6bb0313e6001a83628dc5506100474254e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php85/zipball/d4e5fcd4ab3d998ab16c0db48e6cbb9a01993f91",
-                "reference": "d4e5fcd4ab3d998ab16c0db48e6cbb9a01993f91",
+                "url": "https://api.github.com/repos/symfony/polyfill-php85/zipball/2c408a6bb0313e6001a83628dc5506100474254e",
+                "reference": "2c408a6bb0313e6001a83628dc5506100474254e",
                 "shasum": ""
             },
             "require": {
@@ -7634,7 +7701,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php85/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-php85/tree/v1.35.0"
             },
             "funding": [
                 {
@@ -7654,7 +7721,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-23T16:12:55+00:00"
+            "time": "2026-04-10T16:50:15+00:00"
         },
         {
             "name": "symfony/process",
@@ -8435,16 +8502,16 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "2.1.6",
+            "version": "2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozarts/assert.git",
-                "reference": "ff31ad6efc62e66e518fbab1cde3453d389bcdc8"
+                "reference": "eb0d790f735ba6cff25c683a85a1da0eadeff9e4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/ff31ad6efc62e66e518fbab1cde3453d389bcdc8",
-                "reference": "ff31ad6efc62e66e518fbab1cde3453d389bcdc8",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/eb0d790f735ba6cff25c683a85a1da0eadeff9e4",
+                "reference": "eb0d790f735ba6cff25c683a85a1da0eadeff9e4",
                 "shasum": ""
             },
             "require": {
@@ -8491,9 +8558,9 @@
             ],
             "support": {
                 "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/2.1.6"
+                "source": "https://github.com/webmozarts/assert/tree/2.3.0"
             },
-            "time": "2026-02-27T10:28:38+00:00"
+            "time": "2026-04-11T10:33:05+00:00"
         }
     ],
     "aliases": [],

--- a/rules-ignore.neon
+++ b/rules-ignore.neon
@@ -14,3 +14,5 @@ parameters:
             identifier: haspadar.cyclomaticComplexity
         -
             identifier: haspadar.parameterName
+        -
+            identifier: haspadar.noNullReturn

--- a/rules.neon
+++ b/rules.neon
@@ -488,3 +488,7 @@ services:
         class: Haspadar\PHPStanRules\Rules\NeverAcceptNullArgumentsRule
         tags:
             - phpstan.rules.rule
+    -
+        class: Haspadar\PHPStanRules\Rules\NeverReturnNullRule
+        tags:
+            - phpstan.rules.rule

--- a/src/Rules.php
+++ b/src/Rules.php
@@ -57,6 +57,7 @@ final class Rules
         Rules\BeImmutableRule::class,
         Rules\KeepInterfacesShortRule::class,
         Rules\NeverAcceptNullArgumentsRule::class,
+        Rules\NeverReturnNullRule::class,
     ];
 
     /**

--- a/src/Rules/NeverReturnNullRule.php
+++ b/src/Rules/NeverReturnNullRule.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Rules;
+
+use Override;
+use PhpParser\Node;
+use PhpParser\Node\Expr\ArrowFunction;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Expr\ConstFetch;
+use PhpParser\Node\FunctionLike;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\NullableType;
+use PhpParser\Node\Stmt;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Function_;
+use PhpParser\Node\Stmt\Return_;
+use PhpParser\Node\UnionType;
+use PhpParser\NodeFinder;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * Reports nullable return types and explicit `return null` in methods and standalone functions.
+ *
+ * Detects three patterns:
+ * - `?Type` (NullableType)
+ * - `Type|null` (UnionType containing null)
+ * - `return null;` (explicit null return statement)
+ *
+ * Closures and arrow functions are excluded because they commonly
+ * use nullable returns for optional callbacks.
+ *
+ * @implements Rule<Stmt>
+ */
+final readonly class NeverReturnNullRule implements Rule
+{
+    #[Override]
+    public function getNodeType(): string
+    {
+        return Stmt::class;
+    }
+
+    /**
+     * Analyses the node and returns a list of errors.
+     *
+     * @param Stmt $node
+     * @return list<IdentifierRuleError>
+     */
+    #[Override]
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!$node instanceof ClassMethod && !$node instanceof Function_) {
+            return [];
+        }
+
+        $errors = [];
+        $label = $this->functionLabel($node, $scope);
+
+        if ($this->hasNullableReturnType($node)) {
+            $errors[] = RuleErrorBuilder::message(
+                sprintf('%s must not have a nullable return type.', $label),
+            )
+                ->identifier('haspadar.noNullReturn')
+                ->line($node->getStartLine())
+                ->build();
+        }
+
+        foreach ($this->findReturnNullStatements($node) as $return) {
+            $errors[] = RuleErrorBuilder::message(
+                sprintf('%s must not return null.', $label),
+            )
+                ->identifier('haspadar.noNullReturn')
+                ->line($return->getStartLine())
+                ->build();
+        }
+
+        return $errors;
+    }
+
+    /**
+     * Returns true when the function declares a nullable return type.
+     */
+    private function hasNullableReturnType(FunctionLike $node): bool
+    {
+        if ($node->getReturnType() instanceof NullableType) {
+            return true;
+        }
+
+        $returnType = $node->getReturnType();
+
+        if (!$returnType instanceof UnionType) {
+            return false;
+        }
+
+        foreach ($returnType->types as $type) {
+            if ($type instanceof Identifier && $type->toLowerString() === 'null') {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Finds all `return null;` statements in the function body, excluding nested closures and arrow functions.
+     *
+     * @return list<Return_>
+     */
+    private function findReturnNullStatements(FunctionLike $node): array
+    {
+        $stmts = $node->getStmts();
+
+        if ($stmts === null) {
+            return [];
+        }
+
+        $finder = new NodeFinder();
+        $results = [];
+
+        /** @var list<Return_> $returns */
+        $returns = $finder->find(
+            $stmts,
+            static fn(Node $n): bool => $n instanceof Return_
+                && $n->expr instanceof ConstFetch
+                && $n->expr->name->toLowerString() === 'null',
+        );
+
+        foreach ($returns as $return) {
+            if (!$this->isInsideNestedFunction($return, array_values($stmts))) {
+                $results[] = $return;
+            }
+        }
+
+        return $results;
+    }
+
+    /**
+     * Checks whether a node is inside a nested closure or arrow function.
+     *
+     * @param list<Stmt> $stmts
+     */
+    private function isInsideNestedFunction(Return_ $return, array $stmts): bool
+    {
+        $finder = new NodeFinder();
+
+        /** @var list<Closure|ArrowFunction> $nestedFunctions */
+        $nestedFunctions = $finder->find(
+            $stmts,
+            static fn(Node $n): bool => $n instanceof Closure || $n instanceof ArrowFunction,
+        );
+
+        $returnLine = $return->getStartLine();
+        $returnEndLine = $return->getEndLine();
+
+        foreach ($nestedFunctions as $nested) {
+            if ($returnLine >= $nested->getStartLine() && $returnEndLine <= $nested->getEndLine()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns a human-readable label for the enclosing function or method.
+     *
+     * @param ClassMethod|Function_ $node
+     */
+    private function functionLabel(FunctionLike $node, Scope $scope): string
+    {
+        if ($node instanceof ClassMethod) {
+            $classReflection = $scope->getClassReflection();
+            assert($classReflection !== null);
+
+            return sprintf('Method %s::%s()', $classReflection->getName(), $node->name->toString());
+        }
+
+        return sprintf('Function %s()', $node->namespacedName ?? $node->name->toString());
+    }
+}

--- a/tests/Fixtures/Rules/NeverReturnNullRule/AbstractMethodWithNullableReturn.php
+++ b/tests/Fixtures/Rules/NeverReturnNullRule/AbstractMethodWithNullableReturn.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NeverReturnNullRule;
+
+abstract class AbstractMethodWithNullableReturn
+{
+    abstract public function greet(): ?string;
+}

--- a/tests/Fixtures/Rules/NeverReturnNullRule/ArrowFunctionWithNullableReturn.php
+++ b/tests/Fixtures/Rules/NeverReturnNullRule/ArrowFunctionWithNullableReturn.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NeverReturnNullRule;
+
+final class ArrowFunctionWithNullableReturn
+{
+    public function run(): string
+    {
+        $fn = static fn(): ?string => null;
+
+        return $fn() ?? 'default';
+    }
+}

--- a/tests/Fixtures/Rules/NeverReturnNullRule/ClosureWithNullableReturn.php
+++ b/tests/Fixtures/Rules/NeverReturnNullRule/ClosureWithNullableReturn.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NeverReturnNullRule;
+
+final class ClosureWithNullableReturn
+{
+    public function run(): string
+    {
+        $fn = static function (): ?string {
+            return null;
+        };
+
+        return $fn() ?? 'default';
+    }
+}

--- a/tests/Fixtures/Rules/NeverReturnNullRule/FunctionWithNullableReturn.php
+++ b/tests/Fixtures/Rules/NeverReturnNullRule/FunctionWithNullableReturn.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NeverReturnNullRule;
+
+function findName(): ?string
+{
+    return 'hello';
+}

--- a/tests/Fixtures/Rules/NeverReturnNullRule/MethodWithNullableReturn.php
+++ b/tests/Fixtures/Rules/NeverReturnNullRule/MethodWithNullableReturn.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NeverReturnNullRule;
+
+final class MethodWithNullableReturn
+{
+    public function greet(): ?string
+    {
+        return 'hello';
+    }
+}

--- a/tests/Fixtures/Rules/NeverReturnNullRule/MethodWithReturnNull.php
+++ b/tests/Fixtures/Rules/NeverReturnNullRule/MethodWithReturnNull.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NeverReturnNullRule;
+
+final class MethodWithReturnNull
+{
+    /** @return mixed */
+    public function greet()
+    {
+        return null;
+    }
+}

--- a/tests/Fixtures/Rules/NeverReturnNullRule/MethodWithUnionNullReturn.php
+++ b/tests/Fixtures/Rules/NeverReturnNullRule/MethodWithUnionNullReturn.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NeverReturnNullRule;
+
+final class MethodWithUnionNullReturn
+{
+    public function greet(): string|null
+    {
+        return 'hello';
+    }
+}

--- a/tests/Fixtures/Rules/NeverReturnNullRule/MethodWithUnionWithoutNull.php
+++ b/tests/Fixtures/Rules/NeverReturnNullRule/MethodWithUnionWithoutNull.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NeverReturnNullRule;
+
+final class MethodWithUnionWithoutNull
+{
+    public function greet(): string|int
+    {
+        return 'hello';
+    }
+}

--- a/tests/Fixtures/Rules/NeverReturnNullRule/MethodWithoutNullableReturn.php
+++ b/tests/Fixtures/Rules/NeverReturnNullRule/MethodWithoutNullableReturn.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NeverReturnNullRule;
+
+final class MethodWithoutNullableReturn
+{
+    public function greet(): string
+    {
+        return 'hello';
+    }
+}

--- a/tests/Fixtures/Rules/NeverReturnNullRule/SuppressedNullableReturn.php
+++ b/tests/Fixtures/Rules/NeverReturnNullRule/SuppressedNullableReturn.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NeverReturnNullRule;
+
+final class SuppressedNullableReturn
+{
+    /** @phpstan-ignore haspadar.noNullReturn */
+    public function greet(): ?string
+    {
+        return null; // @phpstan-ignore haspadar.noNullReturn
+    }
+}

--- a/tests/Unit/Rules/NeverReturnNullRule/NeverReturnNullRuleTest.php
+++ b/tests/Unit/Rules/NeverReturnNullRule/NeverReturnNullRuleTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\NeverReturnNullRule;
+
+use Haspadar\PHPStanRules\Rules\NeverReturnNullRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<NeverReturnNullRule> */
+final class NeverReturnNullRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new NeverReturnNullRule();
+    }
+
+    #[Test]
+    public function passesWhenReturnTypeIsNotNullable(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NeverReturnNullRule/MethodWithoutNullableReturn.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function reportsErrorForNullableReturnType(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NeverReturnNullRule/MethodWithNullableReturn.php'],
+            [
+                ['Method Haspadar\PHPStanRules\Tests\Fixtures\Rules\NeverReturnNullRule\MethodWithNullableReturn::greet() must not have a nullable return type.', 9],
+            ],
+        );
+    }
+
+    #[Test]
+    public function reportsErrorForUnionNullReturnType(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NeverReturnNullRule/MethodWithUnionNullReturn.php'],
+            [
+                ['Method Haspadar\PHPStanRules\Tests\Fixtures\Rules\NeverReturnNullRule\MethodWithUnionNullReturn::greet() must not have a nullable return type.', 9],
+            ],
+        );
+    }
+
+    #[Test]
+    public function reportsErrorForReturnNullStatement(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NeverReturnNullRule/MethodWithReturnNull.php'],
+            [
+                ['Method Haspadar\PHPStanRules\Tests\Fixtures\Rules\NeverReturnNullRule\MethodWithReturnNull::greet() must not return null.', 12],
+            ],
+        );
+    }
+
+    #[Test]
+    public function reportsErrorForNullableFunctionReturn(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NeverReturnNullRule/FunctionWithNullableReturn.php'],
+            [
+                ['Function Haspadar\PHPStanRules\Tests\Fixtures\Rules\NeverReturnNullRule\findName() must not have a nullable return type.', 7],
+            ],
+        );
+    }
+
+    #[Test]
+    public function passesForClosureWithNullableReturn(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NeverReturnNullRule/ClosureWithNullableReturn.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function passesForArrowFunctionWithNullableReturn(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NeverReturnNullRule/ArrowFunctionWithNullableReturn.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function suppressesErrorWhenPhpstanIgnorePresent(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NeverReturnNullRule/SuppressedNullableReturn.php'],
+            [],
+        );
+    }
+}

--- a/tests/Unit/Rules/NeverReturnNullRule/NeverReturnNullRuleTest.php
+++ b/tests/Unit/Rules/NeverReturnNullRule/NeverReturnNullRuleTest.php
@@ -89,6 +89,26 @@ final class NeverReturnNullRuleTest extends RuleTestCase
     }
 
     #[Test]
+    public function passesForUnionReturnTypeWithoutNull(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NeverReturnNullRule/MethodWithUnionWithoutNull.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function reportsErrorForAbstractMethodWithNullableReturn(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NeverReturnNullRule/AbstractMethodWithNullableReturn.php'],
+            [
+                ['Method Haspadar\PHPStanRules\Tests\Fixtures\Rules\NeverReturnNullRule\AbstractMethodWithNullableReturn::greet() must not have a nullable return type.', 9],
+            ],
+        );
+    }
+
+    #[Test]
     public function suppressesErrorWhenPhpstanIgnorePresent(): void
     {
         $this->analyse(

--- a/tests/Unit/RulesTest.php
+++ b/tests/Unit/RulesTest.php
@@ -52,6 +52,7 @@ use Haspadar\PHPStanRules\Rules\ForbiddenClassSuffixRule;
 use Haspadar\PHPStanRules\Rules\BeImmutableRule;
 use Haspadar\PHPStanRules\Rules\KeepInterfacesShortRule;
 use Haspadar\PHPStanRules\Rules\NeverAcceptNullArgumentsRule;
+use Haspadar\PHPStanRules\Rules\NeverReturnNullRule;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -109,6 +110,7 @@ final class RulesTest extends TestCase
                 BeImmutableRule::class,
                 KeepInterfacesShortRule::class,
                 NeverAcceptNullArgumentsRule::class,
+                NeverReturnNullRule::class,
             ],
             (new Rules())->all(),
             'Rules::all() must list every registered rule class',


### PR DESCRIPTION
- Added NeverReturnNullRule prohibiting ?Type, Type|null return types and return null statements
- Added tests and fixtures covering nullable type, union null, return null, closures, arrow functions, and suppression
- Updated rules.neon with service registration and rules-ignore.neon to exclude rule from own codebase
- Updated README with rule description in Design table

Closes #118

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added NeverReturnNullRule — enforces non-nullable return types and forbids null returns.

* **Documentation**
  * Documented the new rule and added an ignore-entry for it.

* **Tests**
  * Added unit tests and fixtures covering nullable returns, explicit null returns, and suppression cases.

* **Chores**
  * Updated default infra container image references, added mutation-testing thresholds, and adjusted gitignore.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->