### PR TITLE
NeverUsePublicConstantsRule

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 | `KeepInterfacesShortRule`        | Interfaces must not declare too many methods (default: 10)                         |
 | `NeverAcceptNullArgumentsRule`   | Method and standalone function parameters must not be nullable                     |
 | `NeverReturnNullRule`            | Method and standalone function return types must not be nullable, `return null` is forbidden |
-| `NeverUsePublicConstantsRule`   | Class constants must not be public (explicitly or implicitly)                  |
+| `NeverUsePublicConstantsRule`    | Class constants must not be public (explicitly or implicitly)                      |
 
 ### Error-prone patterns
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@
 | `KeepInterfacesShortRule`        | Interfaces must not declare too many methods (default: 10)                         |
 | `NeverAcceptNullArgumentsRule`   | Method and standalone function parameters must not be nullable                     |
 | `NeverReturnNullRule`            | Method and standalone function return types must not be nullable, `return null` is forbidden |
+| `NeverUsePublicConstantsRule`   | Class constants must not be public (explicitly or implicitly)                  |
 
 ### Error-prone patterns
 

--- a/rules.neon
+++ b/rules.neon
@@ -492,3 +492,7 @@ services:
         class: Haspadar\PHPStanRules\Rules\NeverReturnNullRule
         tags:
             - phpstan.rules.rule
+    -
+        class: Haspadar\PHPStanRules\Rules\NeverUsePublicConstantsRule
+        tags:
+            - phpstan.rules.rule

--- a/src/Rules.php
+++ b/src/Rules.php
@@ -58,6 +58,7 @@ final class Rules
         Rules\KeepInterfacesShortRule::class,
         Rules\NeverAcceptNullArgumentsRule::class,
         Rules\NeverReturnNullRule::class,
+        Rules\NeverUsePublicConstantsRule::class,
     ];
 
     /**

--- a/src/Rules/NeverUsePublicConstantsRule.php
+++ b/src/Rules/NeverUsePublicConstantsRule.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Rules;
+
+use Override;
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassConst;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * Forbids public constants in classes.
+ *
+ * Reports every class constant that is explicitly or implicitly public.
+ * Interfaces, enums, traits, anonymous classes, and abstract classes
+ * with no namespacedName are skipped. Abstract named classes ARE checked
+ * because they still expose public API through their constants.
+ *
+ * @implements Rule<Class_>
+ */
+final readonly class NeverUsePublicConstantsRule implements Rule
+{
+    #[Override]
+    public function getNodeType(): string
+    {
+        return Class_::class;
+    }
+
+    /**
+     * Analyses the node and returns a list of errors.
+     *
+     * @param Class_ $node
+     * @return list<IdentifierRuleError>
+     */
+    #[Override]
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if ($node->isAnonymous() || $node->name === null) {
+            return [];
+        }
+
+        $shortName = $node->name->toString();
+        $errors = [];
+
+        foreach ($node->stmts as $stmt) {
+            if ($stmt instanceof ClassConst && $stmt->isPublic()) {
+                $errors = [...$errors, ...$this->errorsForConst($stmt, $shortName)];
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * Returns errors for each public constant in the given node.
+     *
+     * @return list<IdentifierRuleError>
+     */
+    private function errorsForConst(ClassConst $classConst, string $className): array
+    {
+        $errors = [];
+
+        foreach ($classConst->consts as $const) {
+            $errors[] = RuleErrorBuilder::message(
+                sprintf(
+                    'Constant %s in class %s must not be public. Use private or protected visibility.',
+                    $const->name->toString(),
+                    $className,
+                ),
+            )
+                ->identifier('haspadar.noPublicConstants')
+                ->line($const->getStartLine())
+                ->build();
+        }
+
+        return $errors;
+    }
+}

--- a/src/Rules/NeverUsePublicConstantsRule.php
+++ b/src/Rules/NeverUsePublicConstantsRule.php
@@ -17,9 +17,9 @@ use PHPStan\Rules\RuleErrorBuilder;
  * Forbids public constants in classes.
  *
  * Reports every class constant that is explicitly or implicitly public.
- * Interfaces, enums, traits, anonymous classes, and abstract classes
- * with no namespacedName are skipped. Abstract named classes ARE checked
- * because they still expose public API through their constants.
+ * Only named classes are checked, including abstract ones. Interfaces,
+ * enums, and traits use different AST nodes and are not affected.
+ * Anonymous classes are skipped.
  *
  * @implements Rule<Class_>
  */

--- a/tests/Fixtures/Rules/NeverUsePublicConstantsRule/AbstractClassWithPublicConst.php
+++ b/tests/Fixtures/Rules/NeverUsePublicConstantsRule/AbstractClassWithPublicConst.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NeverUsePublicConstantsRule;
+
+abstract class AbstractClassWithPublicConst
+{
+    public const string NAME = 'test';
+}

--- a/tests/Fixtures/Rules/NeverUsePublicConstantsRule/AnonymousClassWithConst.php
+++ b/tests/Fixtures/Rules/NeverUsePublicConstantsRule/AnonymousClassWithConst.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NeverUsePublicConstantsRule;
+
+/** Creates an anonymous class with a public constant. */
+final class AnonymousClassWithConst
+{
+    /** Returns an anonymous class instance. */
+    public function create(): object
+    {
+        return new class {
+            public const string NAME = 'anon';
+        };
+    }
+}

--- a/tests/Fixtures/Rules/NeverUsePublicConstantsRule/ClassWithImplicitPublicConst.php
+++ b/tests/Fixtures/Rules/NeverUsePublicConstantsRule/ClassWithImplicitPublicConst.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NeverUsePublicConstantsRule;
+
+final class ClassWithImplicitPublicConst
+{
+    const string NAME = 'test';
+}

--- a/tests/Fixtures/Rules/NeverUsePublicConstantsRule/ClassWithMixedVisibilityConsts.php
+++ b/tests/Fixtures/Rules/NeverUsePublicConstantsRule/ClassWithMixedVisibilityConsts.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NeverUsePublicConstantsRule;
+
+final class ClassWithMixedVisibilityConsts
+{
+    public const string PUBLIC_ONE = 'a';
+    private const string PRIVATE_ONE = 'b';
+    protected const string PROTECTED_ONE = 'c';
+}

--- a/tests/Fixtures/Rules/NeverUsePublicConstantsRule/ClassWithMultiplePublicConsts.php
+++ b/tests/Fixtures/Rules/NeverUsePublicConstantsRule/ClassWithMultiplePublicConsts.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NeverUsePublicConstantsRule;
+
+final class ClassWithMultiplePublicConsts
+{
+    public const string FIRST = 'one';
+    public const string SECOND = 'two';
+}

--- a/tests/Fixtures/Rules/NeverUsePublicConstantsRule/ClassWithPrivateConst.php
+++ b/tests/Fixtures/Rules/NeverUsePublicConstantsRule/ClassWithPrivateConst.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NeverUsePublicConstantsRule;
+
+final class ClassWithPrivateConst
+{
+    private const string NAME = 'test';
+}

--- a/tests/Fixtures/Rules/NeverUsePublicConstantsRule/ClassWithProtectedConst.php
+++ b/tests/Fixtures/Rules/NeverUsePublicConstantsRule/ClassWithProtectedConst.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NeverUsePublicConstantsRule;
+
+class ClassWithProtectedConst
+{
+    protected const string NAME = 'test';
+}

--- a/tests/Fixtures/Rules/NeverUsePublicConstantsRule/ClassWithPublicConst.php
+++ b/tests/Fixtures/Rules/NeverUsePublicConstantsRule/ClassWithPublicConst.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NeverUsePublicConstantsRule;
+
+final class ClassWithPublicConst
+{
+    public const string NAME = 'test';
+}

--- a/tests/Fixtures/Rules/NeverUsePublicConstantsRule/EnumWithConst.php
+++ b/tests/Fixtures/Rules/NeverUsePublicConstantsRule/EnumWithConst.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NeverUsePublicConstantsRule;
+
+enum EnumWithConst: string
+{
+    case Active = 'active';
+
+    public const string DEFAULT = 'active';
+}

--- a/tests/Fixtures/Rules/NeverUsePublicConstantsRule/InterfaceWithConst.php
+++ b/tests/Fixtures/Rules/NeverUsePublicConstantsRule/InterfaceWithConst.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NeverUsePublicConstantsRule;
+
+interface InterfaceWithConst
+{
+    public const string NAME = 'test';
+}

--- a/tests/Fixtures/Rules/NeverUsePublicConstantsRule/SuppressedPublicConst.php
+++ b/tests/Fixtures/Rules/NeverUsePublicConstantsRule/SuppressedPublicConst.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NeverUsePublicConstantsRule;
+
+final class SuppressedPublicConst
+{
+    /** @phpstan-ignore haspadar.noPublicConstants */
+    public const string NAME = 'test';
+}

--- a/tests/Unit/Rules/NeverUsePublicConstantsRule/NeverUsePublicConstantsRuleTest.php
+++ b/tests/Unit/Rules/NeverUsePublicConstantsRule/NeverUsePublicConstantsRuleTest.php
@@ -81,6 +81,44 @@ final class NeverUsePublicConstantsRuleTest extends RuleTestCase
     }
 
     #[Test]
+    public function reportsOnlyPublicConstWhenMixedVisibility(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NeverUsePublicConstantsRule/ClassWithMixedVisibilityConsts.php'],
+            [
+                ['Constant PUBLIC_ONE in class ClassWithMixedVisibilityConsts must not be public. Use private or protected visibility.', 9],
+            ],
+        );
+    }
+
+    #[Test]
+    public function passesForInterfaceWithConst(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NeverUsePublicConstantsRule/InterfaceWithConst.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function passesForEnumWithConst(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NeverUsePublicConstantsRule/EnumWithConst.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function passesForAnonymousClassWithConst(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NeverUsePublicConstantsRule/AnonymousClassWithConst.php'],
+            [],
+        );
+    }
+
+    #[Test]
     public function suppressesErrorWhenPhpstanIgnorePresent(): void
     {
         $this->analyse(

--- a/tests/Unit/Rules/NeverUsePublicConstantsRule/NeverUsePublicConstantsRuleTest.php
+++ b/tests/Unit/Rules/NeverUsePublicConstantsRule/NeverUsePublicConstantsRuleTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\NeverUsePublicConstantsRule;
+
+use Haspadar\PHPStanRules\Rules\NeverUsePublicConstantsRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<NeverUsePublicConstantsRule> */
+final class NeverUsePublicConstantsRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new NeverUsePublicConstantsRule();
+    }
+
+    #[Test]
+    public function reportsErrorForPublicConst(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NeverUsePublicConstantsRule/ClassWithPublicConst.php'],
+            [
+                ['Constant NAME in class ClassWithPublicConst must not be public. Use private or protected visibility.', 9],
+            ],
+        );
+    }
+
+    #[Test]
+    public function reportsErrorForImplicitPublicConst(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NeverUsePublicConstantsRule/ClassWithImplicitPublicConst.php'],
+            [
+                ['Constant NAME in class ClassWithImplicitPublicConst must not be public. Use private or protected visibility.', 9],
+            ],
+        );
+    }
+
+    #[Test]
+    public function reportsErrorForMultiplePublicConsts(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NeverUsePublicConstantsRule/ClassWithMultiplePublicConsts.php'],
+            [
+                ['Constant FIRST in class ClassWithMultiplePublicConsts must not be public. Use private or protected visibility.', 9],
+                ['Constant SECOND in class ClassWithMultiplePublicConsts must not be public. Use private or protected visibility.', 10],
+            ],
+        );
+    }
+
+    #[Test]
+    public function reportsErrorForAbstractClassWithPublicConst(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NeverUsePublicConstantsRule/AbstractClassWithPublicConst.php'],
+            [
+                ['Constant NAME in class AbstractClassWithPublicConst must not be public. Use private or protected visibility.', 9],
+            ],
+        );
+    }
+
+    #[Test]
+    public function passesForPrivateConst(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NeverUsePublicConstantsRule/ClassWithPrivateConst.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function passesForProtectedConst(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NeverUsePublicConstantsRule/ClassWithProtectedConst.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function suppressesErrorWhenPhpstanIgnorePresent(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NeverUsePublicConstantsRule/SuppressedPublicConst.php'],
+            [],
+        );
+    }
+}

--- a/tests/Unit/RulesTest.php
+++ b/tests/Unit/RulesTest.php
@@ -53,6 +53,7 @@ use Haspadar\PHPStanRules\Rules\BeImmutableRule;
 use Haspadar\PHPStanRules\Rules\KeepInterfacesShortRule;
 use Haspadar\PHPStanRules\Rules\NeverAcceptNullArgumentsRule;
 use Haspadar\PHPStanRules\Rules\NeverReturnNullRule;
+use Haspadar\PHPStanRules\Rules\NeverUsePublicConstantsRule;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -111,6 +112,7 @@ final class RulesTest extends TestCase
                 KeepInterfacesShortRule::class,
                 NeverAcceptNullArgumentsRule::class,
                 NeverReturnNullRule::class,
+                NeverUsePublicConstantsRule::class,
             ],
             (new Rules())->all(),
             'Rules::all() must list every registered rule class',


### PR DESCRIPTION
- Added NeverUsePublicConstantsRule that reports explicit and implicit public constants in classes
- Added test coverage for interfaces, enums, anonymous classes, abstract classes and mixed visibility

Closes #120

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new PHPStan rule that identifies and reports violations for public class constants, supporting various class types and visibility scenarios.

* **Documentation**
  * Updated README and configuration files to document and register the new rule.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->