### PR TITLE
Move InstabilityRule to opt-in experimental include

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@
 | `AfferentCouplingRule`            | 14      | Class must not be referenced by more than N other classes in the codebase  |
 | `InheritanceDepthRule`            | 3       | Class must not extend a chain of more than N ancestors                     |
 | `LackOfCohesionRule`              | 1       | Class methods must not split into more than N disjoint LCOM4 groups        |
-| `InstabilityRule`                 | 0.8     | Class I = Ce / (Ca + Ce) must not exceed N (Robert C. Martin's metric)     |
 
 ### Design
 
@@ -218,6 +217,33 @@ parameters:
             minProperties: 3
             excludedClasses:
                 - App\Entity\User
+```
+
+Default values match the defaults described in the rules table above. Omitting a parameter keeps the default. Diagnostic identifier for `AtclauseOrderRule`: `haspadar.atclauseOrder` (for targeted ignores, e.g. `@phpstan-ignore haspadar.atclauseOrder`).
+
+---
+
+## Experimental rules
+
+Some rules are not registered by default because their usefulness depends strongly on project topology. They live behind an opt-in include so adopting projects do not fail on legitimate code (for example, entry-point classes that naturally have instability `I = 1`).
+
+To enable them, add `rules-experimental.neon` to your `phpstan.neon`:
+
+```neon
+includes:
+    - vendor/haspadar/phpstan-rules/rules.neon
+    - vendor/haspadar/phpstan-rules/rules-experimental.neon
+```
+
+| Rule              | Why opt-in                                                                       |
+|-------------------|-----------------------------------------------------------------------------------|
+| `InstabilityRule` | Absolute threshold on a relative metric; `I = 1` is normal for entry-point classes |
+
+Once enabled, configure the rule like any other:
+
+```neon
+parameters:
+    haspadar:
         instability:
             maxInstability: 0.8
             minDependencies: 5
@@ -226,8 +252,6 @@ parameters:
             excludedClasses:
                 - App\Controller\HomeController
 ```
-
-Default values match the defaults described in the rules table above. Omitting a parameter keeps the default. Diagnostic identifier for `AtclauseOrderRule`: `haspadar.atclauseOrder` (for targeted ignores, e.g. `@phpstan-ignore haspadar.atclauseOrder`).
 
 ---
 

--- a/rules-experimental.neon
+++ b/rules-experimental.neon
@@ -1,0 +1,32 @@
+parameters:
+    haspadar:
+        instability:
+            maxInstability: 0.8
+            minDependencies: 5
+            ignoreInterfaces: true
+            ignoreAbstract: true
+            excludedClasses: []
+
+parametersSchema:
+    haspadar: structure([
+        instability: structure([
+            maxInstability: float(),
+            minDependencies: int(),
+            ignoreInterfaces: bool(),
+            ignoreAbstract: bool(),
+            excludedClasses: listOf(string()),
+        ]),
+    ])
+
+services:
+    -
+        class: Haspadar\PHPStanRules\Rules\InstabilityRule
+        arguments:
+            maxInstability: %haspadar.instability.maxInstability%
+            minDependencies: %haspadar.instability.minDependencies%
+            options:
+                ignoreInterfaces: %haspadar.instability.ignoreInterfaces%
+                ignoreAbstract: %haspadar.instability.ignoreAbstract%
+                excludedClasses: %haspadar.instability.excludedClasses%
+        tags:
+            - phpstan.rules.rule

--- a/rules-ignore.neon
+++ b/rules-ignore.neon
@@ -21,5 +21,3 @@ parameters:
             paths:
                 - src/Rules/CouplingBetweenObjectsRule.php
                 - src/Rules/MethodLengthRule.php
-        -
-            identifier: haspadar.instability

--- a/rules.neon
+++ b/rules.neon
@@ -118,12 +118,6 @@ parameters:
             minMethods: 7
             minProperties: 3
             excludedClasses: []
-        instability:
-            maxInstability: 0.8
-            minDependencies: 5
-            ignoreInterfaces: true
-            ignoreAbstract: true
-            excludedClasses: []
 
 parametersSchema:
     haspadar: structure([
@@ -244,13 +238,6 @@ parametersSchema:
             maxLcom: int(),
             minMethods: int(),
             minProperties: int(),
-            excludedClasses: listOf(string()),
-        ]),
-        instability: structure([
-            maxInstability: float(),
-            minDependencies: int(),
-            ignoreInterfaces: bool(),
-            ignoreAbstract: bool(),
             excludedClasses: listOf(string()),
         ]),
     ])
@@ -583,16 +570,5 @@ services:
                 minMethods: %haspadar.lackOfCohesion.minMethods%
                 minProperties: %haspadar.lackOfCohesion.minProperties%
                 excludedClasses: %haspadar.lackOfCohesion.excludedClasses%
-        tags:
-            - phpstan.rules.rule
-    -
-        class: Haspadar\PHPStanRules\Rules\InstabilityRule
-        arguments:
-            maxInstability: %haspadar.instability.maxInstability%
-            minDependencies: %haspadar.instability.minDependencies%
-            options:
-                ignoreInterfaces: %haspadar.instability.ignoreInterfaces%
-                ignoreAbstract: %haspadar.instability.ignoreAbstract%
-                excludedClasses: %haspadar.instability.excludedClasses%
         tags:
             - phpstan.rules.rule


### PR DESCRIPTION
- Removed InstabilityRule registration from the default rules.neon
- Added rules-experimental.neon that adopting projects opt into via includes
- Refactored README to document the experimental include mechanism
- Updated rules-ignore.neon to drop the now-dead haspadar.instability ignore

Closes #146