### PR TITLE
Add ProhibitStaticPropertiesRule to forbid static property declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@
 | `ReturnCountRule`                 | Method must not have more than 1 `return` statement (default: 1)                   |
 | `ProtectedMethodInFinalClassRule` | Final classes must not have `protected` methods                                    |
 | `ProhibitStaticMethodsRule`       | Classes must not declare `static` methods of any visibility                        |
+| `ProhibitStaticPropertiesRule`    | Classes must not declare `static` properties of any visibility                     |
 | `ConstructorInitializationRule`   | Constructor must only assign `$this->property` or call `parent::__construct()`     |
 | `BeImmutableRule`                | All non-static properties must be `readonly`                                       |
 | `KeepInterfacesShortRule`        | Interfaces must not declare too many methods (default: 10)                         |

--- a/rules.neon
+++ b/rules.neon
@@ -354,6 +354,10 @@ services:
         tags:
             - phpstan.rules.rule
     -
+        class: Haspadar\PHPStanRules\Rules\ProhibitStaticPropertiesRule
+        tags:
+            - phpstan.rules.rule
+    -
         class: Haspadar\PHPStanRules\Rules\ConstructorInitializationRule
         tags:
             - phpstan.rules.rule

--- a/src/Rules.php
+++ b/src/Rules.php
@@ -25,6 +25,7 @@ final class Rules
         Rules\ReturnCountRule::class,
         Rules\ProtectedMethodInFinalClassRule::class,
         Rules\ProhibitStaticMethodsRule::class,
+        Rules\ProhibitStaticPropertiesRule::class,
         Rules\ConstructorInitializationRule::class,
         Rules\NoParameterReassignmentRule::class,
         Rules\IllegalCatchRule::class,

--- a/src/Rules/ProhibitStaticPropertiesRule.php
+++ b/src/Rules/ProhibitStaticPropertiesRule.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Rules;
+
+use Override;
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Property;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\ShouldNotHappenException;
+
+/**
+ * Detects static property declarations and reports an error for each one regardless of visibility.
+ * Static properties are class-level mutable shared state that cannot be injected, are impossible to
+ * isolate in tests, and create hidden links between all instances of the class. Accesses are not
+ * checked separately: without a declaration, own accesses are syntactically impossible, and
+ * accesses to third-party static fields (e.g., Carbon facades) are out of this rule's scope.
+ *
+ * @implements Rule<Property>
+ */
+final readonly class ProhibitStaticPropertiesRule implements Rule
+{
+    #[Override]
+    public function getNodeType(): string
+    {
+        return Property::class;
+    }
+
+    /**
+     * Reports an error for every declared property inside a static declaration.
+     *
+     * @throws ShouldNotHappenException
+     * @return list<IdentifierRuleError>
+     */
+    #[Override]
+    public function processNode(Node $node, Scope $scope): array
+    {
+        /** @var Property $node */
+        if (!$node->isStatic()) {
+            return [];
+        }
+
+        $reflection = $scope->getClassReflection();
+        $className = $reflection === null || $reflection->isAnonymous()
+            ? 'class@anonymous'
+            : $reflection->getName();
+
+        $errors = [];
+
+        foreach ($node->props as $prop) {
+            $errors[] = RuleErrorBuilder::message(
+                sprintf(
+                    'Property %s::$%s is static. Static properties are prohibited.',
+                    $className,
+                    $prop->name->toString(),
+                ),
+            )
+                ->identifier('haspadar.staticProperty')
+                ->build();
+        }
+
+        return $errors;
+    }
+}

--- a/tests/Fixtures/Rules/ProhibitStaticPropertiesRule/AnonymousClassWithStaticProperty.php
+++ b/tests/Fixtures/Rules/ProhibitStaticPropertiesRule/AnonymousClassWithStaticProperty.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ProhibitStaticPropertiesRule;
+
+final class AnonymousClassWithStaticProperty
+{
+    public function make(): object
+    {
+        return new class {
+            public static int $count = 0;
+        };
+    }
+}

--- a/tests/Fixtures/Rules/ProhibitStaticPropertiesRule/ClassWithGroupedStaticProperties.php
+++ b/tests/Fixtures/Rules/ProhibitStaticPropertiesRule/ClassWithGroupedStaticProperties.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ProhibitStaticPropertiesRule;
+
+final class ClassWithGroupedStaticProperties
+{
+    public static int $first = 0, $second = 0;
+}

--- a/tests/Fixtures/Rules/ProhibitStaticPropertiesRule/ClassWithInstanceProperty.php
+++ b/tests/Fixtures/Rules/ProhibitStaticPropertiesRule/ClassWithInstanceProperty.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ProhibitStaticPropertiesRule;
+
+final class ClassWithInstanceProperty
+{
+    private int $count = 0;
+
+    public function next(): self
+    {
+        $copy = clone $this;
+        $copy->count = $this->count + 1;
+        return $copy;
+    }
+}

--- a/tests/Fixtures/Rules/ProhibitStaticPropertiesRule/ClassWithMultipleStaticProperties.php
+++ b/tests/Fixtures/Rules/ProhibitStaticPropertiesRule/ClassWithMultipleStaticProperties.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ProhibitStaticPropertiesRule;
+
+class ClassWithMultipleStaticProperties
+{
+    public static int $count = 0;
+
+    protected static string $cache = '';
+
+    private static ?self $instance = null;
+}

--- a/tests/Fixtures/Rules/ProhibitStaticPropertiesRule/ClassWithPrivateStaticProperty.php
+++ b/tests/Fixtures/Rules/ProhibitStaticPropertiesRule/ClassWithPrivateStaticProperty.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ProhibitStaticPropertiesRule;
+
+final class ClassWithPrivateStaticProperty
+{
+    private static ?self $instance = null;
+}

--- a/tests/Fixtures/Rules/ProhibitStaticPropertiesRule/ClassWithProtectedStaticProperty.php
+++ b/tests/Fixtures/Rules/ProhibitStaticPropertiesRule/ClassWithProtectedStaticProperty.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ProhibitStaticPropertiesRule;
+
+class ClassWithProtectedStaticProperty
+{
+    protected static string $cache = '';
+}

--- a/tests/Fixtures/Rules/ProhibitStaticPropertiesRule/ClassWithPublicStaticProperty.php
+++ b/tests/Fixtures/Rules/ProhibitStaticPropertiesRule/ClassWithPublicStaticProperty.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ProhibitStaticPropertiesRule;
+
+final class ClassWithPublicStaticProperty
+{
+    public static int $count = 0;
+}

--- a/tests/Fixtures/Rules/ProhibitStaticPropertiesRule/ClassWithStaticAccessToVendor.php
+++ b/tests/Fixtures/Rules/ProhibitStaticPropertiesRule/ClassWithStaticAccessToVendor.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ProhibitStaticPropertiesRule;
+
+final class ClassWithStaticAccessToVendor
+{
+    public function format(\DateTimeImmutable $date): string
+    {
+        return $date->format(\DateTimeInterface::ATOM);
+    }
+}

--- a/tests/Fixtures/Rules/ProhibitStaticPropertiesRule/ClassWithStaticAccessToVendor.php
+++ b/tests/Fixtures/Rules/ProhibitStaticPropertiesRule/ClassWithStaticAccessToVendor.php
@@ -4,10 +4,18 @@ declare(strict_types=1);
 
 namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ProhibitStaticPropertiesRule;
 
+/** Stub that simulates a third-party class exposing a public static property */
+final class VendorStaticCarrier
+{
+    /** @phpstan-ignore haspadar.staticProperty */
+    public static string $translator = 'en';
+}
+
 final class ClassWithStaticAccessToVendor
 {
-    public function format(\DateTimeImmutable $date): string
+    public function useTranslator(): string
     {
-        return $date->format(\DateTimeInterface::ATOM);
+        VendorStaticCarrier::$translator = 'ru';
+        return VendorStaticCarrier::$translator;
     }
 }

--- a/tests/Fixtures/Rules/ProhibitStaticPropertiesRule/SuppressedClassWithStaticProperty.php
+++ b/tests/Fixtures/Rules/ProhibitStaticPropertiesRule/SuppressedClassWithStaticProperty.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ProhibitStaticPropertiesRule;
+
+final class SuppressedClassWithStaticProperty
+{
+    /** @phpstan-ignore haspadar.staticProperty */
+    private static array $cache = [];
+}

--- a/tests/Unit/Rules/ProhibitStaticPropertiesRule/ProhibitStaticPropertiesRuleTest.php
+++ b/tests/Unit/Rules/ProhibitStaticPropertiesRule/ProhibitStaticPropertiesRuleTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\ProhibitStaticPropertiesRule;
+
+use Haspadar\PHPStanRules\Rules\ProhibitStaticPropertiesRule;
+use Override;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<ProhibitStaticPropertiesRule> */
+final class ProhibitStaticPropertiesRuleTest extends RuleTestCase
+{
+    #[Override]
+    protected function getRule(): Rule
+    {
+        return new ProhibitStaticPropertiesRule();
+    }
+
+    #[Test]
+    public function reportsPublicStaticProperty(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ProhibitStaticPropertiesRule/ClassWithPublicStaticProperty.php'],
+            [
+                [
+                    'Property Haspadar\PHPStanRules\Tests\Fixtures\Rules\ProhibitStaticPropertiesRule\ClassWithPublicStaticProperty::$count is static. Static properties are prohibited.',
+                    9,
+                ],
+            ],
+            'Public static property declaration must be reported',
+        );
+    }
+
+    #[Test]
+    public function reportsPrivateStaticProperty(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ProhibitStaticPropertiesRule/ClassWithPrivateStaticProperty.php'],
+            [
+                [
+                    'Property Haspadar\PHPStanRules\Tests\Fixtures\Rules\ProhibitStaticPropertiesRule\ClassWithPrivateStaticProperty::$instance is static. Static properties are prohibited.',
+                    9,
+                ],
+            ],
+            'Private static property must be reported — visibility does not exempt static state',
+        );
+    }
+
+    #[Test]
+    public function reportsProtectedStaticProperty(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ProhibitStaticPropertiesRule/ClassWithProtectedStaticProperty.php'],
+            [
+                [
+                    'Property Haspadar\PHPStanRules\Tests\Fixtures\Rules\ProhibitStaticPropertiesRule\ClassWithProtectedStaticProperty::$cache is static. Static properties are prohibited.',
+                    9,
+                ],
+            ],
+            'Protected static property must be reported — all visibilities are covered',
+        );
+    }
+
+    #[Test]
+    public function passesWhenPropertyIsInstance(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ProhibitStaticPropertiesRule/ClassWithInstanceProperty.php'],
+            [],
+            'Non-static properties must never be reported',
+        );
+    }
+
+    #[Test]
+    public function reportsEveryStaticPropertyIndependently(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ProhibitStaticPropertiesRule/ClassWithMultipleStaticProperties.php'],
+            [
+                [
+                    'Property Haspadar\PHPStanRules\Tests\Fixtures\Rules\ProhibitStaticPropertiesRule\ClassWithMultipleStaticProperties::$count is static. Static properties are prohibited.',
+                    9,
+                ],
+                [
+                    'Property Haspadar\PHPStanRules\Tests\Fixtures\Rules\ProhibitStaticPropertiesRule\ClassWithMultipleStaticProperties::$cache is static. Static properties are prohibited.',
+                    11,
+                ],
+                [
+                    'Property Haspadar\PHPStanRules\Tests\Fixtures\Rules\ProhibitStaticPropertiesRule\ClassWithMultipleStaticProperties::$instance is static. Static properties are prohibited.',
+                    13,
+                ],
+            ],
+            'Every static property declaration across all visibilities must produce a separate error',
+        );
+    }
+
+    #[Test]
+    public function reportsEachPropertyInGroupedDeclaration(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ProhibitStaticPropertiesRule/ClassWithGroupedStaticProperties.php'],
+            [
+                [
+                    'Property Haspadar\PHPStanRules\Tests\Fixtures\Rules\ProhibitStaticPropertiesRule\ClassWithGroupedStaticProperties::$first is static. Static properties are prohibited.',
+                    9,
+                ],
+                [
+                    'Property Haspadar\PHPStanRules\Tests\Fixtures\Rules\ProhibitStaticPropertiesRule\ClassWithGroupedStaticProperties::$second is static. Static properties are prohibited.',
+                    9,
+                ],
+            ],
+            'Every property in a grouped static declaration must produce its own error',
+        );
+    }
+
+    #[Test]
+    public function reportsStaticPropertyInAnonymousClass(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ProhibitStaticPropertiesRule/AnonymousClassWithStaticProperty.php'],
+            [
+                [
+                    'Property class@anonymous::$count is static. Static properties are prohibited.',
+                    12,
+                ],
+            ],
+            'Anonymous classes must be checked the same way as named ones',
+        );
+    }
+
+    #[Test]
+    public function passesWhenErrorIsSuppressed(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ProhibitStaticPropertiesRule/SuppressedClassWithStaticProperty.php'],
+            [],
+            'A @phpstan-ignore haspadar.staticProperty comment must silence the declaration error',
+        );
+    }
+
+    #[Test]
+    public function passesWhenAccessingVendorStaticProperty(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ProhibitStaticPropertiesRule/ClassWithStaticAccessToVendor.php'],
+            [],
+            'Static access to third-party classes is outside the scope of the declaration rule',
+        );
+    }
+}

--- a/tests/Unit/RulesTest.php
+++ b/tests/Unit/RulesTest.php
@@ -42,6 +42,7 @@ use Haspadar\PHPStanRules\Rules\NoPhpDocForOverriddenRule;
 use Haspadar\PHPStanRules\Rules\ParamDescriptionCapitalRule;
 use Haspadar\PHPStanRules\Rules\ReturnDescriptionCapitalRule;
 use Haspadar\PHPStanRules\Rules\ProhibitStaticMethodsRule;
+use Haspadar\PHPStanRules\Rules\ProhibitStaticPropertiesRule;
 use Haspadar\PHPStanRules\Rules\ReturnCountRule;
 use Haspadar\PHPStanRules\Rules\StatementCountRule;
 use Haspadar\PHPStanRules\Rules\TooManyMethodsRule;
@@ -84,6 +85,7 @@ final class RulesTest extends TestCase
                 ReturnCountRule::class,
                 ProtectedMethodInFinalClassRule::class,
                 ProhibitStaticMethodsRule::class,
+                ProhibitStaticPropertiesRule::class,
                 ConstructorInitializationRule::class,
                 NoParameterReassignmentRule::class,
                 IllegalCatchRule::class,


### PR DESCRIPTION
## Summary

- New PHPStan rule `ProhibitStaticPropertiesRule` (identifier `haspadar.staticProperty`) that flags every `static` property declaration regardless of visibility
- Grouped declarations (`public static $a, $b`) produce one error per declared property
- Anonymous classes are reported with `class@anonymous`; errors are suppressible via `@phpstan-ignore haspadar.staticProperty`
- Accesses to static properties of third-party classes are intentionally out of scope (covered by a dedicated vendor-fixture test)

Closes #144

## Test plan

- [ ] `vendor/bin/piqule check` — all 14 tools green locally
- [ ] Dedicated fixtures cover public/protected/private, grouped, anonymous, instance, suppressed, and vendor-access cases
- [ ] `ProhibitStaticPropertiesRuleTest` asserts every expected error line and message
- [ ] `RulesTest` confirms the new rule is registered in `Rules::all()`