### PR TITLE
Add LackOfCohesionRule to flag classes split into disjoint method groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 | `WeightedMethodsPerClassRule`     | 50      | Sum of cyclomatic complexities of all methods must not exceed N            |
 | `AfferentCouplingRule`            | 14      | Class must not be referenced by more than N other classes in the codebase  |
 | `InheritanceDepthRule`            | 3       | Class must not extend a chain of more than N ancestors                     |
+| `LackOfCohesionRule`              | 1       | Methods must not split into more than N disjoint groups (LCOM4)            |
 
 ### Design
 
@@ -209,6 +210,12 @@ parameters:
             maxDepth: 2
             excludedClasses:
                 - Symfony\Bundle\FrameworkBundle\Controller\AbstractController
+        lackOfCohesion:
+            maxLcom: 1
+            minMethods: 10
+            minProperties: 3
+            excludedClasses:
+                - App\Dto\ConfigBag
 ```
 
 Default values match the defaults described in the rules table above. Omitting a parameter keeps the default. Diagnostic identifier for `AtclauseOrderRule`: `haspadar.atclauseOrder` (for targeted ignores, e.g. `@phpstan-ignore haspadar.atclauseOrder`).

--- a/rules-ignore.neon
+++ b/rules-ignore.neon
@@ -16,3 +16,8 @@ parameters:
             identifier: haspadar.parameterName
         -
             identifier: haspadar.noNullReturn
+        -
+            identifier: haspadar.lackOfCohesion
+            paths:
+                - src/Rules/CouplingBetweenObjectsRule.php
+                - src/Rules/MethodLengthRule.php

--- a/rules.neon
+++ b/rules.neon
@@ -113,6 +113,11 @@ parameters:
         inheritanceDepth:
             maxDepth: 3
             excludedClasses: []
+        lackOfCohesion:
+            maxLcom: 1
+            minMethods: 7
+            minProperties: 3
+            excludedClasses: []
 
 parametersSchema:
     haspadar: structure([
@@ -227,6 +232,12 @@ parametersSchema:
         ]),
         inheritanceDepth: structure([
             maxDepth: int(),
+            excludedClasses: listOf(string()),
+        ]),
+        lackOfCohesion: structure([
+            maxLcom: int(),
+            minMethods: int(),
+            minProperties: int(),
             excludedClasses: listOf(string()),
         ]),
     ])
@@ -545,5 +556,15 @@ services:
             maxDepth: %haspadar.inheritanceDepth.maxDepth%
             options:
                 excludedClasses: %haspadar.inheritanceDepth.excludedClasses%
+        tags:
+            - phpstan.rules.rule
+    -
+        class: Haspadar\PHPStanRules\Rules\LackOfCohesionRule
+        arguments:
+            maxLcom: %haspadar.lackOfCohesion.maxLcom%
+            options:
+                minMethods: %haspadar.lackOfCohesion.minMethods%
+                minProperties: %haspadar.lackOfCohesion.minProperties%
+                excludedClasses: %haspadar.lackOfCohesion.excludedClasses%
         tags:
             - phpstan.rules.rule

--- a/src/Rules.php
+++ b/src/Rules.php
@@ -62,6 +62,7 @@ final class Rules
         Rules\WeightedMethodsPerClassRule::class,
         Rules\AfferentCouplingRule::class,
         Rules\InheritanceDepthRule::class,
+        Rules\LackOfCohesionRule::class,
     ];
 
     /**

--- a/src/Rules/LackOfCohesionRule.php
+++ b/src/Rules/LackOfCohesionRule.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Rules;
+
+use Haspadar\PHPStanRules\Rules\LackOfCohesionRule\CohesionGraph;
+use Override;
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\ShouldNotHappenException;
+
+/**
+ * Reports a class whose methods split into more disjoint groups than allowed (LCOM4).
+ *
+ * Builds an undirected graph over the class's own non-magic methods: two methods are connected
+ * when they touch at least one common instance or static property, or one calls the other via
+ * `$this->method()`. The number of connected components is the LCOM4 value. A cohesive class
+ * has exactly one component; a class exceeding `$maxLcom` is reported as lacking cohesion.
+ *
+ * Abstract, anonymous and excluded classes are skipped. Classes with fewer methods than
+ * `$minMethods` or fewer properties than `$minProperties` are skipped — on such classes LCOM
+ * degenerates and carries no signal. Constructors, destructors and PHP magic methods are
+ * excluded from the graph.
+ *
+ * @implements Rule<Class_>
+ */
+final readonly class LackOfCohesionRule implements Rule
+{
+    private const int DEFAULT_MIN_METHODS = 7;
+
+    private const int DEFAULT_MIN_PROPERTIES = 3;
+
+    private const array EXCLUDED_METHOD_NAMES = [
+        '__construct',
+        '__destruct',
+        '__get',
+        '__set',
+        '__isset',
+        '__unset',
+        '__toString',
+        '__invoke',
+        '__clone',
+        '__call',
+        '__callStatic',
+        '__sleep',
+        '__wakeup',
+        '__serialize',
+        '__unserialize',
+        '__debugInfo',
+        '__set_state',
+    ];
+
+    private int $minMethods;
+
+    private int $minProperties;
+
+    /** @var list<string> */
+    private array $excludedClasses;
+
+    /**
+     * Constructs the rule with the LCOM threshold and filter options.
+     *
+     * @param array{
+     *     minMethods?: int,
+     *     minProperties?: int,
+     *     excludedClasses?: list<string>
+     * } $options
+     */
+    public function __construct(private int $maxLcom = 1, array $options = [])
+    {
+        $this->minMethods = $options['minMethods'] ?? self::DEFAULT_MIN_METHODS;
+        $this->minProperties = $options['minProperties'] ?? self::DEFAULT_MIN_PROPERTIES;
+        $this->excludedClasses = array_map(
+            static fn(string $class): string => strtolower(ltrim($class, '\\')),
+            $options['excludedClasses'] ?? [],
+        );
+    }
+
+    #[Override]
+    public function getNodeType(): string
+    {
+        return Class_::class;
+    }
+
+    /**
+     * Analyses the class and reports when LCOM4 exceeds the configured limit.
+     *
+     * @psalm-param Class_ $node
+     * @throws ShouldNotHappenException
+     * @return list<IdentifierRuleError>
+     */
+    #[Override]
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if ($node->isAnonymous() || $node->isAbstract() || $node->name === null) {
+            return [];
+        }
+
+        $className = $node->name->toString();
+
+        if ($this->isExcluded($className, $scope->getNamespace() ?? '')) {
+            return [];
+        }
+
+        $methods = $this->eligibleMethods($node);
+
+        if (count($methods) < $this->minMethods || count($node->getProperties()) < $this->minProperties) {
+            return [];
+        }
+
+        $lcom = (new CohesionGraph())->componentCount($methods);
+
+        if ($lcom <= $this->maxLcom) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message(
+                sprintf(
+                    'Class %s has lack of cohesion %d (methods split into %d disjoint groups). Maximum allowed is %d.',
+                    $className,
+                    $lcom,
+                    $lcom,
+                    $this->maxLcom,
+                ),
+            )
+                ->identifier('haspadar.lackOfCohesion')
+                ->build(),
+        ];
+    }
+
+    /**
+     * Tells whether the class is listed in `excludedClasses` under its short name or its FQCN.
+     */
+    private function isExcluded(string $className, string $namespace): bool
+    {
+        $shortName = strtolower($className);
+        $fqcn = strtolower(ltrim(sprintf('%s\\%s', $namespace, $className), '\\'));
+
+        return in_array($shortName, $this->excludedClasses, true)
+            || in_array($fqcn, $this->excludedClasses, true);
+    }
+
+    /**
+     * Returns the methods that participate in the cohesion graph.
+     *
+     * @return list<ClassMethod>
+     */
+    private function eligibleMethods(Class_ $node): array
+    {
+        $methods = [];
+
+        foreach ($node->getMethods() as $method) {
+            if ($method->isAbstract() || $method->stmts === null) {
+                continue;
+            }
+
+            if (in_array($method->name->toString(), self::EXCLUDED_METHOD_NAMES, true)) {
+                continue;
+            }
+
+            $methods[] = $method;
+        }
+
+        return $methods;
+    }
+}

--- a/src/Rules/LackOfCohesionRule.php
+++ b/src/Rules/LackOfCohesionRule.php
@@ -6,6 +6,7 @@ namespace Haspadar\PHPStanRules\Rules;
 
 use Haspadar\PHPStanRules\Rules\LackOfCohesionRule\CohesionGraph;
 use Override;
+use PhpParser\Modifiers;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
@@ -20,13 +21,15 @@ use PHPStan\ShouldNotHappenException;
  *
  * Builds an undirected graph over the class's own non-magic methods: two methods are connected
  * when they touch at least one common instance or static property, or one calls the other via
- * `$this->method()`. The number of connected components is the LCOM4 value. A cohesive class
- * has exactly one component; a class exceeding `$maxLcom` is reported as lacking cohesion.
+ * `$this->method()`, `self::method()` or `static::method()`. The number of connected components
+ * is the LCOM4 value. A cohesive class has exactly one component; a class exceeding `$maxLcom`
+ * is reported as lacking cohesion.
  *
  * Abstract, anonymous and excluded classes are skipped. Classes with fewer methods than
  * `$minMethods` or fewer properties than `$minProperties` are skipped — on such classes LCOM
- * degenerates and carries no signal. Constructors, destructors and PHP magic methods are
- * excluded from the graph.
+ * degenerates and carries no signal. Both regular properties and promoted constructor parameters
+ * count toward `$minProperties`. Constructors, destructors and PHP magic methods are excluded
+ * from the graph.
  *
  * @implements Rule<Class_>
  */
@@ -43,16 +46,16 @@ final readonly class LackOfCohesionRule implements Rule
         '__set',
         '__isset',
         '__unset',
-        '__toString',
+        '__tostring',
         '__invoke',
         '__clone',
         '__call',
-        '__callStatic',
+        '__callstatic',
         '__sleep',
         '__wakeup',
         '__serialize',
         '__unserialize',
-        '__debugInfo',
+        '__debuginfo',
         '__set_state',
     ];
 
@@ -110,7 +113,7 @@ final readonly class LackOfCohesionRule implements Rule
 
         $methods = $this->eligibleMethods($node);
 
-        if (count($methods) < $this->minMethods || count($node->getProperties()) < $this->minProperties) {
+        if (count($methods) < $this->minMethods || $this->propertyCount($node) < $this->minProperties) {
             return [];
         }
 
@@ -123,9 +126,8 @@ final readonly class LackOfCohesionRule implements Rule
         return [
             RuleErrorBuilder::message(
                 sprintf(
-                    'Class %s has lack of cohesion %d (methods split into %d disjoint groups). Maximum allowed is %d.',
+                    'Class %s splits into %d disjoint method groups (LCOM4). Maximum allowed is %d.',
                     $className,
-                    $lcom,
                     $lcom,
                     $this->maxLcom,
                 ),
@@ -136,15 +138,13 @@ final readonly class LackOfCohesionRule implements Rule
     }
 
     /**
-     * Tells whether the class is listed in `excludedClasses` under its short name or its FQCN.
+     * Tells whether the class's FQCN is listed in `excludedClasses`.
      */
     private function isExcluded(string $className, string $namespace): bool
     {
-        $shortName = strtolower($className);
         $fqcn = strtolower(ltrim(sprintf('%s\\%s', $namespace, $className), '\\'));
 
-        return in_array($shortName, $this->excludedClasses, true)
-            || in_array($fqcn, $this->excludedClasses, true);
+        return in_array($fqcn, $this->excludedClasses, true);
     }
 
     /**
@@ -161,7 +161,7 @@ final readonly class LackOfCohesionRule implements Rule
                 continue;
             }
 
-            if (in_array($method->name->toString(), self::EXCLUDED_METHOD_NAMES, true)) {
+            if (in_array(strtolower($method->name->toString()), self::EXCLUDED_METHOD_NAMES, true)) {
                 continue;
             }
 
@@ -169,5 +169,28 @@ final readonly class LackOfCohesionRule implements Rule
         }
 
         return $methods;
+    }
+
+    /**
+     * Counts regular properties plus promoted constructor parameters.
+     */
+    private function propertyCount(Class_ $node): int
+    {
+        $count = count($node->getProperties());
+        $constructor = $node->getMethod('__construct');
+
+        if ($constructor === null) {
+            return $count;
+        }
+
+        $visibilityMask = Modifiers::PUBLIC | Modifiers::PROTECTED | Modifiers::PRIVATE;
+
+        foreach ($constructor->params as $param) {
+            if (($param->flags & $visibilityMask) !== 0) {
+                $count++;
+            }
+        }
+
+        return $count;
     }
 }

--- a/src/Rules/LackOfCohesionRule/AdjacencyBuilder.php
+++ b/src/Rules/LackOfCohesionRule/AdjacencyBuilder.php
@@ -37,7 +37,10 @@ final readonly class AdjacencyBuilder
     }
 
     /**
-     * Returns a map from method name to its index in `$methods`.
+     * Returns a map from lowercased method name to its index in `$methods`.
+     *
+     * PHP method names are case-insensitive, so keys are lowercased to match
+     * callee names collected by `MethodTouches`.
      *
      * @param list<ClassMethod> $methods
      * @return array<string, int>
@@ -47,7 +50,7 @@ final readonly class AdjacencyBuilder
         $index = [];
 
         foreach ($methods as $i => $method) {
-            $index[$method->name->toString()] = $i;
+            $index[strtolower($method->name->toString())] = $i;
         }
 
         return $index;

--- a/src/Rules/LackOfCohesionRule/AdjacencyBuilder.php
+++ b/src/Rules/LackOfCohesionRule/AdjacencyBuilder.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Rules\LackOfCohesionRule;
+
+use PhpParser\Node\Stmt\ClassMethod;
+
+/**
+ * Builds the undirected adjacency list of the method cohesion graph.
+ *
+ * Two methods get an edge when one calls the other via `$this->method()`, or when they
+ * share at least one touched property (instance or static).
+ */
+final readonly class AdjacencyBuilder
+{
+    private const int MIN_PAIR_SIZE = 2;
+
+    /**
+     * Builds the adjacency list: each index maps to the list of connected indices.
+     *
+     * @param list<ClassMethod> $methods
+     * @param list<array{properties: list<string>, calls: list<string>}> $touches
+     * @return array<int, list<int>>
+     */
+    public function build(array $methods, array $touches): array
+    {
+        $count = count($methods);
+        $methodIndex = $this->methodIndex($methods);
+
+        $edges = [
+            ...$this->callEdges($touches, $methodIndex),
+            ...$this->propertyEdges($touches, $count),
+        ];
+
+        return $this->adjacencyFromEdges($count, $edges);
+    }
+
+    /**
+     * Returns a map from method name to its index in `$methods`.
+     *
+     * @param list<ClassMethod> $methods
+     * @return array<string, int>
+     */
+    private function methodIndex(array $methods): array
+    {
+        $index = [];
+
+        foreach ($methods as $i => $method) {
+            $index[$method->name->toString()] = $i;
+        }
+
+        return $index;
+    }
+
+    /**
+     * Returns edges connecting methods that call each other via `$this->method()`.
+     *
+     * @param list<array{properties: list<string>, calls: list<string>}> $touches
+     * @param array<string, int> $methodIndex
+     * @return list<array{0: int, 1: int}>
+     */
+    private function callEdges(array $touches, array $methodIndex): array
+    {
+        $edges = [];
+
+        foreach ($touches as $i => $data) {
+            foreach ($data['calls'] as $callee) {
+                $target = $methodIndex[$callee] ?? null;
+
+                if ($target !== null && $target !== $i) {
+                    $edges[] = [$i, $target];
+                }
+            }
+        }
+
+        return $edges;
+    }
+
+    /**
+     * Returns edges connecting methods that share at least one touched property.
+     *
+     * @param list<array{properties: list<string>, calls: list<string>}> $touches
+     * @return list<array{0: int, 1: int}>
+     */
+    private function propertyEdges(array $touches, int $count): array
+    {
+        if ($count < self::MIN_PAIR_SIZE) {
+            return [];
+        }
+
+        $edges = [];
+        $lastIndex = $count - 1;
+
+        foreach (range(0, $lastIndex - 1) as $i) {
+            foreach (range($i + 1, $lastIndex) as $j) {
+                if (array_intersect($touches[$i]['properties'], $touches[$j]['properties']) !== []) {
+                    $edges[] = [$i, $j];
+                }
+            }
+        }
+
+        return $edges;
+    }
+
+    /**
+     * Builds the symmetric adjacency map from a list of undirected edges.
+     *
+     * @param list<array{0: int, 1: int}> $edges
+     * @return array<int, list<int>>
+     */
+    private function adjacencyFromEdges(int $count, array $edges): array
+    {
+        if ($count === 0) {
+            return [];
+        }
+
+        $adjacency = [];
+
+        foreach (range(0, $count - 1) as $i) {
+            $adjacency[$i] = [];
+        }
+
+        foreach ($edges as [$from, $target]) {
+            $adjacency[$from][] = $target;
+            $adjacency[$target][] = $from;
+        }
+
+        return $adjacency;
+    }
+}

--- a/src/Rules/LackOfCohesionRule/CohesionGraph.php
+++ b/src/Rules/LackOfCohesionRule/CohesionGraph.php
@@ -9,8 +9,9 @@ use PhpParser\Node\Stmt\ClassMethod;
 /**
  * Counts connected components (LCOM4) in the cohesion graph of class methods.
  *
- * Edges connect methods that either share a touched property or call one another via
- * `$this->method()`. The number of connected components is the LCOM4 value of the class.
+ * Vertices are all given methods; edges connect methods that either share a touched
+ * property or call one another via `$this->method()`, `self::method()` or `static::method()`.
+ * The number of connected components is the LCOM4 value of the class.
  */
 final readonly class CohesionGraph
 {
@@ -21,33 +22,10 @@ final readonly class CohesionGraph
      */
     public function componentCount(array $methods): int
     {
-        $stateful = $this->statefulMethods($methods);
-        $touches = $this->touchesFor($stateful);
-        $adjacency = (new AdjacencyBuilder())->build($stateful, $touches);
+        $touches = $this->touchesFor($methods);
+        $adjacency = (new AdjacencyBuilder())->build($methods, $touches);
 
         return $this->countComponents($adjacency);
-    }
-
-    /**
-     * Returns only methods that touch class state via a property access or a `$this->method()` call.
-     *
-     * @param list<ClassMethod> $methods
-     * @return list<ClassMethod>
-     */
-    private function statefulMethods(array $methods): array
-    {
-        $collector = new MethodTouches();
-        $stateful = [];
-
-        foreach ($methods as $method) {
-            $data = $collector->collect($method);
-
-            if ($data['properties'] !== [] || $data['calls'] !== []) {
-                $stateful[] = $method;
-            }
-        }
-
-        return $stateful;
     }
 
     /**

--- a/src/Rules/LackOfCohesionRule/CohesionGraph.php
+++ b/src/Rules/LackOfCohesionRule/CohesionGraph.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Rules\LackOfCohesionRule;
+
+use PhpParser\Node\Stmt\ClassMethod;
+
+/**
+ * Counts connected components (LCOM4) in the cohesion graph of class methods.
+ *
+ * Edges connect methods that either share a touched property or call one another via
+ * `$this->method()`. The number of connected components is the LCOM4 value of the class.
+ */
+final readonly class CohesionGraph
+{
+    /**
+     * Returns the LCOM4 value for the given methods.
+     *
+     * @param list<ClassMethod> $methods
+     */
+    public function componentCount(array $methods): int
+    {
+        $stateful = $this->statefulMethods($methods);
+        $touches = $this->touchesFor($stateful);
+        $adjacency = (new AdjacencyBuilder())->build($stateful, $touches);
+
+        return $this->countComponents($adjacency);
+    }
+
+    /**
+     * Returns only methods that touch class state via a property access or a `$this->method()` call.
+     *
+     * @param list<ClassMethod> $methods
+     * @return list<ClassMethod>
+     */
+    private function statefulMethods(array $methods): array
+    {
+        $collector = new MethodTouches();
+        $stateful = [];
+
+        foreach ($methods as $method) {
+            $data = $collector->collect($method);
+
+            if ($data['properties'] !== [] || $data['calls'] !== []) {
+                $stateful[] = $method;
+            }
+        }
+
+        return $stateful;
+    }
+
+    /**
+     * Computes touches for the given methods.
+     *
+     * @param list<ClassMethod> $methods
+     * @return list<array{properties: list<string>, calls: list<string>}>
+     */
+    private function touchesFor(array $methods): array
+    {
+        $collector = new MethodTouches();
+        $result = [];
+
+        foreach ($methods as $method) {
+            $result[] = $collector->collect($method);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Counts connected components via iterative depth-first search.
+     *
+     * @param array<int, list<int>> $adjacency
+     */
+    private function countComponents(array $adjacency): int
+    {
+        $visited = [];
+        $components = 0;
+
+        foreach (array_keys($adjacency) as $start) {
+            if (array_key_exists($start, $visited)) {
+                continue;
+            }
+
+            $visited = $this->markReachable($adjacency, $start, $visited);
+            $components++;
+        }
+
+        return $components;
+    }
+
+    /**
+     * Marks every node reachable from `$start` as visited and returns the updated set.
+     *
+     * @param array<int, list<int>> $adjacency
+     * @param array<int, true> $visited
+     * @return array<int, true>
+     */
+    private function markReachable(array $adjacency, int $start, array $visited): array
+    {
+        $seen = $visited;
+        $stack = [$start];
+
+        while ($stack !== []) {
+            $node = array_pop($stack);
+
+            if (array_key_exists($node, $seen)) {
+                continue;
+            }
+
+            $seen[$node] = true;
+
+            foreach ($adjacency[$node] as $neighbour) {
+                if (!array_key_exists($neighbour, $seen)) {
+                    $stack[] = $neighbour;
+                }
+            }
+        }
+
+        return $seen;
+    }
+}

--- a/src/Rules/LackOfCohesionRule/MethodTouches.php
+++ b/src/Rules/LackOfCohesionRule/MethodTouches.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Rules\LackOfCohesionRule;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\StaticPropertyFetch;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\NodeFinder;
+
+/**
+ * Collects property accesses and method calls performed by a class method.
+ *
+ * Both `$this->x` instance fetches and `self::$x` / `static::$x` static fetches are
+ * treated as references to the same "property" for cohesion analysis.
+ */
+final readonly class MethodTouches
+{
+    /**
+     * Returns property names and called method names referenced from the method body.
+     *
+     * @return array{properties: list<string>, calls: list<string>}
+     */
+    public function collect(ClassMethod $method): array
+    {
+        $finder = new NodeFinder();
+        $statements = array_values($method->stmts ?? []);
+
+        return [
+            'properties' => $this->properties($finder, $statements),
+            'calls' => $this->calls($finder, $statements),
+        ];
+    }
+
+    /**
+     * Returns the names of `$this->x`, `self::$x` and `static::$x` references.
+     *
+     * @param list<Node> $statements
+     * @return list<string>
+     */
+    private function properties(NodeFinder $finder, array $statements): array
+    {
+        $names = [];
+
+        foreach ($finder->find(
+            $statements,
+            static fn(Node $inner): bool => $inner instanceof PropertyFetch,
+        ) as $fetch) {
+            assert($fetch instanceof PropertyFetch);
+            $name = $this->instancePropertyName($fetch);
+
+            if ($name !== null) {
+                $names[] = $name;
+            }
+        }
+
+        foreach ($finder->find(
+            $statements,
+            static fn(Node $inner): bool => $inner instanceof StaticPropertyFetch,
+        ) as $fetch) {
+            assert($fetch instanceof StaticPropertyFetch);
+            $name = $this->staticPropertyName($fetch);
+
+            if ($name !== null) {
+                $names[] = $name;
+            }
+        }
+
+        return array_values(array_unique($names));
+    }
+
+    /**
+     * Returns the names of methods called via `$this->method()`.
+     *
+     * @param list<Node> $statements
+     * @return list<string>
+     */
+    private function calls(NodeFinder $finder, array $statements): array
+    {
+        $names = [];
+
+        foreach ($finder->find($statements, static fn(Node $inner): bool => $inner instanceof MethodCall) as $call) {
+            assert($call instanceof MethodCall);
+
+            if ($call->var instanceof Variable && $call->var->name === 'this' && $call->name instanceof Identifier) {
+                $names[] = $call->name->toString();
+            }
+        }
+
+        return array_values(array_unique($names));
+    }
+
+    /**
+     * Returns the property name if the fetch is `$this->x`, otherwise null.
+     */
+    private function instancePropertyName(PropertyFetch $fetch): ?string
+    {
+        if ($fetch->var instanceof Variable && $fetch->var->name === 'this' && $fetch->name instanceof Identifier) {
+            return $fetch->name->toString();
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns the property name if the fetch is `self::$x` / `static::$x`, otherwise null.
+     */
+    private function staticPropertyName(StaticPropertyFetch $fetch): ?string
+    {
+        if ($fetch->class instanceof Name
+            && in_array($fetch->class->toLowerString(), ['self', 'static'], true)
+            && $fetch->name instanceof Identifier
+        ) {
+            return $fetch->name->toString();
+        }
+
+        return null;
+    }
+}

--- a/src/Rules/LackOfCohesionRule/MethodTouches.php
+++ b/src/Rules/LackOfCohesionRule/MethodTouches.php
@@ -7,6 +7,7 @@ namespace Haspadar\PHPStanRules\Rules\LackOfCohesionRule;
 use PhpParser\Node;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\StaticPropertyFetch;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
@@ -18,12 +19,16 @@ use PhpParser\NodeFinder;
  * Collects property accesses and method calls performed by a class method.
  *
  * Both `$this->x` instance fetches and `self::$x` / `static::$x` static fetches are
- * treated as references to the same "property" for cohesion analysis.
+ * treated as references to the same "property" for cohesion analysis. Method names are
+ * normalised to lowercase because PHP method names are case-insensitive.
  */
 final readonly class MethodTouches
 {
     /**
      * Returns property names and called method names referenced from the method body.
+     *
+     * Method names are lowercased; property names keep their original case (PHP property
+     * names are case-sensitive).
      *
      * @return array{properties: list<string>, calls: list<string>}
      */
@@ -76,7 +81,7 @@ final readonly class MethodTouches
     }
 
     /**
-     * Returns the names of methods called via `$this->method()`.
+     * Returns the lowercased names of methods called via `$this->method()`, `self::method()` or `static::method()`.
      *
      * @param list<Node> $statements
      * @return list<string>
@@ -85,11 +90,27 @@ final readonly class MethodTouches
     {
         $names = [];
 
-        foreach ($finder->find($statements, static fn(Node $inner): bool => $inner instanceof MethodCall) as $call) {
+        foreach ($finder->find(
+            $statements,
+            static fn(Node $inner): bool => $inner instanceof MethodCall,
+        ) as $call) {
             assert($call instanceof MethodCall);
+            $name = $this->instanceCallName($call);
 
-            if ($call->var instanceof Variable && $call->var->name === 'this' && $call->name instanceof Identifier) {
-                $names[] = $call->name->toString();
+            if ($name !== null) {
+                $names[] = $name;
+            }
+        }
+
+        foreach ($finder->find(
+            $statements,
+            static fn(Node $inner): bool => $inner instanceof StaticCall,
+        ) as $call) {
+            assert($call instanceof StaticCall);
+            $name = $this->staticCallName($call);
+
+            if ($name !== null) {
+                $names[] = $name;
             }
         }
 
@@ -118,6 +139,33 @@ final readonly class MethodTouches
             && $fetch->name instanceof Identifier
         ) {
             return $fetch->name->toString();
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns the lowercased method name if the call is `$this->method()`, otherwise null.
+     */
+    private function instanceCallName(MethodCall $call): ?string
+    {
+        if ($call->var instanceof Variable && $call->var->name === 'this' && $call->name instanceof Identifier) {
+            return strtolower($call->name->toString());
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns the lowercased method name if the call is `self::method()` / `static::method()`, otherwise null.
+     */
+    private function staticCallName(StaticCall $call): ?string
+    {
+        if ($call->class instanceof Name
+            && in_array($call->class->toLowerString(), ['self', 'static'], true)
+            && $call->name instanceof Identifier
+        ) {
+            return strtolower($call->name->toString());
         }
 
         return null;

--- a/tests/Fixtures/Rules/LackOfCohesionRule/AbstractDisjointClass.php
+++ b/tests/Fixtures/Rules/LackOfCohesionRule/AbstractDisjointClass.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\LackOfCohesionRule;
+
+abstract class AbstractDisjointClass
+{
+    private int $a = 0;
+
+    private int $b = 0;
+
+    private int $c = 0;
+
+    public function firstGroupOne(): int
+    {
+        return $this->a;
+    }
+
+    public function firstGroupTwo(): int
+    {
+        return $this->a + 1;
+    }
+
+    public function firstGroupThree(): int
+    {
+        return $this->a * 2;
+    }
+
+    public function secondGroupOne(): int
+    {
+        return $this->b;
+    }
+
+    public function secondGroupTwo(): int
+    {
+        return $this->b + $this->c;
+    }
+
+    public function secondGroupThree(): int
+    {
+        return $this->c;
+    }
+
+    public function secondGroupFour(): int
+    {
+        return $this->c * 3;
+    }
+}

--- a/tests/Fixtures/Rules/LackOfCohesionRule/AnonymousDisjointClass.php
+++ b/tests/Fixtures/Rules/LackOfCohesionRule/AnonymousDisjointClass.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\LackOfCohesionRule;
+
+final class AnonymousDisjointClass
+{
+    public function make(): object
+    {
+        return new class {
+            private int $a = 0;
+
+            private int $b = 0;
+
+            private int $c = 0;
+
+            public function firstGroupOne(): int
+            {
+                return $this->a;
+            }
+
+            public function firstGroupTwo(): int
+            {
+                return $this->a + 1;
+            }
+
+            public function firstGroupThree(): int
+            {
+                return $this->a * 2;
+            }
+
+            public function secondGroupOne(): int
+            {
+                return $this->b;
+            }
+
+            public function secondGroupTwo(): int
+            {
+                return $this->b + $this->c;
+            }
+
+            public function secondGroupThree(): int
+            {
+                return $this->c;
+            }
+
+            public function secondGroupFour(): int
+            {
+                return $this->c * 3;
+            }
+        };
+    }
+}

--- a/tests/Fixtures/Rules/LackOfCohesionRule/CohesiveClass.php
+++ b/tests/Fixtures/Rules/LackOfCohesionRule/CohesiveClass.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\LackOfCohesionRule;
+
+final class CohesiveClass
+{
+    private int $a = 0;
+
+    private int $b = 0;
+
+    private int $c = 0;
+
+    public function first(): int
+    {
+        return $this->a + $this->b;
+    }
+
+    public function second(): int
+    {
+        return $this->b + $this->c;
+    }
+
+    public function third(): int
+    {
+        return $this->a + $this->c;
+    }
+
+    public function fourth(): int
+    {
+        return $this->a;
+    }
+
+    public function fifth(): int
+    {
+        return $this->b;
+    }
+
+    public function sixth(): int
+    {
+        return $this->c;
+    }
+
+    public function seventh(): int
+    {
+        return $this->a + $this->b + $this->c;
+    }
+}

--- a/tests/Fixtures/Rules/LackOfCohesionRule/DisjointClass.php
+++ b/tests/Fixtures/Rules/LackOfCohesionRule/DisjointClass.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\LackOfCohesionRule;
+
+final class DisjointClass
+{
+    private int $a = 0;
+
+    private int $b = 0;
+
+    private int $c = 0;
+
+    public function firstGroupOne(): int
+    {
+        return $this->a;
+    }
+
+    public function firstGroupTwo(): int
+    {
+        return $this->a + 1;
+    }
+
+    public function firstGroupThree(): int
+    {
+        return $this->a * 2;
+    }
+
+    public function firstGroupFour(): int
+    {
+        return $this->a - 3;
+    }
+
+    public function secondGroupOne(): int
+    {
+        return $this->b;
+    }
+
+    public function secondGroupTwo(): int
+    {
+        return $this->b + $this->c;
+    }
+
+    public function secondGroupThree(): int
+    {
+        return $this->c;
+    }
+}

--- a/tests/Fixtures/Rules/LackOfCohesionRule/DisjointDefaultClass.php
+++ b/tests/Fixtures/Rules/LackOfCohesionRule/DisjointDefaultClass.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\LackOfCohesionRule;
+
+final class DisjointDefaultClass
+{
+    private int $a = 0;
+
+    private int $b = 0;
+
+    private int $c = 0;
+
+    public function firstGroupOne(): int
+    {
+        return $this->a;
+    }
+
+    public function firstGroupTwo(): int
+    {
+        return $this->a + 1;
+    }
+
+    public function firstGroupThree(): int
+    {
+        return $this->a * 2;
+    }
+
+    public function secondGroupOne(): int
+    {
+        return $this->b;
+    }
+
+    public function secondGroupTwo(): int
+    {
+        return $this->b + $this->c;
+    }
+
+    public function secondGroupThree(): int
+    {
+        return $this->c;
+    }
+
+    public function secondGroupFour(): int
+    {
+        return $this->c * 3;
+    }
+}

--- a/tests/Fixtures/Rules/LackOfCohesionRule/ExactDefaultCohesiveClass.php
+++ b/tests/Fixtures/Rules/LackOfCohesionRule/ExactDefaultCohesiveClass.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\LackOfCohesionRule;
+
+final class ExactDefaultCohesiveClass
+{
+    private int $a = 0;
+
+    private int $b = 0;
+
+    private int $c = 0;
+
+    public function one(): int
+    {
+        return $this->a + $this->b;
+    }
+
+    public function two(): int
+    {
+        return $this->b + $this->c;
+    }
+
+    public function three(): int
+    {
+        return $this->a + $this->c;
+    }
+
+    public function four(): int
+    {
+        return $this->a;
+    }
+
+    public function five(): int
+    {
+        return $this->b;
+    }
+
+    public function six(): int
+    {
+        return $this->c;
+    }
+
+    public function seven(): int
+    {
+        return $this->a + $this->b + $this->c;
+    }
+}

--- a/tests/Fixtures/Rules/LackOfCohesionRule/ExcludedClass.php
+++ b/tests/Fixtures/Rules/LackOfCohesionRule/ExcludedClass.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\LackOfCohesionRule;
+
+final class ExcludedClass
+{
+    private int $a = 0;
+
+    private int $b = 0;
+
+    private int $c = 0;
+
+    public function firstGroupOne(): int
+    {
+        return $this->a;
+    }
+
+    public function firstGroupTwo(): int
+    {
+        return $this->a + 1;
+    }
+
+    public function firstGroupThree(): int
+    {
+        return $this->a * 2;
+    }
+
+    public function secondGroupOne(): int
+    {
+        return $this->b;
+    }
+
+    public function secondGroupTwo(): int
+    {
+        return $this->b + $this->c;
+    }
+
+    public function secondGroupThree(): int
+    {
+        return $this->c;
+    }
+
+    public function secondGroupFour(): int
+    {
+        return $this->c * 3;
+    }
+}

--- a/tests/Fixtures/Rules/LackOfCohesionRule/FewPropertiesClass.php
+++ b/tests/Fixtures/Rules/LackOfCohesionRule/FewPropertiesClass.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\LackOfCohesionRule;
+
+final class FewPropertiesClass
+{
+    private int $a = 0;
+
+    private int $b = 0;
+
+    public function one(): int
+    {
+        return $this->a;
+    }
+
+    public function two(): int
+    {
+        return $this->a + 1;
+    }
+
+    public function three(): int
+    {
+        return $this->a * 2;
+    }
+
+    public function four(): int
+    {
+        return $this->b;
+    }
+
+    public function five(): int
+    {
+        return $this->b + 1;
+    }
+
+    public function six(): int
+    {
+        return $this->b * 2;
+    }
+
+    public function seven(): int
+    {
+        return $this->b - 3;
+    }
+}

--- a/tests/Fixtures/Rules/LackOfCohesionRule/InterfaceWithManyMethods.php
+++ b/tests/Fixtures/Rules/LackOfCohesionRule/InterfaceWithManyMethods.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\LackOfCohesionRule;
+
+interface InterfaceWithManyMethods
+{
+    public function one(): int;
+
+    public function two(): int;
+
+    public function three(): int;
+
+    public function four(): int;
+
+    public function five(): int;
+
+    public function six(): int;
+
+    public function seven(): int;
+}

--- a/tests/Fixtures/Rules/LackOfCohesionRule/MethodChainCohesiveClass.php
+++ b/tests/Fixtures/Rules/LackOfCohesionRule/MethodChainCohesiveClass.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\LackOfCohesionRule;
+
+final class MethodChainCohesiveClass
+{
+    private int $a = 0;
+
+    private int $b = 0;
+
+    private int $c = 0;
+
+    public function first(): int
+    {
+        return $this->second() + $this->a;
+    }
+
+    public function second(): int
+    {
+        return $this->third() + 1;
+    }
+
+    public function third(): int
+    {
+        return $this->fourth();
+    }
+
+    public function fourth(): int
+    {
+        return $this->b + $this->c;
+    }
+
+    public function fifth(): int
+    {
+        return $this->first() * 2;
+    }
+
+    public function sixth(): int
+    {
+        return $this->fifth() - 3;
+    }
+
+    public function seventh(): int
+    {
+        return $this->sixth();
+    }
+}

--- a/tests/Fixtures/Rules/LackOfCohesionRule/MixedCaseCallCohesiveClass.php
+++ b/tests/Fixtures/Rules/LackOfCohesionRule/MixedCaseCallCohesiveClass.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\LackOfCohesionRule;
+
+final class MixedCaseCallCohesiveClass
+{
+    private int $a = 0;
+
+    private int $b = 0;
+
+    private int $c = 0;
+
+    public function doWork(): int
+    {
+        return $this->DoHelper() + $this->a;
+    }
+
+    public function doHelper(): int
+    {
+        return $this->b;
+    }
+
+    public function firstGroupExtra(): int
+    {
+        return $this->a;
+    }
+
+    public function secondGroupOne(): int
+    {
+        return $this->b;
+    }
+
+    public function secondGroupTwo(): int
+    {
+        return $this->c;
+    }
+
+    public function secondGroupThree(): int
+    {
+        return $this->b + $this->c;
+    }
+
+    public function secondGroupFour(): int
+    {
+        return $this->c * 2;
+    }
+}

--- a/tests/Fixtures/Rules/LackOfCohesionRule/PromotedPropertiesDisjointClass.php
+++ b/tests/Fixtures/Rules/LackOfCohesionRule/PromotedPropertiesDisjointClass.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\LackOfCohesionRule;
+
+final class PromotedPropertiesDisjointClass
+{
+    public function __construct(
+        private int $a = 0,
+        private int $b = 0,
+        private int $c = 0,
+    ) {
+    }
+
+    public function firstGroupOne(): int
+    {
+        return $this->a;
+    }
+
+    public function firstGroupTwo(): int
+    {
+        return $this->a + 1;
+    }
+
+    public function firstGroupThree(): int
+    {
+        return $this->a * 2;
+    }
+
+    public function secondGroupOne(): int
+    {
+        return $this->b;
+    }
+
+    public function secondGroupTwo(): int
+    {
+        return $this->b + $this->c;
+    }
+
+    public function secondGroupThree(): int
+    {
+        return $this->c;
+    }
+
+    public function secondGroupFour(): int
+    {
+        return $this->c * 3;
+    }
+}

--- a/tests/Fixtures/Rules/LackOfCohesionRule/SelfStaticCallCohesiveClass.php
+++ b/tests/Fixtures/Rules/LackOfCohesionRule/SelfStaticCallCohesiveClass.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\LackOfCohesionRule;
+
+final class SelfStaticCallCohesiveClass
+{
+    private static int $counter = 0;
+
+    private int $a = 0;
+
+    private int $b = 0;
+
+    public function first(): int
+    {
+        return self::second() + $this->a;
+    }
+
+    public static function second(): int
+    {
+        return static::third() + self::$counter;
+    }
+
+    public static function third(): int
+    {
+        return self::$counter;
+    }
+
+    public function fourth(): int
+    {
+        return $this->a + $this->b;
+    }
+
+    public function fifth(): int
+    {
+        return $this->first();
+    }
+
+    public function sixth(): int
+    {
+        return $this->fourth();
+    }
+
+    public function seventh(): int
+    {
+        return $this->fifth() + $this->sixth();
+    }
+}

--- a/tests/Fixtures/Rules/LackOfCohesionRule/SmallClass.php
+++ b/tests/Fixtures/Rules/LackOfCohesionRule/SmallClass.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\LackOfCohesionRule;
+
+final class SmallClass
+{
+    private int $a = 0;
+
+    private int $b = 0;
+
+    private int $c = 0;
+
+    public function one(): int
+    {
+        return $this->a;
+    }
+
+    public function two(): int
+    {
+        return $this->b;
+    }
+
+    public function three(): int
+    {
+        return $this->c;
+    }
+
+    public function four(): int
+    {
+        return $this->a + $this->b;
+    }
+}

--- a/tests/Fixtures/Rules/LackOfCohesionRule/SuppressedDisjointClass.php
+++ b/tests/Fixtures/Rules/LackOfCohesionRule/SuppressedDisjointClass.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\LackOfCohesionRule;
+
+/** @phpstan-ignore haspadar.lackOfCohesion */
+final class SuppressedDisjointClass
+{
+    private int $a = 0;
+
+    private int $b = 0;
+
+    private int $c = 0;
+
+    public function firstGroupOne(): int
+    {
+        return $this->a;
+    }
+
+    public function firstGroupTwo(): int
+    {
+        return $this->a + 1;
+    }
+
+    public function firstGroupThree(): int
+    {
+        return $this->a * 2;
+    }
+
+    public function secondGroupOne(): int
+    {
+        return $this->b;
+    }
+
+    public function secondGroupTwo(): int
+    {
+        return $this->b + $this->c;
+    }
+
+    public function secondGroupThree(): int
+    {
+        return $this->c;
+    }
+
+    public function secondGroupFour(): int
+    {
+        return $this->c * 3;
+    }
+}

--- a/tests/Fixtures/Rules/LackOfCohesionRule/TraitWithDisjointMethods.php
+++ b/tests/Fixtures/Rules/LackOfCohesionRule/TraitWithDisjointMethods.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\LackOfCohesionRule;
+
+trait TraitWithDisjointMethods
+{
+    private int $a = 0;
+
+    private int $b = 0;
+
+    private int $c = 0;
+
+    public function firstGroupOne(): int
+    {
+        return $this->a;
+    }
+
+    public function firstGroupTwo(): int
+    {
+        return $this->a + 1;
+    }
+
+    public function firstGroupThree(): int
+    {
+        return $this->a * 2;
+    }
+
+    public function secondGroupOne(): int
+    {
+        return $this->b;
+    }
+
+    public function secondGroupTwo(): int
+    {
+        return $this->b + $this->c;
+    }
+
+    public function secondGroupThree(): int
+    {
+        return $this->c;
+    }
+
+    public function secondGroupFour(): int
+    {
+        return $this->c * 3;
+    }
+}

--- a/tests/Unit/Rules/LackOfCohesionRule/LackOfCohesionRuleAnonymousTest.php
+++ b/tests/Unit/Rules/LackOfCohesionRule/LackOfCohesionRuleAnonymousTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\LackOfCohesionRule;
+
+use Haspadar\PHPStanRules\Rules\LackOfCohesionRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<LackOfCohesionRule> */
+final class LackOfCohesionRuleAnonymousTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new LackOfCohesionRule(1, ['minMethods' => 4, 'minProperties' => 2]);
+    }
+
+    #[Test]
+    public function skipsAnonymousClassDeclarations(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/LackOfCohesionRule/AnonymousDisjointClass.php'],
+            [],
+            'anonymous classes are skipped via isAnonymous()',
+        );
+    }
+}

--- a/tests/Unit/Rules/LackOfCohesionRule/LackOfCohesionRuleCaseInsensitiveCallTest.php
+++ b/tests/Unit/Rules/LackOfCohesionRule/LackOfCohesionRuleCaseInsensitiveCallTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\LackOfCohesionRule;
+
+use Haspadar\PHPStanRules\Rules\LackOfCohesionRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<LackOfCohesionRule> */
+final class LackOfCohesionRuleCaseInsensitiveCallTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new LackOfCohesionRule(1, ['minMethods' => 4, 'minProperties' => 2]);
+    }
+
+    #[Test]
+    public function matchesMethodCallsRegardlessOfLetterCase(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/LackOfCohesionRule/MixedCaseCallCohesiveClass.php'],
+            [],
+            'PHP method names are case-insensitive, $this->DoHelper() must link to doHelper()',
+        );
+    }
+}

--- a/tests/Unit/Rules/LackOfCohesionRule/LackOfCohesionRuleDefaultLimitTest.php
+++ b/tests/Unit/Rules/LackOfCohesionRule/LackOfCohesionRuleDefaultLimitTest.php
@@ -32,7 +32,7 @@ final class LackOfCohesionRuleDefaultLimitTest extends RuleTestCase
         $this->analyse(
             [__DIR__ . '/../../../Fixtures/Rules/LackOfCohesionRule/DisjointDefaultClass.php'],
             [
-                ['Class DisjointDefaultClass has lack of cohesion 2 (methods split into 2 disjoint groups). Maximum allowed is 1.', 7],
+                ['Class DisjointDefaultClass splits into 2 disjoint method groups (LCOM4). Maximum allowed is 1.', 7],
             ],
         );
     }

--- a/tests/Unit/Rules/LackOfCohesionRule/LackOfCohesionRuleDefaultLimitTest.php
+++ b/tests/Unit/Rules/LackOfCohesionRule/LackOfCohesionRuleDefaultLimitTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\LackOfCohesionRule;
+
+use Haspadar\PHPStanRules\Rules\LackOfCohesionRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<LackOfCohesionRule> */
+final class LackOfCohesionRuleDefaultLimitTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new LackOfCohesionRule();
+    }
+
+    #[Test]
+    public function passesWhenClassIsCohesiveAtDefaultLimits(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/LackOfCohesionRule/ExactDefaultCohesiveClass.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function reportsErrorWhenClassSplitsIntoDisjointGroupsAtDefaultLimits(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/LackOfCohesionRule/DisjointDefaultClass.php'],
+            [
+                ['Class DisjointDefaultClass has lack of cohesion 2 (methods split into 2 disjoint groups). Maximum allowed is 1.', 7],
+            ],
+        );
+    }
+}

--- a/tests/Unit/Rules/LackOfCohesionRule/LackOfCohesionRuleExcludedClassesTest.php
+++ b/tests/Unit/Rules/LackOfCohesionRule/LackOfCohesionRuleExcludedClassesTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\LackOfCohesionRule;
+
+use Haspadar\PHPStanRules\Rules\LackOfCohesionRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<LackOfCohesionRule> */
+final class LackOfCohesionRuleExcludedClassesTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new LackOfCohesionRule(1, [
+            'minMethods' => 4,
+            'minProperties' => 2,
+            'excludedClasses' => ['Haspadar\\PHPStanRules\\Tests\\Fixtures\\Rules\\LackOfCohesionRule\\ExcludedClass'],
+        ]);
+    }
+
+    #[Test]
+    public function skipsClassListedInExcludedClasses(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/LackOfCohesionRule/ExcludedClass.php'],
+            [],
+        );
+    }
+}

--- a/tests/Unit/Rules/LackOfCohesionRule/LackOfCohesionRuleInterfaceTest.php
+++ b/tests/Unit/Rules/LackOfCohesionRule/LackOfCohesionRuleInterfaceTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\LackOfCohesionRule;
+
+use Haspadar\PHPStanRules\Rules\LackOfCohesionRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<LackOfCohesionRule> */
+final class LackOfCohesionRuleInterfaceTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new LackOfCohesionRule(1, ['minMethods' => 4, 'minProperties' => 2]);
+    }
+
+    #[Test]
+    public function skipsInterfaceDeclarations(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/LackOfCohesionRule/InterfaceWithManyMethods.php'],
+            [],
+            'interfaces are not Class_ nodes, the rule must not fire on them',
+        );
+    }
+}

--- a/tests/Unit/Rules/LackOfCohesionRule/LackOfCohesionRuleMinMethodsTest.php
+++ b/tests/Unit/Rules/LackOfCohesionRule/LackOfCohesionRuleMinMethodsTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\LackOfCohesionRule;
+
+use Haspadar\PHPStanRules\Rules\LackOfCohesionRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<LackOfCohesionRule> */
+final class LackOfCohesionRuleMinMethodsTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new LackOfCohesionRule(1, ['minMethods' => 5, 'minProperties' => 2]);
+    }
+
+    #[Test]
+    public function skipsClassWithFewerMethodsThanMinMethods(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/LackOfCohesionRule/SmallClass.php'],
+            [],
+        );
+    }
+}

--- a/tests/Unit/Rules/LackOfCohesionRule/LackOfCohesionRuleMinPropertiesTest.php
+++ b/tests/Unit/Rules/LackOfCohesionRule/LackOfCohesionRuleMinPropertiesTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\LackOfCohesionRule;
+
+use Haspadar\PHPStanRules\Rules\LackOfCohesionRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<LackOfCohesionRule> */
+final class LackOfCohesionRuleMinPropertiesTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new LackOfCohesionRule(1, ['minMethods' => 4, 'minProperties' => 3]);
+    }
+
+    #[Test]
+    public function skipsClassWithFewerPropertiesThanMinProperties(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/LackOfCohesionRule/FewPropertiesClass.php'],
+            [],
+        );
+    }
+}

--- a/tests/Unit/Rules/LackOfCohesionRule/LackOfCohesionRulePromotedPropertiesTest.php
+++ b/tests/Unit/Rules/LackOfCohesionRule/LackOfCohesionRulePromotedPropertiesTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\LackOfCohesionRule;
+
+use Haspadar\PHPStanRules\Rules\LackOfCohesionRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<LackOfCohesionRule> */
+final class LackOfCohesionRulePromotedPropertiesTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new LackOfCohesionRule();
+    }
+
+    #[Test]
+    public function countsPromotedConstructorParametersTowardsMinProperties(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/LackOfCohesionRule/PromotedPropertiesDisjointClass.php'],
+            [
+                ['Class PromotedPropertiesDisjointClass splits into 2 disjoint method groups (LCOM4). Maximum allowed is 1.', 7],
+            ],
+            'promoted constructor properties count toward minProperties, otherwise the class would be skipped',
+        );
+    }
+}

--- a/tests/Unit/Rules/LackOfCohesionRule/LackOfCohesionRuleSelfStaticCallTest.php
+++ b/tests/Unit/Rules/LackOfCohesionRule/LackOfCohesionRuleSelfStaticCallTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\LackOfCohesionRule;
+
+use Haspadar\PHPStanRules\Rules\LackOfCohesionRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<LackOfCohesionRule> */
+final class LackOfCohesionRuleSelfStaticCallTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new LackOfCohesionRule(1, ['minMethods' => 4, 'minProperties' => 2]);
+    }
+
+    #[Test]
+    public function linksMethodsConnectedViaSelfAndStaticCalls(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/LackOfCohesionRule/SelfStaticCallCohesiveClass.php'],
+            [],
+            'self::method() and static::method() must create edges in the cohesion graph',
+        );
+    }
+}

--- a/tests/Unit/Rules/LackOfCohesionRule/LackOfCohesionRuleTest.php
+++ b/tests/Unit/Rules/LackOfCohesionRule/LackOfCohesionRuleTest.php
@@ -32,7 +32,7 @@ final class LackOfCohesionRuleTest extends RuleTestCase
         $this->analyse(
             [__DIR__ . '/../../../Fixtures/Rules/LackOfCohesionRule/DisjointClass.php'],
             [
-                ['Class DisjointClass has lack of cohesion 2 (methods split into 2 disjoint groups). Maximum allowed is 1.', 7],
+                ['Class DisjointClass splits into 2 disjoint method groups (LCOM4). Maximum allowed is 1.', 7],
             ],
         );
     }

--- a/tests/Unit/Rules/LackOfCohesionRule/LackOfCohesionRuleTest.php
+++ b/tests/Unit/Rules/LackOfCohesionRule/LackOfCohesionRuleTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\LackOfCohesionRule;
+
+use Haspadar\PHPStanRules\Rules\LackOfCohesionRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<LackOfCohesionRule> */
+final class LackOfCohesionRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new LackOfCohesionRule(1, ['minMethods' => 4, 'minProperties' => 2]);
+    }
+
+    #[Test]
+    public function passesWhenClassIsCohesive(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/LackOfCohesionRule/CohesiveClass.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function reportsErrorWhenClassSplitsIntoDisjointGroups(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/LackOfCohesionRule/DisjointClass.php'],
+            [
+                ['Class DisjointClass has lack of cohesion 2 (methods split into 2 disjoint groups). Maximum allowed is 1.', 7],
+            ],
+        );
+    }
+
+    #[Test]
+    public function passesWhenMethodsAreConnectedOnlyViaMutualCalls(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/LackOfCohesionRule/MethodChainCohesiveClass.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function suppressesErrorWhenPhpstanIgnorePresent(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/LackOfCohesionRule/SuppressedDisjointClass.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function skipsAbstractClass(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/LackOfCohesionRule/AbstractDisjointClass.php'],
+            [],
+        );
+    }
+}

--- a/tests/Unit/Rules/LackOfCohesionRule/LackOfCohesionRuleTraitTest.php
+++ b/tests/Unit/Rules/LackOfCohesionRule/LackOfCohesionRuleTraitTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\LackOfCohesionRule;
+
+use Haspadar\PHPStanRules\Rules\LackOfCohesionRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<LackOfCohesionRule> */
+final class LackOfCohesionRuleTraitTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new LackOfCohesionRule(1, ['minMethods' => 4, 'minProperties' => 2]);
+    }
+
+    #[Test]
+    public function skipsTraitDeclarations(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/LackOfCohesionRule/TraitWithDisjointMethods.php'],
+            [],
+            'traits are not Class_ nodes, the rule must not fire on them',
+        );
+    }
+}

--- a/tests/Unit/RulesTest.php
+++ b/tests/Unit/RulesTest.php
@@ -57,6 +57,7 @@ use Haspadar\PHPStanRules\Rules\NeverUsePublicConstantsRule;
 use Haspadar\PHPStanRules\Rules\WeightedMethodsPerClassRule;
 use Haspadar\PHPStanRules\Rules\AfferentCouplingRule;
 use Haspadar\PHPStanRules\Rules\InheritanceDepthRule;
+use Haspadar\PHPStanRules\Rules\LackOfCohesionRule;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -119,6 +120,7 @@ final class RulesTest extends TestCase
                 WeightedMethodsPerClassRule::class,
                 AfferentCouplingRule::class,
                 InheritanceDepthRule::class,
+                LackOfCohesionRule::class,
             ],
             (new Rules())->all(),
             'Rules::all() must list every registered rule class',


### PR DESCRIPTION
## Summary
- New PHPStan rule `LackOfCohesionRule` (identifier `haspadar.lackOfCohesion`) reports classes whose methods split into more than `maxLcom` disjoint groups (LCOM4).
- Graph vertices are all eligible methods; edges are shared property touches or `$this->m()`, `self::m()`, `static::m()` calls (case-insensitive, matching PHP semantics).
- Defaults: `maxLcom=1`, `minMethods=7`, `minProperties=3`, `excludedClasses=[]`. Promoted constructor parameters count toward `minProperties`.
- Abstract, anonymous, interface, trait and excluded classes are skipped. Magic methods and constructors are excluded from the graph.

## Test plan
- [x] `piqule check` passes (14/14)
- [x] `piqule check infection` passes (MSI unchanged)
- [x] Fixtures cover cohesive, disjoint, default-limit, minMethods, minProperties, excluded, suppressed, abstract, anonymous, interface, trait, promoted, self/static calls, mixed-case calls
- [x] Rule registered in `Rules::all()` and wired in `rules.neon` with schema

Closes #136

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Lack of Cohesion (LCOM4) rule to detect classes where methods have weak connectivity and can be split into separate groups, indicating poor design cohesion.

* **Documentation**
  * Updated documentation with the new rule, its default threshold, and configurable parameters including method/property minimums and excluded classes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->