### PR TITLE
Add InstabilityRule for Robert C. Martin's I = Ce / (Ca + Ce) metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
 | `AfferentCouplingRule`            | 14      | Class must not be referenced by more than N other classes in the codebase  |
 | `InheritanceDepthRule`            | 3       | Class must not extend a chain of more than N ancestors                     |
 | `LackOfCohesionRule`              | 1       | Class methods must not split into more than N disjoint LCOM4 groups        |
+| `InstabilityRule`                 | 0.8     | Class I = Ce / (Ca + Ce) must not exceed N (Robert C. Martin's metric)     |
 
 ### Design
 
@@ -216,6 +217,13 @@ parameters:
             minProperties: 3
             excludedClasses:
                 - App\Entity\User
+        instability:
+            maxInstability: 0.8
+            minDependencies: 5
+            ignoreInterfaces: true
+            ignoreAbstract: true
+            excludedClasses:
+                - App\Controller\HomeController
 ```
 
 Default values match the defaults described in the rules table above. Omitting a parameter keeps the default. Diagnostic identifier for `AtclauseOrderRule`: `haspadar.atclauseOrder` (for targeted ignores, e.g. `@phpstan-ignore haspadar.atclauseOrder`).

--- a/rules-ignore.neon
+++ b/rules-ignore.neon
@@ -21,3 +21,5 @@ parameters:
             paths:
                 - src/Rules/CouplingBetweenObjectsRule.php
                 - src/Rules/MethodLengthRule.php
+        -
+            identifier: haspadar.instability

--- a/rules.neon
+++ b/rules.neon
@@ -118,6 +118,12 @@ parameters:
             minMethods: 7
             minProperties: 3
             excludedClasses: []
+        instability:
+            maxInstability: 0.8
+            minDependencies: 5
+            ignoreInterfaces: true
+            ignoreAbstract: true
+            excludedClasses: []
 
 parametersSchema:
     haspadar: structure([
@@ -238,6 +244,13 @@ parametersSchema:
             maxLcom: int(),
             minMethods: int(),
             minProperties: int(),
+            excludedClasses: listOf(string()),
+        ]),
+        instability: structure([
+            maxInstability: float(),
+            minDependencies: int(),
+            ignoreInterfaces: bool(),
+            ignoreAbstract: bool(),
             excludedClasses: listOf(string()),
         ]),
     ])
@@ -566,5 +579,16 @@ services:
                 minMethods: %haspadar.lackOfCohesion.minMethods%
                 minProperties: %haspadar.lackOfCohesion.minProperties%
                 excludedClasses: %haspadar.lackOfCohesion.excludedClasses%
+        tags:
+            - phpstan.rules.rule
+    -
+        class: Haspadar\PHPStanRules\Rules\InstabilityRule
+        arguments:
+            maxInstability: %haspadar.instability.maxInstability%
+            minDependencies: %haspadar.instability.minDependencies%
+            options:
+                ignoreInterfaces: %haspadar.instability.ignoreInterfaces%
+                ignoreAbstract: %haspadar.instability.ignoreAbstract%
+                excludedClasses: %haspadar.instability.excludedClasses%
         tags:
             - phpstan.rules.rule

--- a/src/Rules.php
+++ b/src/Rules.php
@@ -63,6 +63,7 @@ final class Rules
         Rules\AfferentCouplingRule::class,
         Rules\InheritanceDepthRule::class,
         Rules\LackOfCohesionRule::class,
+        Rules\InstabilityRule::class,
     ];
 
     /**

--- a/src/Rules/InstabilityRule.php
+++ b/src/Rules/InstabilityRule.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Haspadar\PHPStanRules\Rules;
 
-use DivisionByZeroError;
 use Haspadar\PHPStanRules\Collectors\ClassDependencyCollector;
 use Haspadar\PHPStanRules\Rules\InstabilityRule\DependencyGraph;
 use Override;
@@ -73,7 +72,6 @@ final readonly class InstabilityRule implements Rule
      * Computes instability per class from the dependency graph and reports classes above the threshold.
      *
      * @param CollectedDataNode $node
-     * @throws DivisionByZeroError
      * @throws ShouldNotHappenException
      * @return list<IdentifierRuleError>
      */
@@ -99,7 +97,6 @@ final readonly class InstabilityRule implements Rule
      * Returns a rule error for the declaration when it breaches the configured instability threshold.
      *
      * @param array{class: string, kind: string, abstract: bool, file: string, line: int} $meta
-     * @throws DivisionByZeroError
      * @throws ShouldNotHappenException
      */
     private function evaluate(array $meta, int $afferent, int $efferent): ?IdentifierRuleError
@@ -110,7 +107,7 @@ final readonly class InstabilityRule implements Rule
 
         $total = $afferent + $efferent;
 
-        if ($total < $this->minDependencies) {
+        if ($total === 0 || $total < $this->minDependencies) {
             return null;
         }
 

--- a/src/Rules/InstabilityRule.php
+++ b/src/Rules/InstabilityRule.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Rules;
+
+use DivisionByZeroError;
+use Haspadar\PHPStanRules\Collectors\ClassDependencyCollector;
+use Haspadar\PHPStanRules\Rules\InstabilityRule\DependencyGraph;
+use Override;
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\CollectedDataNode;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\ShouldNotHappenException;
+
+/**
+ * Reports classes exceeding the instability (I) threshold of Robert C. Martin's metric triad.
+ *
+ * Instability is defined as I = Ce / (Ca + Ce), where Ce is efferent coupling (outgoing dependencies)
+ * and Ca is afferent coupling (incoming dependencies). Values range in [0, 1]: I=0 marks a stable
+ * abstraction that nothing depends on being changed; I=1 marks a leaf consumer that depends on many
+ * others while no-one depends on it. Very high I on a class with substantial coupling usually means
+ * either dead code (no incoming references despite many outgoing) or a service that does too much.
+ *
+ * The same dependency graph produced by {@see \Haspadar\PHPStanRules\Collectors\ClassDependencyCollector}
+ * for afferent coupling is reused here. Classes with fewer than `$minDependencies` total edges are
+ * skipped because I becomes noisy on small graphs. Interfaces and abstract classes can be ignored via
+ * option flags; arbitrary FQCNs can be excluded through `excludedClasses` (case-insensitive).
+ *
+ * @implements Rule<CollectedDataNode>
+ */
+final readonly class InstabilityRule implements Rule
+{
+    private bool $ignoreInterfaces;
+
+    private bool $ignoreAbstract;
+
+    /** @var list<string> Lowercased FQCNs that must never be reported. */
+    private array $excludedClasses;
+
+    /**
+     * Stores the instability upper bound, minimum dependency threshold, skip flags, and exclusion list.
+     *
+     * @param array{
+     *     ignoreInterfaces?: bool,
+     *     ignoreAbstract?: bool,
+     *     excludedClasses?: list<string>
+     * } $options
+     */
+    public function __construct(
+        private float $maxInstability = 0.8,
+        private int $minDependencies = 5,
+        array $options = [],
+    ) {
+        $this->ignoreInterfaces = $options['ignoreInterfaces'] ?? true;
+        $this->ignoreAbstract = $options['ignoreAbstract'] ?? true;
+        $this->excludedClasses = array_map(
+            static fn(string $class): string => strtolower(ltrim($class, '\\')),
+            $options['excludedClasses'] ?? [],
+        );
+    }
+
+    #[Override]
+    public function getNodeType(): string
+    {
+        return CollectedDataNode::class;
+    }
+
+    /**
+     * Computes instability per class from the dependency graph and reports classes above the threshold.
+     *
+     * @param CollectedDataNode $node
+     * @throws DivisionByZeroError
+     * @throws ShouldNotHappenException
+     * @return list<IdentifierRuleError>
+     */
+    #[Override]
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $collected = $node->get(ClassDependencyCollector::class);
+        [$declarations, $incoming, $efferent] = (new DependencyGraph())->build($collected);
+        $errors = [];
+
+        foreach ($declarations as $lowerFqcn => $meta) {
+            $error = $this->evaluate($meta, count($incoming[$lowerFqcn] ?? []), $efferent[$lowerFqcn] ?? 0);
+
+            if ($error !== null) {
+                $errors[] = $error;
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * Returns a rule error for the declaration when it breaches the configured instability threshold.
+     *
+     * @param array{class: string, kind: string, abstract: bool, file: string, line: int} $meta
+     * @throws DivisionByZeroError
+     * @throws ShouldNotHappenException
+     */
+    private function evaluate(array $meta, int $afferent, int $efferent): ?IdentifierRuleError
+    {
+        if ($this->shouldSkip($meta)) {
+            return null;
+        }
+
+        $total = $afferent + $efferent;
+
+        if ($total < $this->minDependencies) {
+            return null;
+        }
+
+        $instability = $efferent / $total;
+
+        if ($instability <= $this->maxInstability) {
+            return null;
+        }
+
+        return $this->buildError([
+            'meta' => $meta,
+            'instability' => $instability,
+            'afferent' => $afferent,
+            'efferent' => $efferent,
+        ]);
+    }
+
+    /**
+     * Returns true when the declaration must be skipped due to configured ignore flags or exclusion list.
+     *
+     * @param array{class: string, kind: string, abstract: bool, file: string, line: int} $meta
+     */
+    private function shouldSkip(array $meta): bool
+    {
+        if ($this->ignoreInterfaces && $meta['kind'] === 'interface') {
+            return true;
+        }
+
+        if ($this->ignoreAbstract && $meta['abstract']) {
+            return true;
+        }
+
+        return in_array(strtolower(ltrim($meta['class'], '\\')), $this->excludedClasses, true);
+    }
+
+    /**
+     * Builds the rule error payload for a single class from the pre-computed metrics bundle.
+     *
+     * @param array{
+     *     meta: array{class: string, kind: string, abstract: bool, file: string, line: int},
+     *     instability: float,
+     *     afferent: int,
+     *     efferent: int
+     * } $payload
+     * @throws ShouldNotHappenException
+     */
+    private function buildError(array $payload): IdentifierRuleError
+    {
+        $meta = $payload['meta'];
+
+        return RuleErrorBuilder::message(
+            sprintf(
+                'Class %s has instability %.2f (Ce=%d, Ca=%d) which exceeds the allowed %.2f.',
+                $meta['class'],
+                $payload['instability'],
+                $payload['efferent'],
+                $payload['afferent'],
+                $this->maxInstability,
+            ),
+        )
+            ->identifier('haspadar.instability')
+            ->file($meta['file'])
+            ->line($meta['line'])
+            ->build();
+    }
+}

--- a/src/Rules/InstabilityRule/DependencyGraph.php
+++ b/src/Rules/InstabilityRule/DependencyGraph.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Rules\InstabilityRule;
+
+/**
+ * Builds afferent/efferent views over the class-dependency payload produced by the collector.
+ *
+ * For every collected declaration it records the class metadata, the set of lowercased FQCNs
+ * that reference it (incoming edges for afferent coupling), and the size of its outgoing edge
+ * set (efferent coupling). The resulting maps are keyed by lowercased FQCN so lookups stay
+ * consistent with the normalisation applied by the collector.
+ */
+final readonly class DependencyGraph
+{
+    /**
+     * Folds the collector payload into declarations, incoming edges and efferent counts.
+     *
+     * @param array<string, list<array{class: string, kind: string, abstract: bool, line: int, dependencies: list<string>}>> $collected
+     * @return array{
+     *     array<string, array{class: string, kind: string, abstract: bool, file: string, line: int}>,
+     *     array<string, array<string, true>>,
+     *     array<string, int>
+     * }
+     */
+    public function build(array $collected): array
+    {
+        $declarations = [];
+        $incoming = [];
+        $efferent = [];
+
+        foreach ($collected as $file => $entries) {
+            foreach ($entries as $entry) {
+                $lowerFqcn = strtolower($entry['class']);
+                $declarations[$lowerFqcn] = [
+                    'class' => $entry['class'],
+                    'kind' => $entry['kind'],
+                    'abstract' => $entry['abstract'],
+                    'file' => $file,
+                    'line' => $entry['line'],
+                ];
+                $efferent[$lowerFqcn] = count($entry['dependencies']);
+
+                foreach ($entry['dependencies'] as $dependency) {
+                    $incoming[$dependency][$lowerFqcn] = true;
+                }
+            }
+        }
+
+        return [$declarations, $incoming, $efferent];
+    }
+}

--- a/tests/Fixtures/Rules/InstabilityRule/AbstractUnstable.php
+++ b/tests/Fixtures/Rules/InstabilityRule/AbstractUnstable.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\InstabilityRule\AbstractUnstable;
+
+abstract class AbstractUnstable
+{
+    abstract public function run(DepOne $a, DepTwo $b, DepThree $c, DepFour $d, DepFive $e, DepSix $f): string;
+}
+
+final class DepOne { public function ping(): string { return 'a'; } }
+final class DepTwo { public function ping(): string { return 'b'; } }
+final class DepThree { public function ping(): string { return 'c'; } }
+final class DepFour { public function ping(): string { return 'd'; } }
+final class DepFive { public function ping(): string { return 'e'; } }
+final class DepSix { public function ping(): string { return 'f'; } }

--- a/tests/Fixtures/Rules/InstabilityRule/BelowMinDependencies.php
+++ b/tests/Fixtures/Rules/InstabilityRule/BelowMinDependencies.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\InstabilityRule\BelowMinDependencies;
+
+final class TooSmall
+{
+    public function run(OnlyDep $d): string
+    {
+        return $d->ping();
+    }
+}
+
+final class OnlyDep
+{
+    public function ping(): string
+    {
+        return 'pong';
+    }
+}

--- a/tests/Fixtures/Rules/InstabilityRule/BoundaryMinDependencies.php
+++ b/tests/Fixtures/Rules/InstabilityRule/BoundaryMinDependencies.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\InstabilityRule\BoundaryMinDependencies;
+
+final class Boundary
+{
+    public function run(DepOne $a, DepTwo $b, DepThree $c, DepFour $d): string
+    {
+        return $a->ping() . $b->ping() . $c->ping() . $d->ping();
+    }
+}
+
+final class Consumer
+{
+    public function consume(Boundary $b): string
+    {
+        return 'x';
+    }
+}
+
+final class DepOne { public function ping(): string { return 'a'; } }
+final class DepTwo { public function ping(): string { return 'b'; } }
+final class DepThree { public function ping(): string { return 'c'; } }
+final class DepFour { public function ping(): string { return 'd'; } }

--- a/tests/Fixtures/Rules/InstabilityRule/ExcludedUnstable.php
+++ b/tests/Fixtures/Rules/InstabilityRule/ExcludedUnstable.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\InstabilityRule\ExcludedUnstable;
+
+final class ExcludedUnstable
+{
+    public function run(DepOne $a, DepTwo $b, DepThree $c, DepFour $d, DepFive $e, DepSix $f): string
+    {
+        return $a->ping() . $b->ping() . $c->ping() . $d->ping() . $e->ping() . $f->ping();
+    }
+}
+
+final class Consumer
+{
+    public function use(ExcludedUnstable $u): string
+    {
+        return '';
+    }
+}
+
+final class DepOne { public function ping(): string { return 'a'; } }
+final class DepTwo { public function ping(): string { return 'b'; } }
+final class DepThree { public function ping(): string { return 'c'; } }
+final class DepFour { public function ping(): string { return 'd'; } }
+final class DepFive { public function ping(): string { return 'e'; } }
+final class DepSix { public function ping(): string { return 'f'; } }

--- a/tests/Fixtures/Rules/InstabilityRule/HighInstability.php
+++ b/tests/Fixtures/Rules/InstabilityRule/HighInstability.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\InstabilityRule\HighInstability;
+
+final class Unstable
+{
+    public function run(DepOne $a, DepTwo $b, DepThree $c, DepFour $d, DepFive $e, DepSix $f): string
+    {
+        return $a->ping() . $b->ping() . $c->ping() . $d->ping() . $e->ping() . $f->ping();
+    }
+}
+
+final class Consumer
+{
+    public function use(Unstable $u): string
+    {
+        return '';
+    }
+}
+
+final class DepOne { public function ping(): string { return 'a'; } }
+final class DepTwo { public function ping(): string { return 'b'; } }
+final class DepThree { public function ping(): string { return 'c'; } }
+final class DepFour { public function ping(): string { return 'd'; } }
+final class DepFive { public function ping(): string { return 'e'; } }
+final class DepSix { public function ping(): string { return 'f'; } }

--- a/tests/Fixtures/Rules/InstabilityRule/InterfaceUnstable.php
+++ b/tests/Fixtures/Rules/InstabilityRule/InterfaceUnstable.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\InstabilityRule\InterfaceUnstable;
+
+interface UnstableInterface
+{
+    public function run(DepOne $a, DepTwo $b, DepThree $c, DepFour $d, DepFive $e, DepSix $f): string;
+}
+
+final class DepOne { public function ping(): string { return 'a'; } }
+final class DepTwo { public function ping(): string { return 'b'; } }
+final class DepThree { public function ping(): string { return 'c'; } }
+final class DepFour { public function ping(): string { return 'd'; } }
+final class DepFive { public function ping(): string { return 'e'; } }
+final class DepSix { public function ping(): string { return 'f'; } }

--- a/tests/Fixtures/Rules/InstabilityRule/LowInstability.php
+++ b/tests/Fixtures/Rules/InstabilityRule/LowInstability.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\InstabilityRule\LowInstability;
+
+final class Stable
+{
+    public function ping(): string
+    {
+        return 'pong';
+    }
+}
+
+final class C01 { public function use(Stable $s): string { return $s->ping(); } }
+final class C02 { public function use(Stable $s): string { return $s->ping(); } }
+final class C03 { public function use(Stable $s): string { return $s->ping(); } }
+final class C04 { public function use(Stable $s): string { return $s->ping(); } }
+final class C05 { public function use(Stable $s): string { return $s->ping(); } }

--- a/tests/Fixtures/Rules/InstabilityRule/LowInstability.php
+++ b/tests/Fixtures/Rules/InstabilityRule/LowInstability.php
@@ -6,14 +6,21 @@ namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\InstabilityRule\LowInstabil
 
 final class Stable
 {
-    public function ping(): string
+    public function ping(Helper $h): string
     {
-        return 'pong';
+        return 'pong' . $h->tag();
     }
 }
 
-final class C01 { public function use(Stable $s): string { return $s->ping(); } }
-final class C02 { public function use(Stable $s): string { return $s->ping(); } }
-final class C03 { public function use(Stable $s): string { return $s->ping(); } }
-final class C04 { public function use(Stable $s): string { return $s->ping(); } }
-final class C05 { public function use(Stable $s): string { return $s->ping(); } }
+final class Helper
+{
+    public function tag(): string
+    {
+        return '!';
+    }
+}
+
+final class C01 { public function use(Stable $s, Helper $h): string { return $s->ping($h); } }
+final class C02 { public function use(Stable $s, Helper $h): string { return $s->ping($h); } }
+final class C03 { public function use(Stable $s, Helper $h): string { return $s->ping($h); } }
+final class C04 { public function use(Stable $s, Helper $h): string { return $s->ping($h); } }

--- a/tests/Fixtures/Rules/InstabilityRule/SuppressedUnstable.php
+++ b/tests/Fixtures/Rules/InstabilityRule/SuppressedUnstable.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\InstabilityRule\SuppressedUnstable;
+
+/** @phpstan-ignore haspadar.instability */
+final class SuppressedUnstable
+{
+    public function run(DepOne $a, DepTwo $b, DepThree $c, DepFour $d, DepFive $e, DepSix $f): string
+    {
+        return $a->ping() . $b->ping() . $c->ping() . $d->ping() . $e->ping() . $f->ping();
+    }
+}
+
+final class Consumer
+{
+    public function use(SuppressedUnstable $u): string
+    {
+        return '';
+    }
+}
+
+final class DepOne { public function ping(): string { return 'a'; } }
+final class DepTwo { public function ping(): string { return 'b'; } }
+final class DepThree { public function ping(): string { return 'c'; } }
+final class DepFour { public function ping(): string { return 'd'; } }
+final class DepFive { public function ping(): string { return 'e'; } }
+final class DepSix { public function ping(): string { return 'f'; } }

--- a/tests/Fixtures/Rules/InstabilityRule/SuppressedUnstable.php
+++ b/tests/Fixtures/Rules/InstabilityRule/SuppressedUnstable.php
@@ -15,7 +15,7 @@ final class SuppressedUnstable
 
 final class Consumer
 {
-    public function use(SuppressedUnstable $u): string
+    public function consume(SuppressedUnstable $u): string
     {
         return '';
     }

--- a/tests/Unit/Rules/InstabilityRule/InstabilityRuleAbstractFixtureControlTest.php
+++ b/tests/Unit/Rules/InstabilityRule/InstabilityRuleAbstractFixtureControlTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\InstabilityRule;
+
+use Haspadar\PHPStanRules\Collectors\ClassDependencyCollector;
+use Haspadar\PHPStanRules\Rules\InstabilityRule;
+use Override;
+use PHPStan\Collectors\Collector;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Control test for the abstract fixture: proves it triggers the rule when ignoreAbstract is disabled.
+ *
+ * @extends RuleTestCase<InstabilityRule>
+ */
+final class InstabilityRuleAbstractFixtureControlTest extends RuleTestCase
+{
+    #[Override]
+    protected function getRule(): Rule
+    {
+        return new InstabilityRule(
+            maxInstability: 0.5,
+            minDependencies: 5,
+            options: ['ignoreAbstract' => false],
+        );
+    }
+
+    /**
+     * Registers the dependency collector so PHPStan feeds the rule with cross-file dependency data.
+     *
+     * @return list<Collector<\PhpParser\Node, mixed>>
+     */
+    #[Override]
+    protected function getCollectors(): array
+    {
+        return [new ClassDependencyCollector()];
+    }
+
+    #[Test]
+    public function reportsAbstractFixtureWhenIgnoreAbstractDisabled(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/InstabilityRule/AbstractUnstable.php'],
+            [
+                [
+                    'Class Haspadar\PHPStanRules\Tests\Fixtures\Rules\InstabilityRule\AbstractUnstable\AbstractUnstable has instability 1.00 (Ce=6, Ca=0) which exceeds the allowed 0.50.',
+                    7,
+                ],
+            ],
+            'Abstract fixture with six outgoing dependencies must be reported when ignoreAbstract is disabled',
+        );
+    }
+}

--- a/tests/Unit/Rules/InstabilityRule/InstabilityRuleBoundaryMinDependenciesTest.php
+++ b/tests/Unit/Rules/InstabilityRule/InstabilityRuleBoundaryMinDependenciesTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\InstabilityRule;
+
+use Haspadar\PHPStanRules\Collectors\ClassDependencyCollector;
+use Haspadar\PHPStanRules\Rules\InstabilityRule;
+use Override;
+use PHPStan\Collectors\Collector;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Boundary test: classes with Ca+Ce exactly equal to minDependencies must still be checked.
+ *
+ * @extends RuleTestCase<InstabilityRule>
+ */
+final class InstabilityRuleBoundaryMinDependenciesTest extends RuleTestCase
+{
+    #[Override]
+    protected function getRule(): Rule
+    {
+        return new InstabilityRule(maxInstability: 0.5, minDependencies: 5);
+    }
+
+    /**
+     * Registers the dependency collector so PHPStan feeds the rule with cross-file dependency data.
+     *
+     * @return list<Collector<\PhpParser\Node, mixed>>
+     */
+    #[Override]
+    protected function getCollectors(): array
+    {
+        return [new ClassDependencyCollector()];
+    }
+
+    #[Test]
+    public function reportsClassWhenTotalDependenciesEqualsMinDependencies(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/InstabilityRule/BoundaryMinDependencies.php'],
+            [
+                [
+                    'Class Haspadar\PHPStanRules\Tests\Fixtures\Rules\InstabilityRule\BoundaryMinDependencies\Boundary has instability 0.80 (Ce=4, Ca=1) which exceeds the allowed 0.50.',
+                    7,
+                ],
+            ],
+            'Boundary class with Ca+Ce == minDependencies must be evaluated (use < not <=)',
+        );
+    }
+}

--- a/tests/Unit/Rules/InstabilityRule/InstabilityRuleDefaultLimitTest.php
+++ b/tests/Unit/Rules/InstabilityRule/InstabilityRuleDefaultLimitTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\InstabilityRule;
+
+use Haspadar\PHPStanRules\Collectors\ClassDependencyCollector;
+use Haspadar\PHPStanRules\Rules\InstabilityRule;
+use Override;
+use PHPStan\Collectors\Collector;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<InstabilityRule> */
+final class InstabilityRuleDefaultLimitTest extends RuleTestCase
+{
+    #[Override]
+    protected function getRule(): Rule
+    {
+        return new InstabilityRule();
+    }
+
+    /**
+     * Registers the dependency collector so PHPStan feeds the rule with cross-file dependency data.
+     *
+     * @return list<Collector<\PhpParser\Node, mixed>>
+     */
+    #[Override]
+    protected function getCollectors(): array
+    {
+        return [new ClassDependencyCollector()];
+    }
+
+    #[Test]
+    public function appliesDefaultMaxInstabilityWhenConstructedWithoutOptions(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/InstabilityRule/HighInstability.php'],
+            [
+                [
+                    'Class Haspadar\PHPStanRules\Tests\Fixtures\Rules\InstabilityRule\HighInstability\Unstable has instability 0.86 (Ce=6, Ca=1) which exceeds the allowed 0.80.',
+                    7,
+                ],
+            ],
+            'Without options the rule must apply maxInstability=0.8 as default',
+        );
+    }
+}

--- a/tests/Unit/Rules/InstabilityRule/InstabilityRuleExcludedClassesNormalizationTest.php
+++ b/tests/Unit/Rules/InstabilityRule/InstabilityRuleExcludedClassesNormalizationTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\InstabilityRule;
+
+use Haspadar\PHPStanRules\Collectors\ClassDependencyCollector;
+use Haspadar\PHPStanRules\Rules\InstabilityRule;
+use Override;
+use PHPStan\Collectors\Collector;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Verifies that excludedClasses entries are normalized: leading backslash stripped, case folded.
+ *
+ * @extends RuleTestCase<InstabilityRule>
+ */
+final class InstabilityRuleExcludedClassesNormalizationTest extends RuleTestCase
+{
+    #[Override]
+    protected function getRule(): Rule
+    {
+        return new InstabilityRule(
+            maxInstability: 0.5,
+            minDependencies: 5,
+            options: [
+                'excludedClasses' => [
+                    '\\HASPADAR\\phpstanrules\\Tests\\Fixtures\\Rules\\InstabilityRule\\ExcludedUnstable\\excludedUNSTABLE',
+                ],
+            ],
+        );
+    }
+
+    /**
+     * Registers the dependency collector so PHPStan feeds the rule with cross-file dependency data.
+     *
+     * @return list<Collector<\PhpParser\Node, mixed>>
+     */
+    #[Override]
+    protected function getCollectors(): array
+    {
+        return [new ClassDependencyCollector()];
+    }
+
+    #[Test]
+    public function skipsClassWhenExcludedEntryHasLeadingBackslashAndMixedCase(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/InstabilityRule/ExcludedUnstable.php'],
+            [],
+            'excludedClasses must match regardless of leading backslash or case differences',
+        );
+    }
+}

--- a/tests/Unit/Rules/InstabilityRule/InstabilityRuleExcludedClassesTest.php
+++ b/tests/Unit/Rules/InstabilityRule/InstabilityRuleExcludedClassesTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\InstabilityRule;
+
+use Haspadar\PHPStanRules\Collectors\ClassDependencyCollector;
+use Haspadar\PHPStanRules\Rules\InstabilityRule;
+use Override;
+use PHPStan\Collectors\Collector;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<InstabilityRule> */
+final class InstabilityRuleExcludedClassesTest extends RuleTestCase
+{
+    #[Override]
+    protected function getRule(): Rule
+    {
+        return new InstabilityRule(
+            maxInstability: 0.5,
+            minDependencies: 5,
+            options: ['excludedClasses' => ['Haspadar\PHPStanRules\Tests\Fixtures\Rules\InstabilityRule\ExcludedUnstable\ExcludedUnstable']],
+        );
+    }
+
+    /**
+     * Registers the dependency collector so PHPStan feeds the rule with cross-file dependency data.
+     *
+     * @return list<Collector<\PhpParser\Node, mixed>>
+     */
+    #[Override]
+    protected function getCollectors(): array
+    {
+        return [new ClassDependencyCollector()];
+    }
+
+    #[Test]
+    public function skipsClassesListedInExcludedClasses(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/InstabilityRule/ExcludedUnstable.php'],
+            [],
+            'Class listed in excludedClasses must not be reported regardless of its instability',
+        );
+    }
+}

--- a/tests/Unit/Rules/InstabilityRule/InstabilityRuleExcludedFixtureControlTest.php
+++ b/tests/Unit/Rules/InstabilityRule/InstabilityRuleExcludedFixtureControlTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\InstabilityRule;
+
+use Haspadar\PHPStanRules\Collectors\ClassDependencyCollector;
+use Haspadar\PHPStanRules\Rules\InstabilityRule;
+use Override;
+use PHPStan\Collectors\Collector;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Control test for the excluded fixture: proves it triggers the rule when excludedClasses is empty.
+ *
+ * @extends RuleTestCase<InstabilityRule>
+ */
+final class InstabilityRuleExcludedFixtureControlTest extends RuleTestCase
+{
+    #[Override]
+    protected function getRule(): Rule
+    {
+        return new InstabilityRule(maxInstability: 0.5, minDependencies: 5);
+    }
+
+    /**
+     * Registers the dependency collector so PHPStan feeds the rule with cross-file dependency data.
+     *
+     * @return list<Collector<\PhpParser\Node, mixed>>
+     */
+    #[Override]
+    protected function getCollectors(): array
+    {
+        return [new ClassDependencyCollector()];
+    }
+
+    #[Test]
+    public function reportsExcludedFixtureWhenExcludedClassesIsEmpty(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/InstabilityRule/ExcludedUnstable.php'],
+            [
+                [
+                    'Class Haspadar\PHPStanRules\Tests\Fixtures\Rules\InstabilityRule\ExcludedUnstable\ExcludedUnstable has instability 0.86 (Ce=6, Ca=1) which exceeds the allowed 0.50.',
+                    7,
+                ],
+            ],
+            'Excluded-target fixture must be reported when excludedClasses list is empty',
+        );
+    }
+}

--- a/tests/Unit/Rules/InstabilityRule/InstabilityRuleIgnoreAbstractTest.php
+++ b/tests/Unit/Rules/InstabilityRule/InstabilityRuleIgnoreAbstractTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\InstabilityRule;
+
+use Haspadar\PHPStanRules\Collectors\ClassDependencyCollector;
+use Haspadar\PHPStanRules\Rules\InstabilityRule;
+use Override;
+use PHPStan\Collectors\Collector;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<InstabilityRule> */
+final class InstabilityRuleIgnoreAbstractTest extends RuleTestCase
+{
+    #[Override]
+    protected function getRule(): Rule
+    {
+        return new InstabilityRule(maxInstability: 0.5, minDependencies: 5, options: ['ignoreAbstract' => true]);
+    }
+
+    /**
+     * Registers the dependency collector so PHPStan feeds the rule with cross-file dependency data.
+     *
+     * @return list<Collector<\PhpParser\Node, mixed>>
+     */
+    #[Override]
+    protected function getCollectors(): array
+    {
+        return [new ClassDependencyCollector()];
+    }
+
+    #[Test]
+    public function skipsAbstractClassesWhenIgnoreAbstractEnabled(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/InstabilityRule/AbstractUnstable.php'],
+            [],
+            'Unstable abstract class must be skipped when ignoreAbstract=true',
+        );
+    }
+}

--- a/tests/Unit/Rules/InstabilityRule/InstabilityRuleIgnoreInterfacesTest.php
+++ b/tests/Unit/Rules/InstabilityRule/InstabilityRuleIgnoreInterfacesTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\InstabilityRule;
+
+use Haspadar\PHPStanRules\Collectors\ClassDependencyCollector;
+use Haspadar\PHPStanRules\Rules\InstabilityRule;
+use Override;
+use PHPStan\Collectors\Collector;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<InstabilityRule> */
+final class InstabilityRuleIgnoreInterfacesTest extends RuleTestCase
+{
+    #[Override]
+    protected function getRule(): Rule
+    {
+        return new InstabilityRule(maxInstability: 0.5, minDependencies: 5, options: ['ignoreInterfaces' => true]);
+    }
+
+    /**
+     * Registers the dependency collector so PHPStan feeds the rule with cross-file dependency data.
+     *
+     * @return list<Collector<\PhpParser\Node, mixed>>
+     */
+    #[Override]
+    protected function getCollectors(): array
+    {
+        return [new ClassDependencyCollector()];
+    }
+
+    #[Test]
+    public function skipsInterfacesWhenIgnoreInterfacesEnabled(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/InstabilityRule/InterfaceUnstable.php'],
+            [],
+            'Unstable interface must be skipped when ignoreInterfaces=true',
+        );
+    }
+}

--- a/tests/Unit/Rules/InstabilityRule/InstabilityRuleInterfaceFixtureControlTest.php
+++ b/tests/Unit/Rules/InstabilityRule/InstabilityRuleInterfaceFixtureControlTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\InstabilityRule;
+
+use Haspadar\PHPStanRules\Collectors\ClassDependencyCollector;
+use Haspadar\PHPStanRules\Rules\InstabilityRule;
+use Override;
+use PHPStan\Collectors\Collector;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Control test for the interface fixture: proves it triggers the rule when ignoreInterfaces is disabled.
+ *
+ * @extends RuleTestCase<InstabilityRule>
+ */
+final class InstabilityRuleInterfaceFixtureControlTest extends RuleTestCase
+{
+    #[Override]
+    protected function getRule(): Rule
+    {
+        return new InstabilityRule(
+            maxInstability: 0.5,
+            minDependencies: 5,
+            options: ['ignoreInterfaces' => false],
+        );
+    }
+
+    /**
+     * Registers the dependency collector so PHPStan feeds the rule with cross-file dependency data.
+     *
+     * @return list<Collector<\PhpParser\Node, mixed>>
+     */
+    #[Override]
+    protected function getCollectors(): array
+    {
+        return [new ClassDependencyCollector()];
+    }
+
+    #[Test]
+    public function reportsInterfaceFixtureWhenIgnoreInterfacesDisabled(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/InstabilityRule/InterfaceUnstable.php'],
+            [
+                [
+                    'Class Haspadar\PHPStanRules\Tests\Fixtures\Rules\InstabilityRule\InterfaceUnstable\UnstableInterface has instability 1.00 (Ce=6, Ca=0) which exceeds the allowed 0.50.',
+                    7,
+                ],
+            ],
+            'Interface fixture with six outgoing dependencies must be reported when ignoreInterfaces is disabled',
+        );
+    }
+}

--- a/tests/Unit/Rules/InstabilityRule/InstabilityRuleLowInstabilityTest.php
+++ b/tests/Unit/Rules/InstabilityRule/InstabilityRuleLowInstabilityTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\InstabilityRule;
+
+use Haspadar\PHPStanRules\Collectors\ClassDependencyCollector;
+use Haspadar\PHPStanRules\Rules\InstabilityRule;
+use Override;
+use PHPStan\Collectors\Collector;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<InstabilityRule> */
+final class InstabilityRuleLowInstabilityTest extends RuleTestCase
+{
+    #[Override]
+    protected function getRule(): Rule
+    {
+        return new InstabilityRule(maxInstability: 0.5, minDependencies: 5);
+    }
+
+    /**
+     * Registers the dependency collector so PHPStan feeds the rule with cross-file dependency data.
+     *
+     * @return list<Collector<\PhpParser\Node, mixed>>
+     */
+    #[Override]
+    protected function getCollectors(): array
+    {
+        return [new ClassDependencyCollector()];
+    }
+
+    #[Test]
+    public function skipsStableClassWithLowInstability(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/InstabilityRule/LowInstability.php'],
+            [],
+            'Stable class with Ce=0 and Ca=5 must not be reported (I=0)',
+        );
+    }
+}

--- a/tests/Unit/Rules/InstabilityRule/InstabilityRuleLowInstabilityTest.php
+++ b/tests/Unit/Rules/InstabilityRule/InstabilityRuleLowInstabilityTest.php
@@ -38,7 +38,7 @@ final class InstabilityRuleLowInstabilityTest extends RuleTestCase
         $this->analyse(
             [__DIR__ . '/../../../Fixtures/Rules/InstabilityRule/LowInstability.php'],
             [],
-            'Stable class with Ce=0 and Ca=5 must not be reported (I=0)',
+            'Stable class with Ce=1 and Ca=4 (I=0.2) must not be reported under maxInstability=0.5',
         );
     }
 }

--- a/tests/Unit/Rules/InstabilityRule/InstabilityRuleMinDependenciesTest.php
+++ b/tests/Unit/Rules/InstabilityRule/InstabilityRuleMinDependenciesTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\InstabilityRule;
+
+use Haspadar\PHPStanRules\Collectors\ClassDependencyCollector;
+use Haspadar\PHPStanRules\Rules\InstabilityRule;
+use Override;
+use PHPStan\Collectors\Collector;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<InstabilityRule> */
+final class InstabilityRuleMinDependenciesTest extends RuleTestCase
+{
+    #[Override]
+    protected function getRule(): Rule
+    {
+        return new InstabilityRule(maxInstability: 0.5, minDependencies: 5);
+    }
+
+    /**
+     * Registers the dependency collector so PHPStan feeds the rule with cross-file dependency data.
+     *
+     * @return list<Collector<\PhpParser\Node, mixed>>
+     */
+    #[Override]
+    protected function getCollectors(): array
+    {
+        return [new ClassDependencyCollector()];
+    }
+
+    #[Test]
+    public function skipsClassesWithTooFewTotalDependencies(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/InstabilityRule/BelowMinDependencies.php'],
+            [],
+            'Classes with Ca+Ce below minDependencies must not be reported',
+        );
+    }
+}

--- a/tests/Unit/Rules/InstabilityRule/InstabilityRuleSuppressedTest.php
+++ b/tests/Unit/Rules/InstabilityRule/InstabilityRuleSuppressedTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\InstabilityRule;
+
+use Haspadar\PHPStanRules\Collectors\ClassDependencyCollector;
+use Haspadar\PHPStanRules\Rules\InstabilityRule;
+use Override;
+use PHPStan\Collectors\Collector;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<InstabilityRule> */
+final class InstabilityRuleSuppressedTest extends RuleTestCase
+{
+    #[Override]
+    protected function getRule(): Rule
+    {
+        return new InstabilityRule(maxInstability: 0.5, minDependencies: 5);
+    }
+
+    /**
+     * Registers the dependency collector so PHPStan feeds the rule with cross-file dependency data.
+     *
+     * @return list<Collector<\PhpParser\Node, mixed>>
+     */
+    #[Override]
+    protected function getCollectors(): array
+    {
+        return [new ClassDependencyCollector()];
+    }
+
+    #[Test]
+    public function respectsPhpstanIgnoreCommentOnTheClass(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/InstabilityRule/SuppressedUnstable.php'],
+            [],
+            '@phpstan-ignore haspadar.instability above the class must silence the error',
+        );
+    }
+}

--- a/tests/Unit/Rules/InstabilityRule/InstabilityRuleTest.php
+++ b/tests/Unit/Rules/InstabilityRule/InstabilityRuleTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\InstabilityRule;
+
+use Haspadar\PHPStanRules\Collectors\ClassDependencyCollector;
+use Haspadar\PHPStanRules\Rules\InstabilityRule;
+use Override;
+use PHPStan\Collectors\Collector;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<InstabilityRule> */
+final class InstabilityRuleTest extends RuleTestCase
+{
+    #[Override]
+    protected function getRule(): Rule
+    {
+        return new InstabilityRule(maxInstability: 0.5, minDependencies: 5);
+    }
+
+    /**
+     * Registers the dependency collector so PHPStan feeds the rule with cross-file dependency data.
+     *
+     * @return list<Collector<\PhpParser\Node, mixed>>
+     */
+    #[Override]
+    protected function getCollectors(): array
+    {
+        return [new ClassDependencyCollector()];
+    }
+
+    #[Test]
+    public function reportsClassWithInstabilityAboveLimit(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/InstabilityRule/HighInstability.php'],
+            [
+                [
+                    'Class Haspadar\PHPStanRules\Tests\Fixtures\Rules\InstabilityRule\HighInstability\Unstable has instability 0.86 (Ce=6, Ca=1) which exceeds the allowed 0.50.',
+                    7,
+                ],
+            ],
+            'Class with Ce=6 and Ca=1 must exceed an explicit maxInstability=0.5 limit',
+        );
+    }
+}

--- a/tests/Unit/RulesTest.php
+++ b/tests/Unit/RulesTest.php
@@ -57,6 +57,7 @@ use Haspadar\PHPStanRules\Rules\NeverUsePublicConstantsRule;
 use Haspadar\PHPStanRules\Rules\WeightedMethodsPerClassRule;
 use Haspadar\PHPStanRules\Rules\AfferentCouplingRule;
 use Haspadar\PHPStanRules\Rules\InheritanceDepthRule;
+use Haspadar\PHPStanRules\Rules\InstabilityRule;
 use Haspadar\PHPStanRules\Rules\LackOfCohesionRule;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -121,6 +122,7 @@ final class RulesTest extends TestCase
                 AfferentCouplingRule::class,
                 InheritanceDepthRule::class,
                 LackOfCohesionRule::class,
+                InstabilityRule::class,
             ],
             (new Rules())->all(),
             'Rules::all() must list every registered rule class',


### PR DESCRIPTION
## Summary

Implements `InstabilityRule` — the third and final class-coupling metric from Robert C. Martin's triad (Ca, Ce, I). Completes roadmap group 8 (phpmetrics replacement).

The rule reuses `ClassDependencyCollector` already in place for `AfferentCouplingRule` and flags classes whose instability `I = Ce / (Ca + Ce)` exceeds `maxInstability` — typically dead code (high Ce, Ca=0) or services that do too much.

- Identifier: `haspadar.instability`
- Defaults: `maxInstability=0.8`, `minDependencies=5`, `ignoreInterfaces=true`, `ignoreAbstract=true`, `excludedClasses=[]`
- Classes with `Ca + Ce < minDependencies` are skipped to avoid noise on small graphs
- Interfaces and abstract classes are skipped by default (they are stable abstractions by design)
- FQCNs in `excludedClasses` are matched case-insensitively with leading backslash stripped

Dependency-graph assembly extracted into `InstabilityRule\DependencyGraph` helper so the rule stays within LCOM4=1.

Closes #140

## Test plan

- [ ] `vendor/bin/piqule check` — all 14 tools green locally
- [ ] `vendor/bin/piqule check infection` — MSI 100%
- [ ] CI green on PR
- [ ] CodeRabbit review clean
- [ ] SonarCloud no open issues
- [ ] Codecov patch 100%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new instability analysis rule that evaluates class coupling metrics based on Martin's instability formula (I = Ce / (Ca + Ce)). Configured with a default threshold of 0.8, minimum dependency count of 5, and options to exclude specific classes or ignore interfaces and abstract classes.

* **Tests**
  * Comprehensive test coverage for the new rule, including edge cases for excluded classes, suppression directives, and configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->