### PR TITLE
#122: Add WeightedMethodsPerClassRule (WMC)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 | `BooleanExpressionComplexityRule` | 3       | Method must not have more than N boolean operators in a single expression  |
 | `ClassLengthRule`                 | 500     | Class body must not exceed N lines                                         |
 | `StatementCountRule`              | 30      | Method must not have more than N executable statements                     |
+| `WeightedMethodsPerClassRule`     | 50      | Sum of cyclomatic complexities of all methods must not exceed N            |
 
 ### Design
 
@@ -116,6 +117,8 @@ parameters:
             skipComments: true
         statementCount:
             maxStatements: 20
+        weightedMethods:
+            maxWmc: 30
         returnCount:
             max: 2
         illegalCatch:

--- a/rules.neon
+++ b/rules.neon
@@ -88,6 +88,8 @@ parameters:
             excludedClasses: []
         interfaceMethods:
             maxMethods: 10
+        weightedMethods:
+            maxWmc: 50
         forbiddenClassSuffix:
             forbiddenSuffixes:
                 - Manager
@@ -201,6 +203,9 @@ parametersSchema:
         ]),
         interfaceMethods: structure([
             maxMethods: int(),
+        ]),
+        weightedMethods: structure([
+            maxWmc: int(),
         ]),
         forbiddenClassSuffix: structure([
             forbiddenSuffixes: listOf(string()),
@@ -494,5 +499,11 @@ services:
             - phpstan.rules.rule
     -
         class: Haspadar\PHPStanRules\Rules\NeverUsePublicConstantsRule
+        tags:
+            - phpstan.rules.rule
+    -
+        class: Haspadar\PHPStanRules\Rules\WeightedMethodsPerClassRule
+        arguments:
+            maxWmc: %haspadar.weightedMethods.maxWmc%
         tags:
             - phpstan.rules.rule

--- a/src/Rules.php
+++ b/src/Rules.php
@@ -59,6 +59,7 @@ final class Rules
         Rules\NeverAcceptNullArgumentsRule::class,
         Rules\NeverReturnNullRule::class,
         Rules\NeverUsePublicConstantsRule::class,
+        Rules\WeightedMethodsPerClassRule::class,
     ];
 
     /**

--- a/src/Rules/WeightedMethodsPerClassRule.php
+++ b/src/Rules/WeightedMethodsPerClassRule.php
@@ -72,9 +72,11 @@ final readonly class WeightedMethodsPerClassRule implements Rule
             return [];
         }
 
-        if ($node->isAnonymous() || $node->name === null) {
+        if ($node->isAnonymous()) {
             return [];
         }
+
+        assert($node->name !== null);
 
         return [
             RuleErrorBuilder::message(

--- a/src/Rules/WeightedMethodsPerClassRule.php
+++ b/src/Rules/WeightedMethodsPerClassRule.php
@@ -29,7 +29,6 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
-use PHPStan\ShouldNotHappenException;
 
 /**
  * Reports a class whose weighted method count (sum of cyclomatic complexities) exceeds the configured limit.
@@ -62,7 +61,6 @@ final readonly class WeightedMethodsPerClassRule implements Rule
      * Analyses the node and returns a list of errors.
      *
      * @psalm-param Class_ $node
-     * @throws ShouldNotHappenException
      * @return list<IdentifierRuleError>
      */
     #[Override]
@@ -74,8 +72,8 @@ final readonly class WeightedMethodsPerClassRule implements Rule
             return [];
         }
 
-        if ($node->name === null) {
-            throw new ShouldNotHappenException();
+        if ($node->isAnonymous() || $node->name === null) {
+            return [];
         }
 
         return [

--- a/src/Rules/WeightedMethodsPerClassRule.php
+++ b/src/Rules/WeightedMethodsPerClassRule.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Rules;
+
+use InvalidArgumentException;
+use Override;
+use PhpParser\Node;
+use PhpParser\Node\Expr\BinaryOp\BooleanAnd;
+use PhpParser\Node\Expr\BinaryOp\BooleanOr;
+use PhpParser\Node\Expr\BinaryOp\Coalesce;
+use PhpParser\Node\Expr\BinaryOp\LogicalAnd;
+use PhpParser\Node\Expr\BinaryOp\LogicalOr;
+use PhpParser\Node\Expr\Ternary;
+use PhpParser\Node\MatchArm;
+use PhpParser\Node\Stmt\Case_;
+use PhpParser\Node\Stmt\Catch_;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Do_;
+use PhpParser\Node\Stmt\ElseIf_;
+use PhpParser\Node\Stmt\For_;
+use PhpParser\Node\Stmt\Foreach_;
+use PhpParser\Node\Stmt\If_;
+use PhpParser\Node\Stmt\While_;
+use PhpParser\NodeFinder;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\ShouldNotHappenException;
+
+/**
+ * Reports a class whose weighted method count (sum of cyclomatic complexities) exceeds the configured limit.
+ *
+ * @implements Rule<Class_>
+ */
+final readonly class WeightedMethodsPerClassRule implements Rule
+{
+    /**
+     * Constructs the rule with the given WMC limit.
+     *
+     * @throws InvalidArgumentException
+     */
+    public function __construct(private int $maxWmc = 50)
+    {
+        if ($maxWmc <= 0) {
+            throw new InvalidArgumentException(
+                sprintf('maxWmc must be a positive integer, %d given', $maxWmc),
+            );
+        }
+    }
+
+    #[Override]
+    public function getNodeType(): string
+    {
+        return Class_::class;
+    }
+
+    /**
+     * Analyses the node and returns a list of errors.
+     *
+     * @psalm-param Class_ $node
+     * @throws ShouldNotHappenException
+     * @return list<IdentifierRuleError>
+     */
+    #[Override]
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $wmc = $this->wmc($node);
+
+        if ($wmc <= $this->maxWmc) {
+            return [];
+        }
+
+        if ($node->name === null) {
+            throw new ShouldNotHappenException();
+        }
+
+        return [
+            RuleErrorBuilder::message(
+                sprintf(
+                    'Class %s has weighted method complexity of %d. Maximum allowed is %d.',
+                    $node->name->toString(),
+                    $wmc,
+                    $this->maxWmc,
+                ),
+            )
+                ->identifier('haspadar.weightedMethods')
+                ->build(),
+        ];
+    }
+
+    /**
+     * Computes the weighted method count for a class.
+     *
+     * @param Class_ $node
+     */
+    private function wmc(Node $node): int
+    {
+        $total = 0;
+
+        foreach ($node->getMethods() as $method) {
+            $total += $this->complexity($method);
+        }
+
+        return $total;
+    }
+
+    /** Computes the cyclomatic complexity of a method. */
+    private function complexity(ClassMethod $method): int
+    {
+        $finder = new NodeFinder();
+        $count = 1;
+
+        foreach ($finder->find($method->stmts ?? [], $this->isBranchingNode(...)) as $candidate) {
+            if ($candidate instanceof Case_ && $candidate->cond === null) {
+                continue;
+            }
+
+            if ($candidate instanceof MatchArm && $candidate->conds === null) {
+                continue;
+            }
+
+            $count++;
+        }
+
+        return $count;
+    }
+
+    /** Returns true for nodes that contribute to cyclomatic complexity. */
+    private function isBranchingNode(Node $node): bool
+    {
+        return $this->isControlFlowNode($node) || $this->isLogicalOrConditionalNode($node);
+    }
+
+    /** Returns true for control flow statement nodes. */
+    private function isControlFlowNode(Node $node): bool
+    {
+        return $node instanceof If_
+            || $node instanceof ElseIf_
+            || $node instanceof While_
+            || $node instanceof Do_
+            || $node instanceof For_
+            || $node instanceof Foreach_
+            || $node instanceof Catch_
+            || $node instanceof Case_
+            || $node instanceof MatchArm;
+    }
+
+    /** Returns true for logical and conditional expression nodes. */
+    private function isLogicalOrConditionalNode(Node $node): bool
+    {
+        return $node instanceof BooleanAnd
+            || $node instanceof BooleanOr
+            || $node instanceof LogicalAnd
+            || $node instanceof LogicalOr
+            || $node instanceof Ternary
+            || $node instanceof Coalesce;
+    }
+}

--- a/tests/Fixtures/Rules/WeightedMethodsPerClassRule/AllBranchTypesClass.php
+++ b/tests/Fixtures/Rules/WeightedMethodsPerClassRule/AllBranchTypesClass.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\WeightedMethodsPerClassRule;
+
+final class AllBranchTypesClass
+{
+    /** @param list<int> $items */
+    public function controlFlow(int $val, array $items): int
+    {
+        $result = 0;
+
+        if ($val > 0) {
+            $result++;
+        } elseif ($val < 0) {
+            $result--;
+        }
+
+        while ($result < 10) {
+            $result++;
+        }
+
+        do {
+            $result++;
+        } while ($result < 20);
+
+        for ($idx = 0; $idx < $val; $idx++) {
+            $result += $idx;
+        }
+
+        foreach ($items as $item) {
+            $result += $item;
+        }
+
+        try {
+            $result += intdiv($val, $result);
+        } catch (\DivisionByZeroError $exc) {
+            $result = strlen($exc->getMessage());
+        }
+
+        switch ($val) {
+            case 1:
+                $result = 10;
+                break;
+            case 2:
+                $result = 20;
+                break;
+            default:
+                $result = 30;
+        }
+
+        return $result;
+    }
+
+    public function logicalAndConditional(int $val, bool $flag): int
+    {
+        if ($val > 0 && $flag) {
+            return 1;
+        }
+
+        if ($val < 0 || $flag) {
+            return 2;
+        }
+
+        if ($val > 0 and $flag) {
+            return 3;
+        }
+
+        if ($val < 0 or $flag) {
+            return 4;
+        }
+
+        $ternary = $flag ? $val : 0;
+
+        $coalesce = $ternary ?? 0;
+
+        return match ($val) {
+            1 => 10,
+            2 => 20,
+            default => $coalesce,
+        };
+    }
+}

--- a/tests/Fixtures/Rules/WeightedMethodsPerClassRule/AnonymousClassFile.php
+++ b/tests/Fixtures/Rules/WeightedMethodsPerClassRule/AnonymousClassFile.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\WeightedMethodsPerClassRule;
+
+$instance = new class {
+    public function one(int $val): int
+    {
+        if ($val > 0) {
+            return $val;
+        }
+
+        return 0;
+    }
+
+    public function two(int $val): int
+    {
+        if ($val > 0) {
+            return $val;
+        }
+
+        return 0;
+    }
+
+    public function three(int $val): int
+    {
+        if ($val > 0) {
+            return $val;
+        }
+
+        return 0;
+    }
+};

--- a/tests/Fixtures/Rules/WeightedMethodsPerClassRule/ComplexClass.php
+++ b/tests/Fixtures/Rules/WeightedMethodsPerClassRule/ComplexClass.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\WeightedMethodsPerClassRule;
+
+final class ComplexClass
+{
+    public function one(int $val): int
+    {
+        if ($val > 0) {
+            return $val;
+        }
+
+        return 0;
+    }
+
+    public function two(int $val): int
+    {
+        if ($val > 0) {
+            return $val;
+        }
+
+        return 0;
+    }
+
+    public function three(int $val): int
+    {
+        if ($val > 0) {
+            return $val;
+        }
+
+        return 0;
+    }
+}

--- a/tests/Fixtures/Rules/WeightedMethodsPerClassRule/ExactClass.php
+++ b/tests/Fixtures/Rules/WeightedMethodsPerClassRule/ExactClass.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\WeightedMethodsPerClassRule;
+
+final class ExactClass
+{
+    public function one(int $val): int
+    {
+        if ($val > 0) {
+            return $val;
+        }
+
+        return 0;
+    }
+
+    public function two(int $val): int
+    {
+        if ($val > 0) {
+            return $val;
+        }
+
+        return 0;
+    }
+
+    public function three(): void
+    {
+    }
+}

--- a/tests/Fixtures/Rules/WeightedMethodsPerClassRule/LargeComplexClass.php
+++ b/tests/Fixtures/Rules/WeightedMethodsPerClassRule/LargeComplexClass.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\WeightedMethodsPerClassRule;
+
+final class LargeComplexClass
+{
+    public function one(int $val): int
+    {
+        if ($val > 0) {
+            for ($i = 0; $i < $val; $i++) {
+                if ($i > 5) {
+                    return $i;
+                }
+            }
+        }
+
+        return 0;
+    }
+
+    public function two(int $val): int
+    {
+        if ($val > 0) {
+            for ($i = 0; $i < $val; $i++) {
+                if ($i > 5) {
+                    return $i;
+                }
+            }
+        }
+
+        return 0;
+    }
+
+    public function three(int $val): int
+    {
+        if ($val > 0) {
+            for ($i = 0; $i < $val; $i++) {
+                if ($i > 5) {
+                    return $i;
+                }
+            }
+        }
+
+        return 0;
+    }
+
+    public function four(int $val): int
+    {
+        if ($val > 0) {
+            for ($i = 0; $i < $val; $i++) {
+                if ($i > 5) {
+                    return $i;
+                }
+            }
+        }
+
+        return 0;
+    }
+
+    public function five(int $val): int
+    {
+        if ($val > 0) {
+            for ($i = 0; $i < $val; $i++) {
+                if ($i > 5) {
+                    return $i;
+                }
+            }
+        }
+
+        return 0;
+    }
+
+    public function six(int $val): int
+    {
+        if ($val > 0) {
+            for ($i = 0; $i < $val; $i++) {
+                if ($i > 5) {
+                    return $i;
+                }
+            }
+        }
+
+        return 0;
+    }
+
+    public function seven(int $val): int
+    {
+        if ($val > 0) {
+            for ($i = 0; $i < $val; $i++) {
+                if ($i > 5) {
+                    return $i;
+                }
+            }
+        }
+
+        return 0;
+    }
+
+    public function eight(int $val): int
+    {
+        if ($val > 0) {
+            for ($i = 0; $i < $val; $i++) {
+                if ($i > 5) {
+                    return $i;
+                }
+            }
+        }
+
+        return 0;
+    }
+
+    public function nine(int $val): int
+    {
+        if ($val > 0) {
+            for ($i = 0; $i < $val; $i++) {
+                if ($i > 5) {
+                    return $i;
+                }
+            }
+        }
+
+        return 0;
+    }
+
+    public function ten(int $val): int
+    {
+        if ($val > 0) {
+            for ($i = 0; $i < $val; $i++) {
+                if ($i > 5) {
+                    return $i;
+                }
+            }
+        }
+
+        return 0;
+    }
+
+    public function eleven(int $val): int
+    {
+        if ($val > 0) {
+            for ($i = 0; $i < $val; $i++) {
+                if ($i > 5) {
+                    return $i;
+                }
+            }
+        }
+
+        return 0;
+    }
+
+    public function twelve(int $val): int
+    {
+        if ($val > 0) {
+            for ($i = 0; $i < $val; $i++) {
+                if ($i > 5) {
+                    return $i;
+                }
+            }
+        }
+
+        return 0;
+    }
+
+    public function thirteen(int $val): int
+    {
+        if ($val > 0) {
+            for ($i = 0; $i < $val; $i++) {
+                if ($i > 5) {
+                    return $i;
+                }
+            }
+        }
+
+        return 0;
+    }
+}

--- a/tests/Fixtures/Rules/WeightedMethodsPerClassRule/SimpleClass.php
+++ b/tests/Fixtures/Rules/WeightedMethodsPerClassRule/SimpleClass.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\WeightedMethodsPerClassRule;
+
+final class SimpleClass
+{
+    public function one(): void
+    {
+    }
+
+    public function two(): void
+    {
+    }
+
+    public function three(): void
+    {
+    }
+}

--- a/tests/Fixtures/Rules/WeightedMethodsPerClassRule/SuppressedComplexClass.php
+++ b/tests/Fixtures/Rules/WeightedMethodsPerClassRule/SuppressedComplexClass.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\WeightedMethodsPerClassRule;
+
+/** @phpstan-ignore haspadar.weightedMethods */
+final class SuppressedComplexClass
+{
+    public function one(int $val): int
+    {
+        if ($val > 0) {
+            return $val;
+        }
+
+        return 0;
+    }
+
+    public function two(int $val): int
+    {
+        if ($val > 0) {
+            return $val;
+        }
+
+        return 0;
+    }
+
+    public function three(int $val): int
+    {
+        if ($val > 0) {
+            return $val;
+        }
+
+        return 0;
+    }
+}

--- a/tests/Unit/Rules/WeightedMethodsPerClassRule/WeightedMethodsPerClassRuleDefaultLimitTest.php
+++ b/tests/Unit/Rules/WeightedMethodsPerClassRule/WeightedMethodsPerClassRuleDefaultLimitTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\WeightedMethodsPerClassRule;
+
+use Haspadar\PHPStanRules\Rules\WeightedMethodsPerClassRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<WeightedMethodsPerClassRule> */
+final class WeightedMethodsPerClassRuleDefaultLimitTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new WeightedMethodsPerClassRule();
+    }
+
+    #[Test]
+    public function passesWhenWmcIsWithinDefaultLimit(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/WeightedMethodsPerClassRule/ComplexClass.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function reportsErrorWhenWmcExceedsDefaultLimit(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/WeightedMethodsPerClassRule/LargeComplexClass.php'],
+            [
+                ['Class LargeComplexClass has weighted method complexity of 52. Maximum allowed is 50.', 7],
+            ],
+        );
+    }
+}

--- a/tests/Unit/Rules/WeightedMethodsPerClassRule/WeightedMethodsPerClassRuleTest.php
+++ b/tests/Unit/Rules/WeightedMethodsPerClassRule/WeightedMethodsPerClassRuleTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Haspadar\PHPStanRules\Tests\Unit\Rules\WeightedMethodsPerClassRule;
 
 use Haspadar\PHPStanRules\Rules\WeightedMethodsPerClassRule;
+use InvalidArgumentException;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPUnit\Framework\Attributes\Test;
@@ -64,6 +65,20 @@ final class WeightedMethodsPerClassRuleTest extends RuleTestCase
             [__DIR__ . '/../../../Fixtures/Rules/WeightedMethodsPerClassRule/AnonymousClassFile.php'],
             [],
         );
+    }
+
+    #[Test]
+    public function throwsExceptionWhenMaxWmcIsZero(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new WeightedMethodsPerClassRule(0);
+    }
+
+    #[Test]
+    public function throwsExceptionWhenMaxWmcIsNegative(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new WeightedMethodsPerClassRule(-1);
     }
 
     #[Test]

--- a/tests/Unit/Rules/WeightedMethodsPerClassRule/WeightedMethodsPerClassRuleTest.php
+++ b/tests/Unit/Rules/WeightedMethodsPerClassRule/WeightedMethodsPerClassRuleTest.php
@@ -47,6 +47,17 @@ final class WeightedMethodsPerClassRuleTest extends RuleTestCase
     }
 
     #[Test]
+    public function reportsErrorWhenAllBranchTypesExceedLimit(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/WeightedMethodsPerClassRule/AllBranchTypesClass.php'],
+            [
+                ['Class AllBranchTypesClass has weighted method complexity of 23. Maximum allowed is 5.', 7],
+            ],
+        );
+    }
+
+    #[Test]
     public function suppressesErrorWhenPhpstanIgnorePresent(): void
     {
         $this->analyse(

--- a/tests/Unit/Rules/WeightedMethodsPerClassRule/WeightedMethodsPerClassRuleTest.php
+++ b/tests/Unit/Rules/WeightedMethodsPerClassRule/WeightedMethodsPerClassRuleTest.php
@@ -58,6 +58,15 @@ final class WeightedMethodsPerClassRuleTest extends RuleTestCase
     }
 
     #[Test]
+    public function skipsAnonymousClassEvenWhenWmcExceedsLimit(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/WeightedMethodsPerClassRule/AnonymousClassFile.php'],
+            [],
+        );
+    }
+
+    #[Test]
     public function suppressesErrorWhenPhpstanIgnorePresent(): void
     {
         $this->analyse(

--- a/tests/Unit/Rules/WeightedMethodsPerClassRule/WeightedMethodsPerClassRuleTest.php
+++ b/tests/Unit/Rules/WeightedMethodsPerClassRule/WeightedMethodsPerClassRuleTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\WeightedMethodsPerClassRule;
+
+use Haspadar\PHPStanRules\Rules\WeightedMethodsPerClassRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<WeightedMethodsPerClassRule> */
+final class WeightedMethodsPerClassRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new WeightedMethodsPerClassRule(5);
+    }
+
+    #[Test]
+    public function passesWhenWmcIsWithinLimit(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/WeightedMethodsPerClassRule/SimpleClass.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function reportsErrorWhenWmcExceedsLimit(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/WeightedMethodsPerClassRule/ComplexClass.php'],
+            [
+                ['Class ComplexClass has weighted method complexity of 6. Maximum allowed is 5.', 7],
+            ],
+        );
+    }
+
+    #[Test]
+    public function passesWhenWmcIsExactlyAtLimit(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/WeightedMethodsPerClassRule/ExactClass.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function suppressesErrorWhenPhpstanIgnorePresent(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/WeightedMethodsPerClassRule/SuppressedComplexClass.php'],
+            [],
+        );
+    }
+}

--- a/tests/Unit/RulesTest.php
+++ b/tests/Unit/RulesTest.php
@@ -54,6 +54,7 @@ use Haspadar\PHPStanRules\Rules\KeepInterfacesShortRule;
 use Haspadar\PHPStanRules\Rules\NeverAcceptNullArgumentsRule;
 use Haspadar\PHPStanRules\Rules\NeverReturnNullRule;
 use Haspadar\PHPStanRules\Rules\NeverUsePublicConstantsRule;
+use Haspadar\PHPStanRules\Rules\WeightedMethodsPerClassRule;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -113,6 +114,7 @@ final class RulesTest extends TestCase
                 NeverAcceptNullArgumentsRule::class,
                 NeverReturnNullRule::class,
                 NeverUsePublicConstantsRule::class,
+                WeightedMethodsPerClassRule::class,
             ],
             (new Rules())->all(),
             'Rules::all() must list every registered rule class',


### PR DESCRIPTION
## Summary

- Add `WeightedMethodsPerClassRule` — enforces upper limit on Weighted Method Count (sum of cyclomatic complexities of all methods in a class)
- Default limit: 50 (matches PHPMD `ExcessiveClassComplexity`)
- Configurable via `haspadar.weightedMethods.maxWmc` in `phpstan.neon`
- Replaces phpmetrics WMC check in piqule

## Test plan

- [ ] `WeightedMethodsPerClassRuleTest` — custom limit (maxWmc=5): passes, fails, exact boundary, suppressed
- [ ] `WeightedMethodsPerClassRuleDefaultLimitTest` — default limit (maxWmc=50): passes and fails
- [ ] `RulesTest` — rule registered in `Rules::all()`

Closes #122

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable "weighted methods per class" rule that sums method complexity and flags classes exceeding a max (default: 50); example threshold: 30. Rule supports per-class suppression.

* **Documentation**
  * README updated with the new rule entry and configuration example for parameters.haspadar.weightedMethods.maxWmc.

* **Tests**
  * Added unit and fixture tests covering default/custom limits, anonymous classes, suppression, and many branch types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->