### PR TITLE
Report Classes Exceeding Inheritance Depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 | `StatementCountRule`              | 30      | Method must not have more than N executable statements                     |
 | `WeightedMethodsPerClassRule`     | 50      | Sum of cyclomatic complexities of all methods must not exceed N            |
 | `AfferentCouplingRule`            | 14      | Class must not be referenced by more than N other classes in the codebase  |
+| `InheritanceDepthRule`            | 3       | Class must not extend a chain of more than N ancestors                     |
 
 ### Design
 
@@ -204,6 +205,10 @@ parameters:
             ignoreAbstract: true
             excludedClasses:
                 - App\Kernel
+        inheritanceDepth:
+            maxDepth: 2
+            excludedClasses:
+                - Symfony\Bundle\FrameworkBundle\Controller\AbstractController
 ```
 
 Default values match the defaults described in the rules table above. Omitting a parameter keeps the default. Diagnostic identifier for `AtclauseOrderRule`: `haspadar.atclauseOrder` (for targeted ignores, e.g. `@phpstan-ignore haspadar.atclauseOrder`).

--- a/rules.neon
+++ b/rules.neon
@@ -110,6 +110,9 @@ parameters:
             ignoreInterfaces: false
             ignoreAbstract: false
             excludedClasses: []
+        inheritanceDepth:
+            maxDepth: 3
+            excludedClasses: []
 
 parametersSchema:
     haspadar: structure([
@@ -220,6 +223,10 @@ parametersSchema:
             maxAfferent: int(),
             ignoreInterfaces: bool(),
             ignoreAbstract: bool(),
+            excludedClasses: listOf(string()),
+        ]),
+        inheritanceDepth: structure([
+            maxDepth: int(),
             excludedClasses: listOf(string()),
         ]),
     ])
@@ -530,5 +537,13 @@ services:
                 ignoreInterfaces: %haspadar.afferentCoupling.ignoreInterfaces%
                 ignoreAbstract: %haspadar.afferentCoupling.ignoreAbstract%
                 excludedClasses: %haspadar.afferentCoupling.excludedClasses%
+        tags:
+            - phpstan.rules.rule
+    -
+        class: Haspadar\PHPStanRules\Rules\InheritanceDepthRule
+        arguments:
+            maxDepth: %haspadar.inheritanceDepth.maxDepth%
+            options:
+                excludedClasses: %haspadar.inheritanceDepth.excludedClasses%
         tags:
             - phpstan.rules.rule

--- a/src/Rules.php
+++ b/src/Rules.php
@@ -61,6 +61,7 @@ final class Rules
         Rules\NeverUsePublicConstantsRule::class,
         Rules\WeightedMethodsPerClassRule::class,
         Rules\AfferentCouplingRule::class,
+        Rules\InheritanceDepthRule::class,
     ];
 
     /**

--- a/src/Rules/InheritanceDepthRule.php
+++ b/src/Rules/InheritanceDepthRule.php
@@ -81,9 +81,7 @@ final readonly class InheritanceDepthRule implements Rule
             return [];
         }
 
-        if (!$this->reflectionProvider->hasClass($fqcn)) {
-            return [];
-        }
+        assert($this->reflectionProvider->hasClass($fqcn));
 
         $depth = count($this->reflectionProvider->getClass($fqcn)->getParents());
 

--- a/src/Rules/InheritanceDepthRule.php
+++ b/src/Rules/InheritanceDepthRule.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Rules;
+
+use Override;
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * Reports classes exceeding the configured inheritance depth (DIT).
+ *
+ * Depth is the number of `extends` ancestors from the analysed class up to the root: a class with no parent
+ * has depth 0, `class B extends A` gives B depth 1, and so on. Interfaces (`implements`) and traits (`use`)
+ * never contribute to the count. Anonymous classes are skipped because they cannot be named in configuration
+ * and rarely participate in multi-level hierarchies.
+ *
+ * The `excludedClasses` option lists FQCNs that must never be reported regardless of their depth; matching
+ * normalizes a leading backslash and is case-insensitive.
+ *
+ * @implements Rule<Class_>
+ */
+final readonly class InheritanceDepthRule implements Rule
+{
+    /** @var list<string> Normalized (lowercased, leading-backslash-stripped) FQCNs that must never be reported. */
+    private array $excludedClasses;
+
+    /**
+     * Stores the inclusive upper bound on inheritance depth and the exclusion list.
+     *
+     * @param array{
+     *     excludedClasses?: list<string>
+     * } $options
+     */
+    public function __construct(
+        private ReflectionProvider $reflectionProvider,
+        private int $maxDepth = 3,
+        array $options = [],
+    ) {
+        $this->excludedClasses = array_map(
+            static fn(string $class): string => strtolower(ltrim($class, '\\')),
+            $options['excludedClasses'] ?? [],
+        );
+    }
+
+    #[Override]
+    public function getNodeType(): string
+    {
+        return Class_::class;
+    }
+
+    /**
+     * Analyses the node and returns a list of errors.
+     *
+     * @psalm-param Class_ $node
+     * @return list<IdentifierRuleError>
+     */
+    #[Override]
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if ($node->name === null || $node->namespacedName === null) {
+            return [];
+        }
+
+        $fqcn = $node->namespacedName->toString();
+
+        if (in_array(strtolower($fqcn), $this->excludedClasses, true)) {
+            return [];
+        }
+
+        if (!$this->reflectionProvider->hasClass($fqcn)) {
+            return [];
+        }
+
+        $depth = count($this->reflectionProvider->getClass($fqcn)->getParents());
+
+        if ($depth <= $this->maxDepth) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message(
+                sprintf(
+                    'Class %s has inheritance depth %d which exceeds the allowed %d.',
+                    $node->name->toString(),
+                    $depth,
+                    $this->maxDepth,
+                ),
+            )
+                ->identifier('haspadar.inheritanceDepth')
+                ->build(),
+        ];
+    }
+}

--- a/src/Rules/InheritanceDepthRule.php
+++ b/src/Rules/InheritanceDepthRule.php
@@ -12,6 +12,7 @@ use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\ShouldNotHappenException;
 
 /**
  * Reports classes exceeding the configured inheritance depth (DIT).
@@ -32,11 +33,13 @@ final readonly class InheritanceDepthRule implements Rule
     private array $excludedClasses;
 
     /**
-     * Stores the inclusive upper bound on inheritance depth and the exclusion list.
+     * Stores the reflection provider, the inclusive upper bound on inheritance depth, and the exclusion list.
      *
+     * @param ReflectionProvider $reflectionProvider Resolves each analysed class to its inheritance chain
+     * @param int $maxDepth Inclusive upper bound on DIT; classes with depth greater than this are reported
      * @param array{
      *     excludedClasses?: list<string>
-     * } $options
+     * } $options FQCNs listed under `excludedClasses` are never reported
      */
     public function __construct(
         private ReflectionProvider $reflectionProvider,
@@ -49,6 +52,9 @@ final readonly class InheritanceDepthRule implements Rule
         );
     }
 
+    /**
+     * Returns the PHP-Parser node type this rule reacts to.
+     */
     #[Override]
     public function getNodeType(): string
     {
@@ -56,9 +62,10 @@ final readonly class InheritanceDepthRule implements Rule
     }
 
     /**
-     * Analyses the node and returns a list of errors.
+     * Computes the inheritance depth of the class declared by `$node` and reports it when the depth exceeds the configured limit.
      *
-     * @psalm-param Class_ $node
+     * @param Class_ $node
+     * @throws ShouldNotHappenException
      * @return list<IdentifierRuleError>
      */
     #[Override]

--- a/tests/Fixtures/Rules/InheritanceDepthRule/Anonymous/AnonymousBase.php
+++ b/tests/Fixtures/Rules/InheritanceDepthRule/Anonymous/AnonymousBase.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\InheritanceDepthRule\Anonymous;
+
+class AnonymousBase
+{
+}

--- a/tests/Fixtures/Rules/InheritanceDepthRule/Anonymous/AnonymousFactory.php
+++ b/tests/Fixtures/Rules/InheritanceDepthRule/Anonymous/AnonymousFactory.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\InheritanceDepthRule\Anonymous;
+
+final class AnonymousFactory
+{
+    public function make(): AnonymousBase
+    {
+        return new class extends AnonymousBase {
+        };
+    }
+}

--- a/tests/Fixtures/Rules/InheritanceDepthRule/AtLimit/AtLimitLeaf.php
+++ b/tests/Fixtures/Rules/InheritanceDepthRule/AtLimit/AtLimitLeaf.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\InheritanceDepthRule\AtLimit;
+
+final class AtLimitLeaf extends AtLimitLevelTwo
+{
+}

--- a/tests/Fixtures/Rules/InheritanceDepthRule/AtLimit/AtLimitLevelOne.php
+++ b/tests/Fixtures/Rules/InheritanceDepthRule/AtLimit/AtLimitLevelOne.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\InheritanceDepthRule\AtLimit;
+
+class AtLimitLevelOne extends AtLimitRoot
+{
+}

--- a/tests/Fixtures/Rules/InheritanceDepthRule/AtLimit/AtLimitLevelTwo.php
+++ b/tests/Fixtures/Rules/InheritanceDepthRule/AtLimit/AtLimitLevelTwo.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\InheritanceDepthRule\AtLimit;
+
+class AtLimitLevelTwo extends AtLimitLevelOne
+{
+}

--- a/tests/Fixtures/Rules/InheritanceDepthRule/AtLimit/AtLimitRoot.php
+++ b/tests/Fixtures/Rules/InheritanceDepthRule/AtLimit/AtLimitRoot.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\InheritanceDepthRule\AtLimit;
+
+class AtLimitRoot
+{
+}

--- a/tests/Fixtures/Rules/InheritanceDepthRule/ExcludedTarget/ExcludedDeepLeaf.php
+++ b/tests/Fixtures/Rules/InheritanceDepthRule/ExcludedTarget/ExcludedDeepLeaf.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\InheritanceDepthRule\ExcludedTarget;
+
+final class ExcludedDeepLeaf extends ExcludedDeepLevelThree
+{
+}

--- a/tests/Fixtures/Rules/InheritanceDepthRule/ExcludedTarget/ExcludedDeepLevelOne.php
+++ b/tests/Fixtures/Rules/InheritanceDepthRule/ExcludedTarget/ExcludedDeepLevelOne.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\InheritanceDepthRule\ExcludedTarget;
+
+class ExcludedDeepLevelOne extends ExcludedDeepRoot
+{
+}

--- a/tests/Fixtures/Rules/InheritanceDepthRule/ExcludedTarget/ExcludedDeepLevelThree.php
+++ b/tests/Fixtures/Rules/InheritanceDepthRule/ExcludedTarget/ExcludedDeepLevelThree.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\InheritanceDepthRule\ExcludedTarget;
+
+class ExcludedDeepLevelThree extends ExcludedDeepLevelTwo
+{
+}

--- a/tests/Fixtures/Rules/InheritanceDepthRule/ExcludedTarget/ExcludedDeepLevelTwo.php
+++ b/tests/Fixtures/Rules/InheritanceDepthRule/ExcludedTarget/ExcludedDeepLevelTwo.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\InheritanceDepthRule\ExcludedTarget;
+
+class ExcludedDeepLevelTwo extends ExcludedDeepLevelOne
+{
+}

--- a/tests/Fixtures/Rules/InheritanceDepthRule/ExcludedTarget/ExcludedDeepRoot.php
+++ b/tests/Fixtures/Rules/InheritanceDepthRule/ExcludedTarget/ExcludedDeepRoot.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\InheritanceDepthRule\ExcludedTarget;
+
+class ExcludedDeepRoot
+{
+}

--- a/tests/Fixtures/Rules/InheritanceDepthRule/InterfacesAndTraits/FirstContract.php
+++ b/tests/Fixtures/Rules/InheritanceDepthRule/InterfacesAndTraits/FirstContract.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\InheritanceDepthRule\InterfacesAndTraits;
+
+interface FirstContract
+{
+    public function first(): string;
+}

--- a/tests/Fixtures/Rules/InheritanceDepthRule/InterfacesAndTraits/ImplementsAndUses.php
+++ b/tests/Fixtures/Rules/InheritanceDepthRule/InterfacesAndTraits/ImplementsAndUses.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\InheritanceDepthRule\InterfacesAndTraits;
+
+final class ImplementsAndUses implements FirstContract, SecondContract
+{
+    use SharedTrait;
+
+    public function first(): string
+    {
+        return 'first';
+    }
+
+    public function second(): string
+    {
+        return 'second';
+    }
+}

--- a/tests/Fixtures/Rules/InheritanceDepthRule/InterfacesAndTraits/SecondContract.php
+++ b/tests/Fixtures/Rules/InheritanceDepthRule/InterfacesAndTraits/SecondContract.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\InheritanceDepthRule\InterfacesAndTraits;
+
+interface SecondContract
+{
+    public function second(): string;
+}

--- a/tests/Fixtures/Rules/InheritanceDepthRule/InterfacesAndTraits/SharedTrait.php
+++ b/tests/Fixtures/Rules/InheritanceDepthRule/InterfacesAndTraits/SharedTrait.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\InheritanceDepthRule\InterfacesAndTraits;
+
+trait SharedTrait
+{
+    public function shared(): string
+    {
+        return 'shared';
+    }
+}

--- a/tests/Fixtures/Rules/InheritanceDepthRule/OneLevel/OneLevelLeaf.php
+++ b/tests/Fixtures/Rules/InheritanceDepthRule/OneLevel/OneLevelLeaf.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\InheritanceDepthRule\OneLevel;
+
+final class OneLevelLeaf extends OneLevelRoot
+{
+}

--- a/tests/Fixtures/Rules/InheritanceDepthRule/OneLevel/OneLevelRoot.php
+++ b/tests/Fixtures/Rules/InheritanceDepthRule/OneLevel/OneLevelRoot.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\InheritanceDepthRule\OneLevel;
+
+class OneLevelRoot
+{
+}

--- a/tests/Fixtures/Rules/InheritanceDepthRule/Shallow/ShallowClass.php
+++ b/tests/Fixtures/Rules/InheritanceDepthRule/Shallow/ShallowClass.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\InheritanceDepthRule\Shallow;
+
+final class ShallowClass
+{
+}

--- a/tests/Fixtures/Rules/InheritanceDepthRule/SuppressedTooDeep/SuppressedTooDeepLeaf.php
+++ b/tests/Fixtures/Rules/InheritanceDepthRule/SuppressedTooDeep/SuppressedTooDeepLeaf.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\InheritanceDepthRule\SuppressedTooDeep;
+
+/** @phpstan-ignore haspadar.inheritanceDepth */
+final class SuppressedTooDeepLeaf extends SuppressedTooDeepLevelThree
+{
+}

--- a/tests/Fixtures/Rules/InheritanceDepthRule/SuppressedTooDeep/SuppressedTooDeepLevelOne.php
+++ b/tests/Fixtures/Rules/InheritanceDepthRule/SuppressedTooDeep/SuppressedTooDeepLevelOne.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\InheritanceDepthRule\SuppressedTooDeep;
+
+class SuppressedTooDeepLevelOne extends SuppressedTooDeepRoot
+{
+}

--- a/tests/Fixtures/Rules/InheritanceDepthRule/SuppressedTooDeep/SuppressedTooDeepLevelThree.php
+++ b/tests/Fixtures/Rules/InheritanceDepthRule/SuppressedTooDeep/SuppressedTooDeepLevelThree.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\InheritanceDepthRule\SuppressedTooDeep;
+
+class SuppressedTooDeepLevelThree extends SuppressedTooDeepLevelTwo
+{
+}

--- a/tests/Fixtures/Rules/InheritanceDepthRule/SuppressedTooDeep/SuppressedTooDeepLevelTwo.php
+++ b/tests/Fixtures/Rules/InheritanceDepthRule/SuppressedTooDeep/SuppressedTooDeepLevelTwo.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\InheritanceDepthRule\SuppressedTooDeep;
+
+class SuppressedTooDeepLevelTwo extends SuppressedTooDeepLevelOne
+{
+}

--- a/tests/Fixtures/Rules/InheritanceDepthRule/SuppressedTooDeep/SuppressedTooDeepRoot.php
+++ b/tests/Fixtures/Rules/InheritanceDepthRule/SuppressedTooDeep/SuppressedTooDeepRoot.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\InheritanceDepthRule\SuppressedTooDeep;
+
+class SuppressedTooDeepRoot
+{
+}

--- a/tests/Fixtures/Rules/InheritanceDepthRule/TooDeep/TooDeepLeaf.php
+++ b/tests/Fixtures/Rules/InheritanceDepthRule/TooDeep/TooDeepLeaf.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\InheritanceDepthRule\TooDeep;
+
+final class TooDeepLeaf extends TooDeepLevelThree
+{
+}

--- a/tests/Fixtures/Rules/InheritanceDepthRule/TooDeep/TooDeepLevelOne.php
+++ b/tests/Fixtures/Rules/InheritanceDepthRule/TooDeep/TooDeepLevelOne.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\InheritanceDepthRule\TooDeep;
+
+class TooDeepLevelOne extends TooDeepRoot
+{
+}

--- a/tests/Fixtures/Rules/InheritanceDepthRule/TooDeep/TooDeepLevelThree.php
+++ b/tests/Fixtures/Rules/InheritanceDepthRule/TooDeep/TooDeepLevelThree.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\InheritanceDepthRule\TooDeep;
+
+class TooDeepLevelThree extends TooDeepLevelTwo
+{
+}

--- a/tests/Fixtures/Rules/InheritanceDepthRule/TooDeep/TooDeepLevelTwo.php
+++ b/tests/Fixtures/Rules/InheritanceDepthRule/TooDeep/TooDeepLevelTwo.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\InheritanceDepthRule\TooDeep;
+
+class TooDeepLevelTwo extends TooDeepLevelOne
+{
+}

--- a/tests/Fixtures/Rules/InheritanceDepthRule/TooDeep/TooDeepRoot.php
+++ b/tests/Fixtures/Rules/InheritanceDepthRule/TooDeep/TooDeepRoot.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\InheritanceDepthRule\TooDeep;
+
+class TooDeepRoot
+{
+}

--- a/tests/Unit/Rules/InheritanceDepthRule/InheritanceDepthRuleAnonymousTest.php
+++ b/tests/Unit/Rules/InheritanceDepthRule/InheritanceDepthRuleAnonymousTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\InheritanceDepthRule;
+
+use Haspadar\PHPStanRules\Rules\InheritanceDepthRule;
+use Override;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Proves that anonymous classes are skipped even when they extend a base class.
+ *
+ * @extends RuleTestCase<InheritanceDepthRule>
+ */
+final class InheritanceDepthRuleAnonymousTest extends RuleTestCase
+{
+    #[Override]
+    protected function getRule(): Rule
+    {
+        return new InheritanceDepthRule($this->createReflectionProvider(), maxDepth: 0);
+    }
+
+    #[Test]
+    public function skipsAnonymousClass(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/InheritanceDepthRule/Anonymous/AnonymousFactory.php'],
+            [],
+            'Anonymous class with extends must be skipped even when its depth exceeds the limit',
+        );
+    }
+}

--- a/tests/Unit/Rules/InheritanceDepthRule/InheritanceDepthRuleDefaultLimitTest.php
+++ b/tests/Unit/Rules/InheritanceDepthRule/InheritanceDepthRuleDefaultLimitTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\InheritanceDepthRule;
+
+use Haspadar\PHPStanRules\Rules\InheritanceDepthRule;
+use Override;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<InheritanceDepthRule> */
+final class InheritanceDepthRuleDefaultLimitTest extends RuleTestCase
+{
+    #[Override]
+    protected function getRule(): Rule
+    {
+        return new InheritanceDepthRule($this->createReflectionProvider());
+    }
+
+    #[Test]
+    public function passesWhenClassIsAtDefaultLimit(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/InheritanceDepthRule/AtLimit/AtLimitLeaf.php'],
+            [],
+            'Class with depth 3 must not be reported under the default limit of 3',
+        );
+    }
+
+    #[Test]
+    public function reportsClassExceedingDefaultLimit(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/InheritanceDepthRule/TooDeep/TooDeepLeaf.php'],
+            [
+                [
+                    'Class TooDeepLeaf has inheritance depth 4 which exceeds the allowed 3.',
+                    7,
+                ],
+            ],
+            'Class with depth 4 must be reported under the default limit of 3',
+        );
+    }
+}

--- a/tests/Unit/Rules/InheritanceDepthRule/InheritanceDepthRuleExcludedClassesNormalizationTest.php
+++ b/tests/Unit/Rules/InheritanceDepthRule/InheritanceDepthRuleExcludedClassesNormalizationTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\InheritanceDepthRule;
+
+use Haspadar\PHPStanRules\Rules\InheritanceDepthRule;
+use Override;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Verifies that excludedClasses entries are normalized: leading backslash stripped, case folded.
+ *
+ * @extends RuleTestCase<InheritanceDepthRule>
+ */
+final class InheritanceDepthRuleExcludedClassesNormalizationTest extends RuleTestCase
+{
+    #[Override]
+    protected function getRule(): Rule
+    {
+        return new InheritanceDepthRule(
+            $this->createReflectionProvider(),
+            maxDepth: 2,
+            options: [
+                'excludedClasses' => [
+                    '\\HASPADAR\\phpstanrules\\Tests\\Fixtures\\Rules\\InheritanceDepthRule\\ExcludedTarget\\excludedDEEPLeaf',
+                ],
+            ],
+        );
+    }
+
+    #[Test]
+    public function skipsClassWhenExcludedEntryHasLeadingBackslashAndMixedCase(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/InheritanceDepthRule/ExcludedTarget/ExcludedDeepLeaf.php'],
+            [],
+            'excludedClasses must match regardless of leading backslash or case differences',
+        );
+    }
+}

--- a/tests/Unit/Rules/InheritanceDepthRule/InheritanceDepthRuleExcludedClassesTest.php
+++ b/tests/Unit/Rules/InheritanceDepthRule/InheritanceDepthRuleExcludedClassesTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\InheritanceDepthRule;
+
+use Haspadar\PHPStanRules\Rules\InheritanceDepthRule;
+use Override;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<InheritanceDepthRule> */
+final class InheritanceDepthRuleExcludedClassesTest extends RuleTestCase
+{
+    #[Override]
+    protected function getRule(): Rule
+    {
+        return new InheritanceDepthRule(
+            $this->createReflectionProvider(),
+            maxDepth: 2,
+            options: [
+                'excludedClasses' => [
+                    'Haspadar\\PHPStanRules\\Tests\\Fixtures\\Rules\\InheritanceDepthRule\\ExcludedTarget\\ExcludedDeepLeaf',
+                ],
+            ],
+        );
+    }
+
+    #[Test]
+    public function skipsClassListedInExcludedClasses(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/InheritanceDepthRule/ExcludedTarget/ExcludedDeepLeaf.php'],
+            [],
+            'Class in excludedClasses must never be reported even when depth exceeds the limit',
+        );
+    }
+
+    #[Test]
+    public function stillReportsOtherClassesWhenExcludedClassesConfigured(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/InheritanceDepthRule/AtLimit/AtLimitLeaf.php'],
+            [
+                [
+                    'Class AtLimitLeaf has inheritance depth 3 which exceeds the allowed 2.',
+                    7,
+                ],
+            ],
+            'Classes not listed in excludedClasses must still be reported',
+        );
+    }
+}

--- a/tests/Unit/Rules/InheritanceDepthRule/InheritanceDepthRuleInterfacesAndTraitsTest.php
+++ b/tests/Unit/Rules/InheritanceDepthRule/InheritanceDepthRuleInterfacesAndTraitsTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\InheritanceDepthRule;
+
+use Haspadar\PHPStanRules\Rules\InheritanceDepthRule;
+use Override;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Proves that interfaces (`implements`) and traits (`use`) never contribute to the depth.
+ *
+ * @extends RuleTestCase<InheritanceDepthRule>
+ */
+final class InheritanceDepthRuleInterfacesAndTraitsTest extends RuleTestCase
+{
+    #[Override]
+    protected function getRule(): Rule
+    {
+        return new InheritanceDepthRule($this->createReflectionProvider(), maxDepth: 0);
+    }
+
+    #[Test]
+    public function doesNotCountInterfacesOrTraits(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/InheritanceDepthRule/InterfacesAndTraits/ImplementsAndUses.php'],
+            [],
+            'Class implementing interfaces and using traits but without extends must have depth 0',
+        );
+    }
+}

--- a/tests/Unit/Rules/InheritanceDepthRule/InheritanceDepthRuleTest.php
+++ b/tests/Unit/Rules/InheritanceDepthRule/InheritanceDepthRuleTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\InheritanceDepthRule;
+
+use Haspadar\PHPStanRules\Rules\InheritanceDepthRule;
+use Override;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<InheritanceDepthRule> */
+final class InheritanceDepthRuleTest extends RuleTestCase
+{
+    #[Override]
+    protected function getRule(): Rule
+    {
+        return new InheritanceDepthRule($this->createReflectionProvider(), maxDepth: 2);
+    }
+
+    #[Test]
+    public function passesWhenClassHasNoParent(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/InheritanceDepthRule/Shallow/ShallowClass.php'],
+            [],
+            'Class with no parent must have depth 0 and must not be reported',
+        );
+    }
+
+    #[Test]
+    public function passesWhenClassIsExactlyAtLimit(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/InheritanceDepthRule/OneLevel/OneLevelLeaf.php'],
+            [],
+            'Class with one parent must have depth 1 and must not be reported under limit 2',
+        );
+    }
+
+    #[Test]
+    public function reportsClassDeeperThanLimit(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/InheritanceDepthRule/AtLimit/AtLimitLeaf.php'],
+            [
+                [
+                    'Class AtLimitLeaf has inheritance depth 3 which exceeds the allowed 2.',
+                    7,
+                ],
+            ],
+            'Class whose depth exceeds the limit must be reported on the line of its declaration',
+        );
+    }
+
+    #[Test]
+    public function suppressesErrorWhenPhpstanIgnorePresent(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/InheritanceDepthRule/SuppressedTooDeep/SuppressedTooDeepLeaf.php'],
+            [],
+            '@phpstan-ignore haspadar.inheritanceDepth must suppress the error',
+        );
+    }
+}

--- a/tests/Unit/Rules/InheritanceDepthRule/InheritanceDepthRuleTest.php
+++ b/tests/Unit/Rules/InheritanceDepthRule/InheritanceDepthRuleTest.php
@@ -33,9 +33,9 @@ final class InheritanceDepthRuleTest extends RuleTestCase
     public function passesWhenClassIsExactlyAtLimit(): void
     {
         $this->analyse(
-            [__DIR__ . '/../../../Fixtures/Rules/InheritanceDepthRule/OneLevel/OneLevelLeaf.php'],
+            [__DIR__ . '/../../../Fixtures/Rules/InheritanceDepthRule/AtLimit/AtLimitLevelTwo.php'],
             [],
-            'Class with one parent must have depth 1 and must not be reported under limit 2',
+            'Class whose depth equals the limit must not be reported',
         );
     }
 

--- a/tests/Unit/RulesTest.php
+++ b/tests/Unit/RulesTest.php
@@ -56,6 +56,7 @@ use Haspadar\PHPStanRules\Rules\NeverReturnNullRule;
 use Haspadar\PHPStanRules\Rules\NeverUsePublicConstantsRule;
 use Haspadar\PHPStanRules\Rules\WeightedMethodsPerClassRule;
 use Haspadar\PHPStanRules\Rules\AfferentCouplingRule;
+use Haspadar\PHPStanRules\Rules\InheritanceDepthRule;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -117,6 +118,7 @@ final class RulesTest extends TestCase
                 NeverUsePublicConstantsRule::class,
                 WeightedMethodsPerClassRule::class,
                 AfferentCouplingRule::class,
+                InheritanceDepthRule::class,
             ],
             (new Rules())->all(),
             'Rules::all() must list every registered rule class',


### PR DESCRIPTION
- Added InheritanceDepthRule reporting classes whose ancestor chain exceeds the configured limit
- Added excludedClasses option with leading-backslash and case-insensitive matching
- Added fixtures covering shallow, at-limit, too-deep, excluded, suppressed, anonymous, and interface/trait branches
- Added unit tests for default limit, custom limit, excluded classes, normalization, anonymous skip, and interfaces/traits

Closes #132

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `InheritanceDepthRule` to enforce maximum class inheritance depth with a default limit of 3 levels.
  * Classes can be excluded from the rule via configuration using the `excludedClasses` parameter.

* **Documentation**
  * Updated README with `InheritanceDepthRule` documentation, including default limit and example PHPStan configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->