### PR TITLE
Exclude Configured Classes From Afferent Coupling Reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 | `ClassLengthRule`                 | 500     | Class body must not exceed N lines                                         |
 | `StatementCountRule`              | 30      | Method must not have more than N executable statements                     |
 | `WeightedMethodsPerClassRule`     | 50      | Sum of cyclomatic complexities of all methods must not exceed N            |
+| `AfferentCouplingRule`            | 14      | Class must not be referenced by more than N other classes in the codebase  |
 
 ### Design
 
@@ -197,6 +198,12 @@ parameters:
             allowedSuffixes:
                 - EventHandler
                 - CommandHandler
+        afferentCoupling:
+            maxAfferent: 10
+            ignoreInterfaces: true
+            ignoreAbstract: true
+            excludedClasses:
+                - App\Kernel
 ```
 
 Default values match the defaults described in the rules table above. Omitting a parameter keeps the default. Diagnostic identifier for `AtclauseOrderRule`: `haspadar.atclauseOrder` (for targeted ignores, e.g. `@phpstan-ignore haspadar.atclauseOrder`).

--- a/rules.neon
+++ b/rules.neon
@@ -109,6 +109,7 @@ parameters:
             maxAfferent: 14
             ignoreInterfaces: false
             ignoreAbstract: false
+            excludedClasses: []
 
 parametersSchema:
     haspadar: structure([
@@ -219,6 +220,7 @@ parametersSchema:
             maxAfferent: int(),
             ignoreInterfaces: bool(),
             ignoreAbstract: bool(),
+            excludedClasses: listOf(string()),
         ]),
     ])
 
@@ -527,5 +529,6 @@ services:
             options:
                 ignoreInterfaces: %haspadar.afferentCoupling.ignoreInterfaces%
                 ignoreAbstract: %haspadar.afferentCoupling.ignoreAbstract%
+                excludedClasses: %haspadar.afferentCoupling.excludedClasses%
         tags:
             - phpstan.rules.rule

--- a/src/Rules/AfferentCouplingRule.php
+++ b/src/Rules/AfferentCouplingRule.php
@@ -24,7 +24,8 @@ use PHPStan\ShouldNotHappenException;
  * it among their outbound dependencies, and emit an error when the count exceeds `$maxAfferent`.
  *
  * The `ignoreInterfaces` and `ignoreAbstract` option flags skip reporting for interfaces and abstract classes,
- * which are expected to be widely implemented or extended by design.
+ * which are expected to be widely implemented or extended by design. The `excludedClasses` option lists
+ * FQCNs that must never be reported, regardless of their incoming edge count; matching is case-insensitive.
  *
  * @implements Rule<CollectedDataNode>
  */
@@ -34,18 +35,23 @@ final readonly class AfferentCouplingRule implements Rule
 
     private bool $ignoreAbstract;
 
+    /** @var list<string> Lowercased FQCNs that must never be reported. */
+    private array $excludedClasses;
+
     /**
-     * Stores the inclusive upper bound on afferent coupling per class and the skip flags.
+     * Stores the inclusive upper bound on afferent coupling per class, skip flags, and the exclusion list.
      *
      * @param array{
      *     ignoreInterfaces?: bool,
-     *     ignoreAbstract?: bool
+     *     ignoreAbstract?: bool,
+     *     excludedClasses?: list<string>
      * } $options
      */
     public function __construct(private int $maxAfferent = 14, array $options = [])
     {
         $this->ignoreInterfaces = $options['ignoreInterfaces'] ?? false;
         $this->ignoreAbstract = $options['ignoreAbstract'] ?? false;
+        $this->excludedClasses = array_map('strtolower', $options['excludedClasses'] ?? []);
     }
 
     #[Override]
@@ -126,7 +132,7 @@ final readonly class AfferentCouplingRule implements Rule
     }
 
     /**
-     * Returns true when the declaration must be skipped due to configured ignore flags.
+     * Returns true when the declaration must be skipped due to configured ignore flags or exclusion list.
      *
      * @param array{class: string, kind: string, abstract: bool, file: string, line: int} $meta
      */
@@ -136,7 +142,11 @@ final readonly class AfferentCouplingRule implements Rule
             return true;
         }
 
-        return $this->ignoreAbstract && $meta['abstract'];
+        if ($this->ignoreAbstract && $meta['abstract']) {
+            return true;
+        }
+
+        return in_array(strtolower($meta['class']), $this->excludedClasses, true);
     }
 
     /**

--- a/src/Rules/AfferentCouplingRule.php
+++ b/src/Rules/AfferentCouplingRule.php
@@ -51,7 +51,10 @@ final readonly class AfferentCouplingRule implements Rule
     {
         $this->ignoreInterfaces = $options['ignoreInterfaces'] ?? false;
         $this->ignoreAbstract = $options['ignoreAbstract'] ?? false;
-        $this->excludedClasses = array_map('strtolower', $options['excludedClasses'] ?? []);
+        $this->excludedClasses = array_map(
+            static fn(string $class): string => strtolower(ltrim($class, '\\')),
+            $options['excludedClasses'] ?? [],
+        );
     }
 
     #[Override]
@@ -146,7 +149,7 @@ final readonly class AfferentCouplingRule implements Rule
             return true;
         }
 
-        return in_array(strtolower($meta['class']), $this->excludedClasses, true);
+        return in_array(strtolower(ltrim($meta['class'], '\\')), $this->excludedClasses, true);
     }
 
     /**

--- a/tests/Fixtures/Rules/AfferentCouplingRule/ExcludedTarget.php
+++ b/tests/Fixtures/Rules/AfferentCouplingRule/ExcludedTarget.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\AfferentCouplingRule\ExcludedTarget;
+
+final class ExcludedHotTarget
+{
+    public function ping(): string
+    {
+        return 'pong';
+    }
+}
+
+final class ConsumerAlpha
+{
+    public function use(ExcludedHotTarget $target): string
+    {
+        return $target->ping();
+    }
+}
+
+final class ConsumerBeta
+{
+    public function use(ExcludedHotTarget $target): string
+    {
+        return $target->ping();
+    }
+}
+
+final class ConsumerGamma
+{
+    public function use(ExcludedHotTarget $target): string
+    {
+        return $target->ping();
+    }
+}

--- a/tests/Unit/Rules/AfferentCouplingRule/AfferentCouplingRuleExcludedClassesNormalizationTest.php
+++ b/tests/Unit/Rules/AfferentCouplingRule/AfferentCouplingRuleExcludedClassesNormalizationTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\AfferentCouplingRule;
+
+use Haspadar\PHPStanRules\Collectors\ClassDependencyCollector;
+use Haspadar\PHPStanRules\Rules\AfferentCouplingRule;
+use Override;
+use PHPStan\Collectors\Collector;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Verifies that excludedClasses entries are normalized: leading backslash stripped, case folded.
+ *
+ * @extends RuleTestCase<AfferentCouplingRule>
+ */
+final class AfferentCouplingRuleExcludedClassesNormalizationTest extends RuleTestCase
+{
+    #[Override]
+    protected function getRule(): Rule
+    {
+        return new AfferentCouplingRule(
+            maxAfferent: 2,
+            options: [
+                'excludedClasses' => [
+                    '\\HASPADAR\\phpstanrules\\Tests\\Fixtures\\Rules\\AfferentCouplingRule\\ExcludedTarget\\excludedHOTTarget',
+                ],
+            ],
+        );
+    }
+
+    /**
+     * Registers the dependency collector so PHPStan feeds the rule with cross-file dependency data.
+     *
+     * @return list<Collector<\PhpParser\Node, mixed>>
+     */
+    #[Override]
+    protected function getCollectors(): array
+    {
+        return [new ClassDependencyCollector()];
+    }
+
+    #[Test]
+    public function skipsClassWhenExcludedEntryHasLeadingBackslashAndMixedCase(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/AfferentCouplingRule/ExcludedTarget.php'],
+            [],
+            'excludedClasses must match regardless of leading backslash or case differences',
+        );
+    }
+}

--- a/tests/Unit/Rules/AfferentCouplingRule/AfferentCouplingRuleExcludedClassesTest.php
+++ b/tests/Unit/Rules/AfferentCouplingRule/AfferentCouplingRuleExcludedClassesTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\AfferentCouplingRule;
+
+use Haspadar\PHPStanRules\Collectors\ClassDependencyCollector;
+use Haspadar\PHPStanRules\Rules\AfferentCouplingRule;
+use Override;
+use PHPStan\Collectors\Collector;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<AfferentCouplingRule> */
+final class AfferentCouplingRuleExcludedClassesTest extends RuleTestCase
+{
+    #[Override]
+    protected function getRule(): Rule
+    {
+        return new AfferentCouplingRule(
+            maxAfferent: 2,
+            options: [
+                'excludedClasses' => [
+                    'Haspadar\\PHPStanRules\\Tests\\Fixtures\\Rules\\AfferentCouplingRule\\ExcludedTarget\\ExcludedHotTarget',
+                ],
+            ],
+        );
+    }
+
+    /**
+     * Registers the dependency collector so PHPStan feeds the rule with cross-file dependency data.
+     *
+     * @return list<Collector<\PhpParser\Node, mixed>>
+     */
+    #[Override]
+    protected function getCollectors(): array
+    {
+        return [new ClassDependencyCollector()];
+    }
+
+    #[Test]
+    public function skipsClassListedInExcludedClasses(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/AfferentCouplingRule/ExcludedTarget.php'],
+            [],
+            'Class in excludedClasses must never be reported even when Ca exceeds the limit',
+        );
+    }
+
+    #[Test]
+    public function stillReportsOtherClassesWhenExcludedClassesConfigured(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/AfferentCouplingRule/SmallLimitTooMany.php'],
+            [
+                [
+                    'Class Haspadar\PHPStanRules\Tests\Fixtures\Rules\AfferentCouplingRule\SmallLimitTooMany\HotTarget has afferent coupling 3 which exceeds the allowed 2.',
+                    7,
+                ],
+            ],
+            'Classes not listed in excludedClasses must still be reported',
+        );
+    }
+}

--- a/tests/Unit/Rules/AfferentCouplingRule/AfferentCouplingRuleExcludedFixtureControlTest.php
+++ b/tests/Unit/Rules/AfferentCouplingRule/AfferentCouplingRuleExcludedFixtureControlTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\AfferentCouplingRule;
+
+use Haspadar\PHPStanRules\Collectors\ClassDependencyCollector;
+use Haspadar\PHPStanRules\Rules\AfferentCouplingRule;
+use Override;
+use PHPStan\Collectors\Collector;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Control test for the excluded-target fixture: proves it triggers the rule when excludedClasses is empty.
+ *
+ * @extends RuleTestCase<AfferentCouplingRule>
+ */
+final class AfferentCouplingRuleExcludedFixtureControlTest extends RuleTestCase
+{
+    #[Override]
+    protected function getRule(): Rule
+    {
+        return new AfferentCouplingRule(maxAfferent: 2);
+    }
+
+    /**
+     * Registers the dependency collector so PHPStan feeds the rule with cross-file dependency data.
+     *
+     * @return list<Collector<\PhpParser\Node, mixed>>
+     */
+    #[Override]
+    protected function getCollectors(): array
+    {
+        return [new ClassDependencyCollector()];
+    }
+
+    #[Test]
+    public function reportsExcludedFixtureWhenExcludedClassesEmpty(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/AfferentCouplingRule/ExcludedTarget.php'],
+            [
+                [
+                    'Class Haspadar\PHPStanRules\Tests\Fixtures\Rules\AfferentCouplingRule\ExcludedTarget\ExcludedHotTarget has afferent coupling 3 which exceeds the allowed 2.',
+                    7,
+                ],
+            ],
+            'Excluded-target fixture with three consumers must be reported when excludedClasses is empty',
+        );
+    }
+}


### PR DESCRIPTION
- Added excludedClasses option that skips listed FQCNs from Ca reports
- Added case-insensitive matching with leading backslash tolerance
- Added control test proving excluded fixture triggers the rule without the option
- Added normalization test covering leading backslash and mixed case
- Updated README with the new rule entry and configuration example

Closes #127

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `excludedClasses` configuration option to the Afferent Coupling Rule, enabling developers to exclude specific classes from being analyzed for excessive incoming dependencies.

* **Documentation**
  * Updated README with configuration examples demonstrating how to use the new `excludedClasses` parameter to exclude framework and third-party classes from analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->