### PR TITLE
Scaffold Afferent Coupling Collector And Rule

### DIFF
--- a/rules.neon
+++ b/rules.neon
@@ -507,3 +507,11 @@ services:
             maxWmc: %haspadar.weightedMethods.maxWmc%
         tags:
             - phpstan.rules.rule
+    -
+        class: Haspadar\PHPStanRules\Collectors\ClassDependencyCollector
+        tags:
+            - phpstan.collector
+    -
+        class: Haspadar\PHPStanRules\Rules\AfferentCouplingRule
+        tags:
+            - phpstan.rules.rule

--- a/src/Collectors/ClassDependencyCollector.php
+++ b/src/Collectors/ClassDependencyCollector.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Collectors;
+
+use Haspadar\PHPStanRules\Rules\CouplingBetweenObjectsRule\MethodBodyTypeCollector;
+use Haspadar\PHPStanRules\Rules\CouplingBetweenObjectsRule\TypeNameExtractor;
+use Override;
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Interface_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Collectors\Collector;
+
+/**
+ * Collects outbound class dependencies for every class and interface in the analysed codebase.
+ *
+ * For each class-like declaration, emits a tuple of its FQCN, kind (class/interface),
+ * abstractness flag, and the list of FQCNs it directly references through:
+ * property types, method signatures, `extends`, `implements`, `new`, static calls,
+ * and `catch` type hints. The data is consumed by a `Rule<CollectedDataNode>` that
+ * inverts the graph to compute afferent coupling (Ca).
+ *
+ * Self-references (`self`, `static`, `parent`) and scalar types are filtered out.
+ * Traits are not collected — their code merges into using classes.
+ *
+ * @implements Collector<Node\Stmt\ClassLike, array{class: string, kind: string, abstract: bool, line: int, dependencies: list<string>}>
+ */
+final readonly class ClassDependencyCollector implements Collector
+{
+    private const array SCALAR_TYPES = ['self', 'parent', 'static', 'void', 'null', 'bool', 'int', 'float', 'string', 'array', 'object', 'callable', 'iterable', 'never', 'mixed', 'true', 'false'];
+
+    private TypeNameExtractor $extractor;
+
+    private MethodBodyTypeCollector $bodyCollector;
+
+    /** Initializes reusable type-extraction helpers. */
+    public function __construct()
+    {
+        $this->extractor = new TypeNameExtractor();
+        $this->bodyCollector = new MethodBodyTypeCollector();
+    }
+
+    #[Override]
+    public function getNodeType(): string
+    {
+        return Node\Stmt\ClassLike::class;
+    }
+
+    /**
+     * Returns the class FQCN, kind, abstractness, declaration line, and the list of classes it depends on.
+     *
+     * @return array{class: string, kind: string, abstract: bool, line: int, dependencies: list<string>}|null
+     */
+    #[Override]
+    public function processNode(Node $node, Scope $scope): ?array
+    {
+        if (!$node instanceof Class_ && !$node instanceof Interface_) {
+            return null;
+        }
+
+        if ($node->namespacedName === null) {
+            return null;
+        }
+
+        $fqcn = $node->namespacedName->toString();
+        $names = $this->collectHeaderTypes($node);
+
+        foreach ($node->getMethods() as $method) {
+            $names = array_merge($names, $this->collectMethodTypes($method));
+        }
+
+        return [
+            'class' => $fqcn,
+            'kind' => $node instanceof Interface_ ? 'interface' : 'class',
+            'abstract' => $node instanceof Class_ && $node->isAbstract(),
+            'line' => $node->getStartLine(),
+            'dependencies' => $this->normalize($names, $fqcn),
+        ];
+    }
+
+    /**
+     * Returns type names referenced in extends/implements and property declarations.
+     *
+     * @return list<string>
+     */
+    private function collectHeaderTypes(Class_|Interface_ $node): array
+    {
+        if ($node instanceof Interface_) {
+            return array_values(
+                array_map(static fn(Node\Name $parent): string => $parent->toString(), $node->extends),
+            );
+        }
+
+        $names = [];
+
+        if ($node->extends !== null) {
+            $names[] = $node->extends->toString();
+        }
+
+        foreach ($node->implements as $interfaceName) {
+            $names[] = $interfaceName->toString();
+        }
+
+        foreach ($node->getProperties() as $property) {
+            if ($property->type !== null) {
+                $names = array_merge($names, $this->extractor->extract($property->type));
+            }
+        }
+
+        return $names;
+    }
+
+    /**
+     * Returns the list of type names referenced inside a method signature and body.
+     *
+     * @return list<string>
+     */
+    private function collectMethodTypes(ClassMethod $method): array
+    {
+        $names = [];
+
+        foreach ($method->params as $param) {
+            if ($param->type !== null) {
+                $names = array_merge($names, $this->extractor->extract($param->type));
+            }
+        }
+
+        if ($method->returnType !== null) {
+            $names = array_merge($names, $this->extractor->extract($method->returnType));
+        }
+
+        return array_merge($names, $this->bodyCollector->collect($method));
+    }
+
+    /**
+     * Filters scalars and the declaring class itself, then deduplicates.
+     *
+     * @param list<string> $names
+     * @return list<string>
+     */
+    private function normalize(array $names, string $selfFqcn): array
+    {
+        $selfLower = strtolower($selfFqcn);
+        $result = [];
+
+        foreach ($names as $name) {
+            $lower = strtolower($name);
+
+            if (in_array($lower, self::SCALAR_TYPES, true)) {
+                continue;
+            }
+
+            if ($lower === $selfLower) {
+                continue;
+            }
+
+            $result[$lower] = $name;
+        }
+
+        return array_values($result);
+    }
+}

--- a/src/Collectors/ClassDependencyCollector.php
+++ b/src/Collectors/ClassDependencyCollector.php
@@ -10,14 +10,15 @@ use Override;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Enum_;
 use PhpParser\Node\Stmt\Interface_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Collectors\Collector;
 
 /**
- * Collects outbound class dependencies for every class and interface in the analysed codebase.
+ * Collects outbound class dependencies for every class, interface, and enum in the analysed codebase.
  *
- * For each class-like declaration, emits a tuple of its FQCN, kind (class/interface),
+ * For each class-like declaration, emits a tuple of its FQCN, kind (class/interface/enum),
  * abstractness flag, and the list of FQCNs it directly references through:
  * property types, method signatures, `extends`, `implements`, `new`, static calls,
  * and `catch` type hints. The data is consumed by a `Rule<CollectedDataNode>` that
@@ -57,7 +58,7 @@ final readonly class ClassDependencyCollector implements Collector
     #[Override]
     public function processNode(Node $node, Scope $scope): ?array
     {
-        if (!$node instanceof Class_ && !$node instanceof Interface_) {
+        if (!$node instanceof Class_ && !$node instanceof Interface_ && !$node instanceof Enum_) {
             return null;
         }
 
@@ -74,11 +75,25 @@ final readonly class ClassDependencyCollector implements Collector
 
         return [
             'class' => $fqcn,
-            'kind' => $node instanceof Interface_ ? 'interface' : 'class',
+            'kind' => $this->kindOf($node),
             'abstract' => $node instanceof Class_ && $node->isAbstract(),
             'line' => $node->getStartLine(),
             'dependencies' => $this->normalize($names, $fqcn),
         ];
+    }
+
+    /** Returns the kind label (class/interface/enum) for the given class-like node. */
+    private function kindOf(Class_|Interface_|Enum_ $node): string
+    {
+        if ($node instanceof Interface_) {
+            return 'interface';
+        }
+
+        if ($node instanceof Enum_) {
+            return 'enum';
+        }
+
+        return 'class';
     }
 
     /**
@@ -86,7 +101,7 @@ final readonly class ClassDependencyCollector implements Collector
      *
      * @return list<string>
      */
-    private function collectHeaderTypes(Class_|Interface_ $node): array
+    private function collectHeaderTypes(Class_|Interface_|Enum_ $node): array
     {
         if ($node instanceof Interface_) {
             return array_values(
@@ -96,7 +111,7 @@ final readonly class ClassDependencyCollector implements Collector
 
         $names = [];
 
-        if ($node->extends !== null) {
+        if ($node instanceof Class_ && $node->extends !== null) {
             $names[] = $node->extends->toString();
         }
 
@@ -136,7 +151,7 @@ final readonly class ClassDependencyCollector implements Collector
     }
 
     /**
-     * Filters scalars and the declaring class itself, then deduplicates.
+     * Filters scalars and the declaring class itself, then deduplicates by lowercased FQCN.
      *
      * @param list<string> $names
      * @return list<string>
@@ -157,7 +172,7 @@ final readonly class ClassDependencyCollector implements Collector
                 continue;
             }
 
-            $result[$lower] = $name;
+            $result[$lower] = $lower;
         }
 
         return array_values($result);

--- a/src/Rules.php
+++ b/src/Rules.php
@@ -60,6 +60,7 @@ final class Rules
         Rules\NeverReturnNullRule::class,
         Rules\NeverUsePublicConstantsRule::class,
         Rules\WeightedMethodsPerClassRule::class,
+        Rules\AfferentCouplingRule::class,
     ];
 
     /**

--- a/src/Rules/AfferentCouplingRule.php
+++ b/src/Rules/AfferentCouplingRule.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Rules;
+
+use Override;
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\CollectedDataNode;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+
+/**
+ * Reports classes exceeding the afferent coupling (Ca) threshold.
+ *
+ * Afferent coupling counts how many other classes in the analysed codebase depend on a given class.
+ * Classes with high Ca become change bottlenecks: every modification risks breaking many downstream consumers.
+ * Dependency data is produced by {@see \Haspadar\PHPStanRules\Collectors\ClassDependencyCollector} and inverted here into an incoming-edge graph.
+ *
+ * This is the initial skeleton that wires the collector into the rule pipeline without emitting errors yet.
+ * Threshold checks will be introduced in follow-up changes.
+ *
+ * @implements Rule<CollectedDataNode>
+ */
+final readonly class AfferentCouplingRule implements Rule
+{
+    #[Override]
+    public function getNodeType(): string
+    {
+        return CollectedDataNode::class;
+    }
+
+    /**
+     * Collects dependency tuples and returns no errors.
+     *
+     * @return list<IdentifierRuleError>
+     */
+    #[Override]
+    public function processNode(Node $node, Scope $scope): array
+    {
+        return [];
+    }
+}

--- a/tests/Fixtures/Rules/AfferentCouplingRule/FewAfferent.php
+++ b/tests/Fixtures/Rules/AfferentCouplingRule/FewAfferent.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\AfferentCouplingRule\FewAfferent;
+
+final class Target
+{
+}
+
+final class UserA
+{
+    public function __construct(private readonly Target $target)
+    {
+    }
+}
+
+final class UserB
+{
+    public function __construct(private readonly Target $target)
+    {
+    }
+}

--- a/tests/Fixtures/Rules/AfferentCouplingRule/FewAfferent.php
+++ b/tests/Fixtures/Rules/AfferentCouplingRule/FewAfferent.php
@@ -79,3 +79,14 @@ final class UserC
         };
     }
 }
+
+enum TargetKind: string implements TargetContract
+{
+    case Primary = 'primary';
+    case Secondary = 'secondary';
+
+    public function tag(): string
+    {
+        return $this->value;
+    }
+}

--- a/tests/Fixtures/Rules/AfferentCouplingRule/FewAfferent.php
+++ b/tests/Fixtures/Rules/AfferentCouplingRule/FewAfferent.php
@@ -4,8 +4,41 @@ declare(strict_types=1);
 
 namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\AfferentCouplingRule\FewAfferent;
 
-final class Target
+interface TargetContract
 {
+    public function tag(): string;
+}
+
+interface Taggable extends TargetContract
+{
+}
+
+trait Stampable
+{
+    public function stamp(): string
+    {
+        return 'stamp';
+    }
+}
+
+abstract class BaseTarget implements Taggable
+{
+    use Stampable;
+
+    public function tag(): string
+    {
+        return 'base';
+    }
+}
+
+final class Target extends BaseTarget
+{
+    public Taggable $sibling;
+
+    public static function make(): self
+    {
+        return new \Haspadar\PHPStanRules\Tests\Fixtures\Rules\AfferentCouplingRule\FewAfferent\Target();
+    }
 }
 
 final class UserA
@@ -13,11 +46,36 @@ final class UserA
     public function __construct(private readonly Target $target)
     {
     }
+
+    public function handle(self $same, int $count): ?Target
+    {
+        $copy = new Target();
+
+        return $count > 0 ? $copy : $this->target;
+    }
 }
 
 final class UserB
 {
     public function __construct(private readonly Target $target)
     {
+    }
+
+    public function describe(Target $other): string
+    {
+        return $other === $this->target ? 'same' : 'other';
+    }
+}
+
+final class UserC
+{
+    public function wrap(): Taggable
+    {
+        return new class implements Taggable {
+            public function tag(): string
+            {
+                return 'anon';
+            }
+        };
     }
 }

--- a/tests/Unit/Rules/AfferentCouplingRule/AfferentCouplingRuleTest.php
+++ b/tests/Unit/Rules/AfferentCouplingRule/AfferentCouplingRuleTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\AfferentCouplingRule;
+
+use Haspadar\PHPStanRules\Collectors\ClassDependencyCollector;
+use Haspadar\PHPStanRules\Rules\AfferentCouplingRule;
+use Override;
+use PHPStan\Collectors\Collector;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<AfferentCouplingRule> */
+final class AfferentCouplingRuleTest extends RuleTestCase
+{
+    #[Override]
+    protected function getRule(): Rule
+    {
+        return new AfferentCouplingRule();
+    }
+
+    /**
+     * Registers the dependency collector so PHPStan feeds the rule with cross-file dependency data.
+     *
+     * @return list<Collector<\PhpParser\Node, mixed>>
+     */
+    #[Override]
+    protected function getCollectors(): array
+    {
+        return [new ClassDependencyCollector()];
+    }
+
+    #[Test]
+    public function collectorAndRuleWireUpWithoutErrors(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/AfferentCouplingRule/FewAfferent.php'],
+            [],
+            'Stub rule must not emit errors; pipeline wiring is the only thing being verified',
+        );
+    }
+}

--- a/tests/Unit/RulesTest.php
+++ b/tests/Unit/RulesTest.php
@@ -55,6 +55,7 @@ use Haspadar\PHPStanRules\Rules\NeverAcceptNullArgumentsRule;
 use Haspadar\PHPStanRules\Rules\NeverReturnNullRule;
 use Haspadar\PHPStanRules\Rules\NeverUsePublicConstantsRule;
 use Haspadar\PHPStanRules\Rules\WeightedMethodsPerClassRule;
+use Haspadar\PHPStanRules\Rules\AfferentCouplingRule;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -115,6 +116,7 @@ final class RulesTest extends TestCase
                 NeverReturnNullRule::class,
                 NeverUsePublicConstantsRule::class,
                 WeightedMethodsPerClassRule::class,
+                AfferentCouplingRule::class,
             ],
             (new Rules())->all(),
             'Rules::all() must list every registered rule class',


### PR DESCRIPTION
- Added ClassDependencyCollector that emits per-class dependency tuples
- Added AfferentCouplingRule skeleton wired through rules.neon and Rules registry
- Added baseline smoke test verifying collector and rule integrate without errors

Part of #127

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new PHPStan rule to analyze and report on afferent coupling (incoming dependencies) for classes
  * Includes an automated dependency collector that extracts and normalizes class relationships across your codebase
  * Configuration updated to integrate the new rule into the PHPStan analysis pipeline

<!-- end of auto-generated comment: release notes by coderabbit.ai -->