### PR TITLE
Afferent Coupling Threshold Rule

### DIFF
--- a/rules.neon
+++ b/rules.neon
@@ -105,6 +105,8 @@ parameters:
                 - Information
                 - Wrapper
             allowedSuffixes: []
+        afferentCoupling:
+            maxAfferent: 14
 
 parametersSchema:
     haspadar: structure([
@@ -210,6 +212,9 @@ parametersSchema:
         forbiddenClassSuffix: structure([
             forbiddenSuffixes: listOf(string()),
             allowedSuffixes: listOf(string()),
+        ]),
+        afferentCoupling: structure([
+            maxAfferent: int(),
         ]),
     ])
 
@@ -513,5 +518,7 @@ services:
             - phpstan.collector
     -
         class: Haspadar\PHPStanRules\Rules\AfferentCouplingRule
+        arguments:
+            maxAfferent: %haspadar.afferentCoupling.maxAfferent%
         tags:
             - phpstan.rules.rule

--- a/src/Rules/AfferentCouplingRule.php
+++ b/src/Rules/AfferentCouplingRule.php
@@ -4,27 +4,32 @@ declare(strict_types=1);
 
 namespace Haspadar\PHPStanRules\Rules;
 
+use Haspadar\PHPStanRules\Collectors\ClassDependencyCollector;
 use Override;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Node\CollectedDataNode;
 use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\ShouldNotHappenException;
 
 /**
  * Reports classes exceeding the afferent coupling (Ca) threshold.
  *
  * Afferent coupling counts how many other classes in the analysed codebase depend on a given class.
  * Classes with high Ca become change bottlenecks: every modification risks breaking many downstream consumers.
- * Dependency data is produced by {@see \Haspadar\PHPStanRules\Collectors\ClassDependencyCollector} and inverted here into an incoming-edge graph.
- *
- * This is the initial skeleton that wires the collector into the rule pipeline without emitting errors yet.
- * Threshold checks will be introduced in follow-up changes.
+ * Dependency data is produced by {@see \Haspadar\PHPStanRules\Collectors\ClassDependencyCollector} and inverted
+ * here into an incoming-edge graph: for every collected declaration we count how many distinct consumers list
+ * it among their outbound dependencies, and emit an error when the count exceeds `$maxAfferent`.
  *
  * @implements Rule<CollectedDataNode>
  */
 final readonly class AfferentCouplingRule implements Rule
 {
+    /** Stores the inclusive upper bound on afferent coupling per class. */
+    public function __construct(private int $maxAfferent = 14) {}
+
     #[Override]
     public function getNodeType(): string
     {
@@ -32,13 +37,85 @@ final readonly class AfferentCouplingRule implements Rule
     }
 
     /**
-     * Collects dependency tuples and returns no errors.
+     * Inverts the dependency graph and reports classes whose incoming edge count exceeds the threshold.
      *
+     * @param CollectedDataNode $node
+     * @throws ShouldNotHappenException
      * @return list<IdentifierRuleError>
      */
     #[Override]
     public function processNode(Node $node, Scope $scope): array
     {
-        return [];
+        [$declarations, $incoming] = $this->buildGraph($this->readCollected($node));
+        $errors = [];
+
+        foreach ($declarations as $lowerFqcn => $meta) {
+            $afferent = count($incoming[$lowerFqcn] ?? []);
+
+            if ($afferent <= $this->maxAfferent) {
+                continue;
+            }
+
+            $errors[] = $this->buildError($meta, $afferent);
+        }
+
+        return $errors;
+    }
+
+    /**
+     * Reads the dependency-collector payload from the CollectedDataNode wired for this rule.
+     *
+     * @return array<string, list<array{class: string, kind: string, abstract: bool, line: int, dependencies: list<string>}>>
+     */
+    private function readCollected(CollectedDataNode $node): array
+    {
+        return $node->get(ClassDependencyCollector::class);
+    }
+
+    /**
+     * Returns a pair of maps: declarations keyed by lowercased FQCN and incoming edges keyed by target FQCN.
+     *
+     * @param array<string, list<array{class: string, kind: string, abstract: bool, line: int, dependencies: list<string>}>> $collected
+     * @return array{array<string, array{class: string, file: string, line: int}>, array<string, array<string, true>>}
+     */
+    private function buildGraph(array $collected): array
+    {
+        $declarations = [];
+        $incoming = [];
+
+        foreach ($collected as $file => $entries) {
+            foreach ($entries as $entry) {
+                $lowerFqcn = strtolower($entry['class']);
+                $declarations[$lowerFqcn] = ['class' => $entry['class'], 'file' => $file, 'line' => $entry['line']];
+
+                foreach ($entry['dependencies'] as $dependency) {
+                    $incoming[$dependency][$lowerFqcn] = true;
+                }
+            }
+        }
+
+        return [$declarations, $incoming];
+    }
+
+    /**
+     * Builds the rule error payload for a single target class.
+     *
+     * @param array{class: string, file: string, line: int} $meta
+     * @throws ShouldNotHappenException
+     */
+    private function buildError(array $meta, int $afferent): IdentifierRuleError
+    {
+        return RuleErrorBuilder::message(
+            sprintf(
+                'Class %s has afferent coupling %d which exceeds the allowed %d.',
+                $meta['class'],
+                $afferent,
+                $this->maxAfferent,
+            ),
+        )
+            ->identifier('haspadar.afferentCoupling')
+            ->file($meta['file'])
+            ->line($meta['line'])
+            ->build();
     }
 }

--- a/tests/Fixtures/Rules/AfferentCouplingRule/ExactAfferent.php
+++ b/tests/Fixtures/Rules/AfferentCouplingRule/ExactAfferent.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\AfferentCouplingRule\ExactAfferent;
+
+final class ExactTarget
+{
+    public function ping(): string
+    {
+        return 'pong';
+    }
+}
+
+final class C01 { public function use(ExactTarget $t): string { return $t->ping(); } }
+final class C02 { public function use(ExactTarget $t): string { return $t->ping(); } }
+final class C03 { public function use(ExactTarget $t): string { return $t->ping(); } }
+final class C04 { public function use(ExactTarget $t): string { return $t->ping(); } }
+final class C05 { public function use(ExactTarget $t): string { return $t->ping(); } }
+final class C06 { public function use(ExactTarget $t): string { return $t->ping(); } }
+final class C07 { public function use(ExactTarget $t): string { return $t->ping(); } }
+final class C08 { public function use(ExactTarget $t): string { return $t->ping(); } }
+final class C09 { public function use(ExactTarget $t): string { return $t->ping(); } }
+final class C10 { public function use(ExactTarget $t): string { return $t->ping(); } }
+final class C11 { public function use(ExactTarget $t): string { return $t->ping(); } }
+final class C12 { public function use(ExactTarget $t): string { return $t->ping(); } }
+final class C13 { public function use(ExactTarget $t): string { return $t->ping(); } }
+final class C14 { public function use(ExactTarget $t): string { return $t->ping(); } }

--- a/tests/Fixtures/Rules/AfferentCouplingRule/SmallLimitTooMany.php
+++ b/tests/Fixtures/Rules/AfferentCouplingRule/SmallLimitTooMany.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\AfferentCouplingRule\SmallLimitTooMany;
+
+final class HotTarget
+{
+    public function ping(): string
+    {
+        return 'pong';
+    }
+}
+
+final class ConsumerOne
+{
+    public function use(HotTarget $target): string
+    {
+        return $target->ping();
+    }
+}
+
+final class ConsumerTwo
+{
+    public function use(HotTarget $target): string
+    {
+        return $target->ping();
+    }
+}
+
+final class ConsumerThree
+{
+    public function use(HotTarget $target): string
+    {
+        return $target->ping();
+    }
+}

--- a/tests/Fixtures/Rules/AfferentCouplingRule/SuppressedTooMany.php
+++ b/tests/Fixtures/Rules/AfferentCouplingRule/SuppressedTooMany.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\AfferentCouplingRule\SuppressedTooMany;
+
+/** @phpstan-ignore haspadar.afferentCoupling */
+final class SuppressedHotTarget
+{
+    public function ping(): string
+    {
+        return 'pong';
+    }
+}
+
+final class C01 { public function use(SuppressedHotTarget $t): string { return $t->ping(); } }
+final class C02 { public function use(SuppressedHotTarget $t): string { return $t->ping(); } }
+final class C03 { public function use(SuppressedHotTarget $t): string { return $t->ping(); } }
+final class C04 { public function use(SuppressedHotTarget $t): string { return $t->ping(); } }
+final class C05 { public function use(SuppressedHotTarget $t): string { return $t->ping(); } }
+final class C06 { public function use(SuppressedHotTarget $t): string { return $t->ping(); } }
+final class C07 { public function use(SuppressedHotTarget $t): string { return $t->ping(); } }
+final class C08 { public function use(SuppressedHotTarget $t): string { return $t->ping(); } }
+final class C09 { public function use(SuppressedHotTarget $t): string { return $t->ping(); } }
+final class C10 { public function use(SuppressedHotTarget $t): string { return $t->ping(); } }
+final class C11 { public function use(SuppressedHotTarget $t): string { return $t->ping(); } }
+final class C12 { public function use(SuppressedHotTarget $t): string { return $t->ping(); } }
+final class C13 { public function use(SuppressedHotTarget $t): string { return $t->ping(); } }
+final class C14 { public function use(SuppressedHotTarget $t): string { return $t->ping(); } }
+final class C15 { public function use(SuppressedHotTarget $t): string { return $t->ping(); } }

--- a/tests/Fixtures/Rules/AfferentCouplingRule/TooManyAfferent.php
+++ b/tests/Fixtures/Rules/AfferentCouplingRule/TooManyAfferent.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\AfferentCouplingRule\TooManyAfferent;
+
+final class HotTarget
+{
+    public function ping(): string
+    {
+        return 'pong';
+    }
+}
+
+final class C01 { public function use(HotTarget $t): string { return $t->ping(); } }
+final class C02 { public function use(HotTarget $t): string { return $t->ping(); } }
+final class C03 { public function use(HotTarget $t): string { return $t->ping(); } }
+final class C04 { public function use(HotTarget $t): string { return $t->ping(); } }
+final class C05 { public function use(HotTarget $t): string { return $t->ping(); } }
+final class C06 { public function use(HotTarget $t): string { return $t->ping(); } }
+final class C07 { public function use(HotTarget $t): string { return $t->ping(); } }
+final class C08 { public function use(HotTarget $t): string { return $t->ping(); } }
+final class C09 { public function use(HotTarget $t): string { return $t->ping(); } }
+final class C10 { public function use(HotTarget $t): string { return $t->ping(); } }
+final class C11 { public function use(HotTarget $t): string { return $t->ping(); } }
+final class C12 { public function use(HotTarget $t): string { return $t->ping(); } }
+final class C13 { public function use(HotTarget $t): string { return $t->ping(); } }
+final class C14 { public function use(HotTarget $t): string { return $t->ping(); } }
+final class C15 { public function use(HotTarget $t): string { return $t->ping(); } }

--- a/tests/Unit/Rules/AfferentCouplingRule/AfferentCouplingRuleDefaultLimitTest.php
+++ b/tests/Unit/Rules/AfferentCouplingRule/AfferentCouplingRuleDefaultLimitTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\AfferentCouplingRule;
+
+use Haspadar\PHPStanRules\Collectors\ClassDependencyCollector;
+use Haspadar\PHPStanRules\Rules\AfferentCouplingRule;
+use Override;
+use PHPStan\Collectors\Collector;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<AfferentCouplingRule> */
+final class AfferentCouplingRuleDefaultLimitTest extends RuleTestCase
+{
+    #[Override]
+    protected function getRule(): Rule
+    {
+        return new AfferentCouplingRule();
+    }
+
+    /**
+     * Registers the dependency collector so PHPStan feeds the rule with cross-file dependency data.
+     *
+     * @return list<Collector<\PhpParser\Node, mixed>>
+     */
+    #[Override]
+    protected function getCollectors(): array
+    {
+        return [new ClassDependencyCollector()];
+    }
+
+    #[Test]
+    public function passesWhenAfferentCouplingFitsWithinDefault(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/AfferentCouplingRule/FewAfferent.php'],
+            [],
+            'Codebase with only a handful of consumers must not trigger the default afferent limit',
+        );
+    }
+
+    #[Test]
+    public function passesWhenAfferentCouplingIsExactlyAtDefault(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/AfferentCouplingRule/ExactAfferent.php'],
+            [],
+            'Ca == 14 must not trigger the default limit',
+        );
+    }
+
+    #[Test]
+    public function reportsClassesExceedingDefaultLimit(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/AfferentCouplingRule/TooManyAfferent.php'],
+            [
+                [
+                    'Class Haspadar\PHPStanRules\Tests\Fixtures\Rules\AfferentCouplingRule\TooManyAfferent\HotTarget has afferent coupling 15 which exceeds the allowed 14.',
+                    7,
+                ],
+            ],
+            'Ca == 15 must trigger the default limit of 14',
+        );
+    }
+
+    #[Test]
+    public function suppressesErrorWhenPhpstanIgnorePresent(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/AfferentCouplingRule/SuppressedTooMany.php'],
+            [],
+            '@phpstan-ignore haspadar.afferentCoupling must suppress the error',
+        );
+    }
+}

--- a/tests/Unit/Rules/AfferentCouplingRule/AfferentCouplingRuleTest.php
+++ b/tests/Unit/Rules/AfferentCouplingRule/AfferentCouplingRuleTest.php
@@ -18,7 +18,7 @@ final class AfferentCouplingRuleTest extends RuleTestCase
     #[Override]
     protected function getRule(): Rule
     {
-        return new AfferentCouplingRule();
+        return new AfferentCouplingRule(maxAfferent: 2);
     }
 
     /**
@@ -33,12 +33,17 @@ final class AfferentCouplingRuleTest extends RuleTestCase
     }
 
     #[Test]
-    public function collectorAndRuleWireUpWithoutErrors(): void
+    public function reportsClassesExceedingExplicitLimit(): void
     {
         $this->analyse(
-            [__DIR__ . '/../../../Fixtures/Rules/AfferentCouplingRule/FewAfferent.php'],
-            [],
-            'Stub rule must not emit errors; pipeline wiring is the only thing being verified',
+            [__DIR__ . '/../../../Fixtures/Rules/AfferentCouplingRule/SmallLimitTooMany.php'],
+            [
+                [
+                    'Class Haspadar\PHPStanRules\Tests\Fixtures\Rules\AfferentCouplingRule\SmallLimitTooMany\HotTarget has afferent coupling 3 which exceeds the allowed 2.',
+                    7,
+                ],
+            ],
+            'Class with three consumers must exceed an explicit maxAfferent=2 limit',
         );
     }
 }


### PR DESCRIPTION
- Added AfferentCouplingRule that reports classes whose incoming dependency count exceeds maxAfferent
- Added rules.neon wiring for maxAfferent (default 14) with parameters schema
- Added fixtures covering explicit-limit, default-boundary, default-violation, and phpstan-ignore paths

Part of #127

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new afferent coupling rule that identifies classes receiving excessive incoming dependencies.
  * Configurable threshold for maximum allowed consumers per class (default: 14).
  * Support for error suppression via `@phpstan-ignore` annotations.

* **Tests**
  * Added comprehensive test suite with fixtures and cases covering default limits, custom thresholds, and suppression scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->