### PR TITLE
Close LCOM4 rule coverage: suppress, interface/trait, defaults, README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 | `WeightedMethodsPerClassRule`     | 50      | Sum of cyclomatic complexities of all methods must not exceed N            |
 | `AfferentCouplingRule`            | 14      | Class must not be referenced by more than N other classes in the codebase  |
 | `InheritanceDepthRule`            | 3       | Class must not extend a chain of more than N ancestors                     |
+| `LackOfCohesionRule`              | 1       | Class methods must not split into more than N disjoint LCOM4 groups        |
 
 ### Design
 
@@ -209,6 +210,12 @@ parameters:
             maxDepth: 2
             excludedClasses:
                 - Symfony\Bundle\FrameworkBundle\Controller\AbstractController
+        lackOfCohesion:
+            maxLcom: 1
+            minMethods: 7
+            minProperties: 3
+            excludedClasses:
+                - App\Entity\User
 ```
 
 Default values match the defaults described in the rules table above. Omitting a parameter keeps the default. Diagnostic identifier for `AtclauseOrderRule`: `haspadar.atclauseOrder` (for targeted ignores, e.g. `@phpstan-ignore haspadar.atclauseOrder`).

--- a/tests/Fixtures/Rules/LackOfCohesionRule/DefaultThresholdsDisjoint.php
+++ b/tests/Fixtures/Rules/LackOfCohesionRule/DefaultThresholdsDisjoint.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\LackOfCohesionRule;
+
+final class DefaultThresholdsDisjoint
+{
+    private int $a = 0;
+
+    private int $b = 0;
+
+    private int $c = 0;
+
+    public function firstGroupOne(): int
+    {
+        return $this->a;
+    }
+
+    public function firstGroupTwo(): int
+    {
+        return $this->a + 1;
+    }
+
+    public function firstGroupThree(): int
+    {
+        return $this->a * 2;
+    }
+
+    public function firstGroupFour(): int
+    {
+        return $this->a - 3;
+    }
+
+    public function secondGroupOne(): int
+    {
+        return $this->b + $this->c;
+    }
+
+    public function secondGroupTwo(): int
+    {
+        return $this->b;
+    }
+
+    public function secondGroupThree(): int
+    {
+        return $this->c;
+    }
+}

--- a/tests/Fixtures/Rules/LackOfCohesionRule/DisjointInterface.php
+++ b/tests/Fixtures/Rules/LackOfCohesionRule/DisjointInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\LackOfCohesionRule;
+
+interface DisjointInterface
+{
+    public function firstGroupOne(): int;
+
+    public function firstGroupTwo(): int;
+
+    public function secondGroupOne(): int;
+
+    public function secondGroupTwo(): int;
+}

--- a/tests/Fixtures/Rules/LackOfCohesionRule/DisjointTrait.php
+++ b/tests/Fixtures/Rules/LackOfCohesionRule/DisjointTrait.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\LackOfCohesionRule;
+
+trait DisjointTrait
+{
+    private int $a = 0;
+
+    private int $b = 0;
+
+    public function firstGroupOne(): int
+    {
+        return $this->a;
+    }
+
+    public function firstGroupTwo(): int
+    {
+        return $this->a + 1;
+    }
+
+    public function secondGroupOne(): int
+    {
+        return $this->b;
+    }
+
+    public function secondGroupTwo(): int
+    {
+        return $this->b + 1;
+    }
+}

--- a/tests/Fixtures/Rules/LackOfCohesionRule/SuppressedDisjointClass.php
+++ b/tests/Fixtures/Rules/LackOfCohesionRule/SuppressedDisjointClass.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\LackOfCohesionRule;
+
+/** @phpstan-ignore haspadar.lackOfCohesion */
+final class SuppressedDisjointClass
+{
+    private int $a = 0;
+
+    private int $b = 0;
+
+    public function firstGroupOne(): int
+    {
+        return $this->a;
+    }
+
+    public function firstGroupTwo(): int
+    {
+        return $this->a + 1;
+    }
+
+    public function secondGroupOne(): int
+    {
+        return $this->b;
+    }
+
+    public function secondGroupTwo(): int
+    {
+        return $this->b + 1;
+    }
+}

--- a/tests/Unit/Rules/LackOfCohesionRule/LackOfCohesionRuleDefaultThresholdsTest.php
+++ b/tests/Unit/Rules/LackOfCohesionRule/LackOfCohesionRuleDefaultThresholdsTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\LackOfCohesionRule;
+
+use Haspadar\PHPStanRules\Rules\LackOfCohesionRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<LackOfCohesionRule> */
+final class LackOfCohesionRuleDefaultThresholdsTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new LackOfCohesionRule();
+    }
+
+    #[Test]
+    public function usesDefaultMinThresholdsOfSevenMethodsAndThreeProperties(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/LackOfCohesionRule/DefaultThresholdsDisjoint.php'],
+            [
+                ['Class DefaultThresholdsDisjoint splits into 2 disjoint method groups (LCOM4). Maximum allowed is 1.', 7],
+            ],
+            'without options the rule must apply minMethods=7 and minProperties=3 as defaults',
+        );
+    }
+}

--- a/tests/Unit/Rules/LackOfCohesionRule/LackOfCohesionRuleInterfaceAndTraitTest.php
+++ b/tests/Unit/Rules/LackOfCohesionRule/LackOfCohesionRuleInterfaceAndTraitTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\LackOfCohesionRule;
+
+use Haspadar\PHPStanRules\Rules\LackOfCohesionRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<LackOfCohesionRule> */
+final class LackOfCohesionRuleInterfaceAndTraitTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new LackOfCohesionRule(1, ['minMethods' => 4, 'minProperties' => 2]);
+    }
+
+    #[Test]
+    public function skipsInterfacesAndTraitsEvenWhenMethodsAreDisjoint(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/../../../Fixtures/Rules/LackOfCohesionRule/DisjointInterface.php',
+                __DIR__ . '/../../../Fixtures/Rules/LackOfCohesionRule/DisjointTrait.php',
+            ],
+            [],
+            'the rule targets Class_ nodes only — interfaces and traits must be skipped',
+        );
+    }
+}

--- a/tests/Unit/Rules/LackOfCohesionRule/LackOfCohesionRuleSuppressedTest.php
+++ b/tests/Unit/Rules/LackOfCohesionRule/LackOfCohesionRuleSuppressedTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\LackOfCohesionRule;
+
+use Haspadar\PHPStanRules\Rules\LackOfCohesionRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<LackOfCohesionRule> */
+final class LackOfCohesionRuleSuppressedTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new LackOfCohesionRule(1, ['minMethods' => 4, 'minProperties' => 2]);
+    }
+
+    #[Test]
+    public function respectsPhpstanIgnoreAttributeOnClass(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/LackOfCohesionRule/SuppressedDisjointClass.php'],
+            [],
+            '@phpstan-ignore haspadar.lackOfCohesion over the class must silence the disjoint-groups error',
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Wraps up issue #136 — the core `LackOfCohesionRule` landed in #138. This PR covers the remaining Conditions from the issue that were not yet exercised:

- `@phpstan-ignore haspadar.lackOfCohesion` over the class silences the error
- Interfaces and traits are skipped (rule listens only to `Class_`)
- Default thresholds `minMethods=7`, `minProperties=3` applied when the rule is constructed without options
- Rule listed in the README table and exposed in the `Configuration` snippet

Closes #136

## Test plan

- [x] `vendor/bin/piqule check` — all 14 tools green locally
- [x] New tests pass: suppressed, interface+trait, default thresholds
- [x] CI green on PR
- [x] CodeRabbit review clean
- [x] SonarCloud no open issues
- [x] Codecov patch 100%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Lack of Cohesion (LCOM4) rule to detect classes with disjoint method-property relationships
  * Configurable thresholds for method and property counts, plus class exclusion lists
  * Supports PHPStan ignore directives for rule suppression

* **Documentation**
  * Updated with configuration examples for the new rule

* **Tests**
  * Added comprehensive test suite covering default thresholds, interface/trait handling, and suppression behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->