### PR TITLE
Afferent Coupling Ignore Options For Interfaces And Abstract Classes

### DIFF
--- a/rules.neon
+++ b/rules.neon
@@ -107,6 +107,8 @@ parameters:
             allowedSuffixes: []
         afferentCoupling:
             maxAfferent: 14
+            ignoreInterfaces: false
+            ignoreAbstract: false
 
 parametersSchema:
     haspadar: structure([
@@ -215,6 +217,8 @@ parametersSchema:
         ]),
         afferentCoupling: structure([
             maxAfferent: int(),
+            ignoreInterfaces: bool(),
+            ignoreAbstract: bool(),
         ]),
     ])
 
@@ -520,5 +524,8 @@ services:
         class: Haspadar\PHPStanRules\Rules\AfferentCouplingRule
         arguments:
             maxAfferent: %haspadar.afferentCoupling.maxAfferent%
+            options:
+                ignoreInterfaces: %haspadar.afferentCoupling.ignoreInterfaces%
+                ignoreAbstract: %haspadar.afferentCoupling.ignoreAbstract%
         tags:
             - phpstan.rules.rule

--- a/src/Rules/AfferentCouplingRule.php
+++ b/src/Rules/AfferentCouplingRule.php
@@ -23,12 +23,30 @@ use PHPStan\ShouldNotHappenException;
  * here into an incoming-edge graph: for every collected declaration we count how many distinct consumers list
  * it among their outbound dependencies, and emit an error when the count exceeds `$maxAfferent`.
  *
+ * The `ignoreInterfaces` and `ignoreAbstract` option flags skip reporting for interfaces and abstract classes,
+ * which are expected to be widely implemented or extended by design.
+ *
  * @implements Rule<CollectedDataNode>
  */
 final readonly class AfferentCouplingRule implements Rule
 {
-    /** Stores the inclusive upper bound on afferent coupling per class. */
-    public function __construct(private int $maxAfferent = 14) {}
+    private bool $ignoreInterfaces;
+
+    private bool $ignoreAbstract;
+
+    /**
+     * Stores the inclusive upper bound on afferent coupling per class and the skip flags.
+     *
+     * @param array{
+     *     ignoreInterfaces?: bool,
+     *     ignoreAbstract?: bool
+     * } $options
+     */
+    public function __construct(private int $maxAfferent = 14, array $options = [])
+    {
+        $this->ignoreInterfaces = $options['ignoreInterfaces'] ?? false;
+        $this->ignoreAbstract = $options['ignoreAbstract'] ?? false;
+    }
 
     #[Override]
     public function getNodeType(): string
@@ -50,6 +68,10 @@ final readonly class AfferentCouplingRule implements Rule
         $errors = [];
 
         foreach ($declarations as $lowerFqcn => $meta) {
+            if ($this->shouldSkip($meta)) {
+                continue;
+            }
+
             $afferent = count($incoming[$lowerFqcn] ?? []);
 
             if ($afferent <= $this->maxAfferent) {
@@ -76,7 +98,7 @@ final readonly class AfferentCouplingRule implements Rule
      * Returns a pair of maps: declarations keyed by lowercased FQCN and incoming edges keyed by target FQCN.
      *
      * @param array<string, list<array{class: string, kind: string, abstract: bool, line: int, dependencies: list<string>}>> $collected
-     * @return array{array<string, array{class: string, file: string, line: int}>, array<string, array<string, true>>}
+     * @return array{array<string, array{class: string, kind: string, abstract: bool, file: string, line: int}>, array<string, array<string, true>>}
      */
     private function buildGraph(array $collected): array
     {
@@ -86,7 +108,13 @@ final readonly class AfferentCouplingRule implements Rule
         foreach ($collected as $file => $entries) {
             foreach ($entries as $entry) {
                 $lowerFqcn = strtolower($entry['class']);
-                $declarations[$lowerFqcn] = ['class' => $entry['class'], 'file' => $file, 'line' => $entry['line']];
+                $declarations[$lowerFqcn] = [
+                    'class' => $entry['class'],
+                    'kind' => $entry['kind'],
+                    'abstract' => $entry['abstract'],
+                    'file' => $file,
+                    'line' => $entry['line'],
+                ];
 
                 foreach ($entry['dependencies'] as $dependency) {
                     $incoming[$dependency][$lowerFqcn] = true;
@@ -98,9 +126,23 @@ final readonly class AfferentCouplingRule implements Rule
     }
 
     /**
+     * Returns true when the declaration must be skipped due to configured ignore flags.
+     *
+     * @param array{class: string, kind: string, abstract: bool, file: string, line: int} $meta
+     */
+    private function shouldSkip(array $meta): bool
+    {
+        if ($this->ignoreInterfaces && $meta['kind'] === 'interface') {
+            return true;
+        }
+
+        return $this->ignoreAbstract && $meta['abstract'];
+    }
+
+    /**
      * Builds the rule error payload for a single target class.
      *
-     * @param array{class: string, file: string, line: int} $meta
+     * @param array{class: string, kind: string, abstract: bool, file: string, line: int} $meta
      * @throws ShouldNotHappenException
      */
     private function buildError(array $meta, int $afferent): IdentifierRuleError

--- a/tests/Fixtures/Rules/AfferentCouplingRule/AbstractWithManyAfferent.php
+++ b/tests/Fixtures/Rules/AfferentCouplingRule/AbstractWithManyAfferent.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\AfferentCouplingRule\AbstractWithManyAfferent;
+
+abstract class HotAbstract
+{
+    public function ping(): string
+    {
+        return 'pong';
+    }
+}
+
+final class ConsumerAlpha
+{
+    public function use(HotAbstract $target): string
+    {
+        return $target->ping();
+    }
+}
+
+final class ConsumerBeta
+{
+    public function use(HotAbstract $target): string
+    {
+        return $target->ping();
+    }
+}
+
+final class ConsumerGamma
+{
+    public function use(HotAbstract $target): string
+    {
+        return $target->ping();
+    }
+}

--- a/tests/Fixtures/Rules/AfferentCouplingRule/InterfaceWithManyAfferent.php
+++ b/tests/Fixtures/Rules/AfferentCouplingRule/InterfaceWithManyAfferent.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\AfferentCouplingRule\InterfaceWithManyAfferent;
+
+interface HotInterface
+{
+    public function ping(): string;
+}
+
+final class ImplementorOne implements HotInterface
+{
+    public function ping(): string
+    {
+        return 'one';
+    }
+}
+
+final class ImplementorTwo implements HotInterface
+{
+    public function ping(): string
+    {
+        return 'two';
+    }
+}
+
+final class ImplementorThree implements HotInterface
+{
+    public function ping(): string
+    {
+        return 'three';
+    }
+}

--- a/tests/Unit/Rules/AfferentCouplingRule/AfferentCouplingRuleAbstractFixtureControlTest.php
+++ b/tests/Unit/Rules/AfferentCouplingRule/AfferentCouplingRuleAbstractFixtureControlTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\AfferentCouplingRule;
+
+use Haspadar\PHPStanRules\Collectors\ClassDependencyCollector;
+use Haspadar\PHPStanRules\Rules\AfferentCouplingRule;
+use Override;
+use PHPStan\Collectors\Collector;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Control test for the abstract-class fixture: proves it triggers the rule when ignoreAbstract is disabled.
+ *
+ * @extends RuleTestCase<AfferentCouplingRule>
+ */
+final class AfferentCouplingRuleAbstractFixtureControlTest extends RuleTestCase
+{
+    #[Override]
+    protected function getRule(): Rule
+    {
+        return new AfferentCouplingRule(maxAfferent: 2);
+    }
+
+    /**
+     * Registers the dependency collector so PHPStan feeds the rule with cross-file dependency data.
+     *
+     * @return list<Collector<\PhpParser\Node, mixed>>
+     */
+    #[Override]
+    protected function getCollectors(): array
+    {
+        return [new ClassDependencyCollector()];
+    }
+
+    #[Test]
+    public function reportsAbstractFixtureWhenIgnoreAbstractDisabled(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/AfferentCouplingRule/AbstractWithManyAfferent.php'],
+            [
+                [
+                    'Class Haspadar\PHPStanRules\Tests\Fixtures\Rules\AfferentCouplingRule\AbstractWithManyAfferent\HotAbstract has afferent coupling 3 which exceeds the allowed 2.',
+                    7,
+                ],
+            ],
+            'Abstract-class fixture with three consumers must be reported when ignoreAbstract is disabled',
+        );
+    }
+}

--- a/tests/Unit/Rules/AfferentCouplingRule/AfferentCouplingRuleIgnoreAbstractTest.php
+++ b/tests/Unit/Rules/AfferentCouplingRule/AfferentCouplingRuleIgnoreAbstractTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\AfferentCouplingRule;
+
+use Haspadar\PHPStanRules\Collectors\ClassDependencyCollector;
+use Haspadar\PHPStanRules\Rules\AfferentCouplingRule;
+use Override;
+use PHPStan\Collectors\Collector;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<AfferentCouplingRule> */
+final class AfferentCouplingRuleIgnoreAbstractTest extends RuleTestCase
+{
+    #[Override]
+    protected function getRule(): Rule
+    {
+        return new AfferentCouplingRule(maxAfferent: 2, options: ['ignoreAbstract' => true]);
+    }
+
+    /**
+     * Registers the dependency collector so PHPStan feeds the rule with cross-file dependency data.
+     *
+     * @return list<Collector<\PhpParser\Node, mixed>>
+     */
+    #[Override]
+    protected function getCollectors(): array
+    {
+        return [new ClassDependencyCollector()];
+    }
+
+    #[Test]
+    public function skipsAbstractClassesWhenIgnoreAbstractEnabled(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/AfferentCouplingRule/AbstractWithManyAfferent.php'],
+            [],
+            'Abstract class with Ca above the limit must be skipped when ignoreAbstract=true',
+        );
+    }
+
+    #[Test]
+    public function stillReportsConcreteClassesWhenIgnoreAbstractEnabled(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/AfferentCouplingRule/SmallLimitTooMany.php'],
+            [
+                [
+                    'Class Haspadar\PHPStanRules\Tests\Fixtures\Rules\AfferentCouplingRule\SmallLimitTooMany\HotTarget has afferent coupling 3 which exceeds the allowed 2.',
+                    7,
+                ],
+            ],
+            'Concrete classes must still be reported when ignoreAbstract=true',
+        );
+    }
+}

--- a/tests/Unit/Rules/AfferentCouplingRule/AfferentCouplingRuleIgnoreInterfacesTest.php
+++ b/tests/Unit/Rules/AfferentCouplingRule/AfferentCouplingRuleIgnoreInterfacesTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\AfferentCouplingRule;
+
+use Haspadar\PHPStanRules\Collectors\ClassDependencyCollector;
+use Haspadar\PHPStanRules\Rules\AfferentCouplingRule;
+use Override;
+use PHPStan\Collectors\Collector;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<AfferentCouplingRule> */
+final class AfferentCouplingRuleIgnoreInterfacesTest extends RuleTestCase
+{
+    #[Override]
+    protected function getRule(): Rule
+    {
+        return new AfferentCouplingRule(maxAfferent: 2, options: ['ignoreInterfaces' => true]);
+    }
+
+    /**
+     * Registers the dependency collector so PHPStan feeds the rule with cross-file dependency data.
+     *
+     * @return list<Collector<\PhpParser\Node, mixed>>
+     */
+    #[Override]
+    protected function getCollectors(): array
+    {
+        return [new ClassDependencyCollector()];
+    }
+
+    #[Test]
+    public function skipsInterfacesWhenIgnoreInterfacesEnabled(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/AfferentCouplingRule/InterfaceWithManyAfferent.php'],
+            [],
+            'Interface with Ca above the limit must be skipped when ignoreInterfaces=true',
+        );
+    }
+
+    #[Test]
+    public function stillReportsRegularClassesWhenIgnoreInterfacesEnabled(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/AfferentCouplingRule/SmallLimitTooMany.php'],
+            [
+                [
+                    'Class Haspadar\PHPStanRules\Tests\Fixtures\Rules\AfferentCouplingRule\SmallLimitTooMany\HotTarget has afferent coupling 3 which exceeds the allowed 2.',
+                    7,
+                ],
+            ],
+            'Regular classes must still be reported when ignoreInterfaces=true',
+        );
+    }
+}

--- a/tests/Unit/Rules/AfferentCouplingRule/AfferentCouplingRuleInterfaceFixtureControlTest.php
+++ b/tests/Unit/Rules/AfferentCouplingRule/AfferentCouplingRuleInterfaceFixtureControlTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\AfferentCouplingRule;
+
+use Haspadar\PHPStanRules\Collectors\ClassDependencyCollector;
+use Haspadar\PHPStanRules\Rules\AfferentCouplingRule;
+use Override;
+use PHPStan\Collectors\Collector;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Control test for the interface fixture: proves it triggers the rule when ignoreInterfaces is disabled.
+ *
+ * @extends RuleTestCase<AfferentCouplingRule>
+ */
+final class AfferentCouplingRuleInterfaceFixtureControlTest extends RuleTestCase
+{
+    #[Override]
+    protected function getRule(): Rule
+    {
+        return new AfferentCouplingRule(maxAfferent: 2);
+    }
+
+    /**
+     * Registers the dependency collector so PHPStan feeds the rule with cross-file dependency data.
+     *
+     * @return list<Collector<\PhpParser\Node, mixed>>
+     */
+    #[Override]
+    protected function getCollectors(): array
+    {
+        return [new ClassDependencyCollector()];
+    }
+
+    #[Test]
+    public function reportsInterfaceFixtureWhenIgnoreInterfacesDisabled(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/AfferentCouplingRule/InterfaceWithManyAfferent.php'],
+            [
+                [
+                    'Class Haspadar\PHPStanRules\Tests\Fixtures\Rules\AfferentCouplingRule\InterfaceWithManyAfferent\HotInterface has afferent coupling 3 which exceeds the allowed 2.',
+                    7,
+                ],
+            ],
+            'Interface fixture with three implementors must be reported when ignoreInterfaces is disabled',
+        );
+    }
+}


### PR DESCRIPTION
- Added ignoreInterfaces and ignoreAbstract options to AfferentCouplingRule
- Added rules.neon parameters and schema for the new options
- Added fixtures with interface and abstract class targets for option coverage
- Added control tests proving fixtures trigger the rule when options are disabled

Part of #127

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added configurable options to the afferent coupling rule: `ignoreInterfaces` and `ignoreAbstract` flags to control whether interfaces and abstract classes should be excluded from afferent coupling checks.

## Tests
* Added comprehensive test coverage for the new configuration options and their behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->