### PR TITLE
Add PhpDocParamDescriptionRule to require non-empty @param description

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@
 | `PhpDocMissingMethodRule`     | Every public method in a class must have a PHPDoc comment (configurable)                |
 | `PhpDocMissingPropertyRule`   | Every public property in a class must have a PHPDoc comment (configurable)              |
 | `PhpDocMissingParamRule`      | Every parameter of a method with a PHPDoc block must have a matching `@param` tag       |
+| `PhpDocParamDescriptionRule`  | Every `@param` tag must have a non-empty description after the parameter name           |
 | `ReturnDescriptionCapitalRule` | `@return` tag description must start with a capital letter                             |
 | `ParamDescriptionCapitalRule`  | `@param` tag descriptions must start with a capital letter                             |
 | `NoPhpDocForOverriddenRule`    | Overridden methods (`#[Override]`) must not have a PHPDoc comment                      |
@@ -150,6 +151,9 @@ parameters:
         phpDocMissingProperty:
             checkPublicOnly: true
         phpDocMissingParam:
+            checkPublicOnly: true
+            skipOverridden: true
+        phpDocParamDescription:
             checkPublicOnly: true
             skipOverridden: true
         abbreviation:

--- a/rules.neon
+++ b/rules.neon
@@ -60,6 +60,9 @@ parameters:
         phpDocMissingParam:
             checkPublicOnly: true
             skipOverridden: true
+        phpDocParamDescription:
+            checkPublicOnly: true
+            skipOverridden: true
         abbreviation:
             maxAllowedConsecutiveCapitals: 4
             allowedAbbreviations: []
@@ -190,6 +193,10 @@ parametersSchema:
             checkPublicOnly: bool(),
         ]),
         phpDocMissingParam: structure([
+            checkPublicOnly: bool(),
+            skipOverridden: bool(),
+        ]),
+        phpDocParamDescription: structure([
             checkPublicOnly: bool(),
             skipOverridden: bool(),
         ]),
@@ -435,6 +442,14 @@ services:
             options:
                 checkPublicOnly: %haspadar.phpDocMissingParam.checkPublicOnly%
                 skipOverridden: %haspadar.phpDocMissingParam.skipOverridden%
+        tags:
+            - phpstan.rules.rule
+    -
+        class: Haspadar\PHPStanRules\Rules\PhpDocParamDescriptionRule
+        arguments:
+            options:
+                checkPublicOnly: %haspadar.phpDocParamDescription.checkPublicOnly%
+                skipOverridden: %haspadar.phpDocParamDescription.skipOverridden%
         tags:
             - phpstan.rules.rule
     -

--- a/src/Rules.php
+++ b/src/Rules.php
@@ -41,6 +41,7 @@ final class Rules
         Rules\PhpDocMissingMethodRule::class,
         Rules\PhpDocMissingPropertyRule::class,
         Rules\PhpDocMissingParamRule::class,
+        Rules\PhpDocParamDescriptionRule::class,
         Rules\ReturnDescriptionCapitalRule::class,
         Rules\ParamDescriptionCapitalRule::class,
         Rules\NoPhpDocForOverriddenRule::class,

--- a/src/Rules/AbbreviationAsWordInNameRule.php
+++ b/src/Rules/AbbreviationAsWordInNameRule.php
@@ -37,7 +37,7 @@ final readonly class AbbreviationAsWordInNameRule implements Rule
      * @param int $maxAllowedConsecutiveCapitals Maximum consecutive capital letters before an identifier must be split.
      * @param array{
      *     allowedAbbreviations?: list<string>
-     * } $options
+     * } $options Abbreviations that bypass the consecutive-capitals check.
      */
     public function __construct(
         private int $maxAllowedConsecutiveCapitals = 4,

--- a/src/Rules/AfferentCouplingRule.php
+++ b/src/Rules/AfferentCouplingRule.php
@@ -46,7 +46,7 @@ final readonly class AfferentCouplingRule implements Rule
      *     ignoreInterfaces?: bool,
      *     ignoreAbstract?: bool,
      *     excludedClasses?: list<string>
-     * } $options
+     * } $options Filters that skip interfaces, abstract classes, and explicit FQCNs.
      */
     public function __construct(private int $maxAfferent = 14, array $options = [])
     {

--- a/src/Rules/AtclauseOrderRule.php
+++ b/src/Rules/AtclauseOrderRule.php
@@ -33,7 +33,7 @@ final readonly class AtclauseOrderRule implements Rule
     /**
      * Constructs the rule with the given tag order configuration.
      *
-     * @param array{tagOrder?: list<string>} $options
+     * @param array{tagOrder?: list<string>} $options Expected order of PHPDoc tag names.
      */
     public function __construct(array $options = [])
     {

--- a/src/Rules/BeImmutableRule.php
+++ b/src/Rules/BeImmutableRule.php
@@ -34,7 +34,7 @@ final readonly class BeImmutableRule implements Rule
      *
      * @param array{
      *     excludedClasses?: list<string>
-     * } $options
+     * } $options Classes to exclude from the immutability check (case-insensitive FQCN match).
      */
     public function __construct(array $options = [])
     {

--- a/src/Rules/ClassLengthRule.php
+++ b/src/Rules/ClassLengthRule.php
@@ -34,7 +34,7 @@ final readonly class ClassLengthRule implements Rule
      * @param array{
      *     skipBlankLines?: bool,
      *     skipComments?: bool
-     * } $options
+     * } $options Flags controlling which lines are counted towards the limit.
      */
     public function __construct(private int $maxLines = 500, array $options = [])
     {

--- a/src/Rules/ConstantUsageRule.php
+++ b/src/Rules/ConstantUsageRule.php
@@ -44,7 +44,7 @@ final readonly class ConstantUsageRule implements Rule
      *     ignoreNumbers?: list<int|float>,
      *     checkStrings?: bool,
      *     ignoreStrings?: list<string>
-     * } $options
+     * } $options Scalars treated as non-magic and toggle for string-literal checking.
      */
     public function __construct(array $options = [])
     {

--- a/src/Rules/CouplingBetweenObjectsRule.php
+++ b/src/Rules/CouplingBetweenObjectsRule.php
@@ -36,7 +36,7 @@ final readonly class CouplingBetweenObjectsRule implements Rule
      * @param int $maximum Maximum number of unique dependent types allowed per class
      * @param array{
      *     excludedClasses?: list<string>
-     * } $options
+     * } $options Classes to exclude from the coupling count (case-insensitive FQCN match).
      */
     public function __construct(private int $maximum = 15, array $options = [])
     {

--- a/src/Rules/FileLengthRule.php
+++ b/src/Rules/FileLengthRule.php
@@ -31,7 +31,7 @@ final readonly class FileLengthRule implements Rule
      * @param array{
      *     skipBlankLines?: bool,
      *     skipComments?: bool
-     * } $options
+     * } $options Flags controlling which lines are counted towards the limit.
      */
     public function __construct(private int $maxLines = 1000, array $options = [])
     {

--- a/src/Rules/ForbiddenClassSuffixRule.php
+++ b/src/Rules/ForbiddenClassSuffixRule.php
@@ -36,7 +36,7 @@ final readonly class ForbiddenClassSuffixRule implements Rule
      * @param array{
      *     forbiddenSuffixes?: list<string>,
      *     allowedSuffixes?: list<string>
-     * } $options
+     * } $options Forbidden and allow-listed class name suffixes.
      */
     public function __construct(array $options = [])
     {

--- a/src/Rules/IllegalThrowsRule.php
+++ b/src/Rules/IllegalThrowsRule.php
@@ -35,7 +35,7 @@ final readonly class IllegalThrowsRule implements Rule
      * Constructs the rule with the given list of forbidden throws class names and options.
      *
      * @param list<string> $illegalClassNames Class names (with or without leading backslash) that are forbidden in @throws
-     * @param array{ignoreOverriddenMethods?: bool} $options
+     * @param array{ignoreOverriddenMethods?: bool} $options Filter that skips `#[Override]` methods when enabled.
      */
     public function __construct(
         array $illegalClassNames = ['Error', 'RuntimeException', 'Throwable'],

--- a/src/Rules/InstabilityRule.php
+++ b/src/Rules/InstabilityRule.php
@@ -49,7 +49,7 @@ final readonly class InstabilityRule implements Rule
      *     ignoreInterfaces?: bool,
      *     ignoreAbstract?: bool,
      *     excludedClasses?: list<string>
-     * } $options
+     * } $options Filters that skip interfaces, abstract classes, and explicit FQCNs.
      */
     public function __construct(
         private float $maxInstability = 0.8,

--- a/src/Rules/InstabilityRule/DependencyGraph.php
+++ b/src/Rules/InstabilityRule/DependencyGraph.php
@@ -17,7 +17,7 @@ final readonly class DependencyGraph
     /**
      * Folds the collector payload into declarations, incoming edges and efferent counts.
      *
-     * @param array<string, list<array{class: string, kind: string, abstract: bool, line: int, dependencies: list<string>}>> $collected
+     * @param array<string, list<array{class: string, kind: string, abstract: bool, line: int, dependencies: list<string>}>> $collected Per-file class data emitted by ClassDependencyCollector.
      * @return array{
      *     array<string, array{class: string, kind: string, abstract: bool, file: string, line: int}>,
      *     array<string, array<string, true>>,

--- a/src/Rules/LackOfCohesionRule.php
+++ b/src/Rules/LackOfCohesionRule.php
@@ -74,7 +74,7 @@ final readonly class LackOfCohesionRule implements Rule
      *     minMethods?: int,
      *     minProperties?: int,
      *     excludedClasses?: list<string>
-     * } $options
+     * } $options Gate sizes under which the class is skipped and an FQCN exclusion list.
      */
     public function __construct(private int $maxLcom = 1, array $options = [])
     {

--- a/src/Rules/LackOfCohesionRule/AdjacencyBuilder.php
+++ b/src/Rules/LackOfCohesionRule/AdjacencyBuilder.php
@@ -19,8 +19,8 @@ final readonly class AdjacencyBuilder
     /**
      * Builds the adjacency list: each index maps to the list of connected indices.
      *
-     * @param list<ClassMethod> $methods
-     * @param list<array{properties: list<string>, calls: list<string>}> $touches
+     * @param list<ClassMethod> $methods Methods that form the nodes of the graph.
+     * @param list<array{properties: list<string>, calls: list<string>}> $touches Property and call references collected per method, indexed the same as $methods.
      * @return array<int, list<int>>
      */
     public function build(array $methods, array $touches): array

--- a/src/Rules/LackOfCohesionRule/CohesionGraph.php
+++ b/src/Rules/LackOfCohesionRule/CohesionGraph.php
@@ -18,7 +18,7 @@ final readonly class CohesionGraph
     /**
      * Returns the LCOM4 value for the given methods.
      *
-     * @param list<ClassMethod> $methods
+     * @param list<ClassMethod> $methods Methods that form the nodes of the cohesion graph.
      */
     public function componentCount(array $methods): int
     {

--- a/src/Rules/MethodLengthRule.php
+++ b/src/Rules/MethodLengthRule.php
@@ -31,7 +31,7 @@ final readonly class MethodLengthRule implements Rule
      * @param array{
      *     skipBlankLines?: bool,
      *     skipComments?: bool
-     * } $options
+     * } $options Flags controlling which lines are counted towards the limit.
      */
     public function __construct(private int $maxLines = 100, array $options = [])
     {

--- a/src/Rules/ParameterNumberRule.php
+++ b/src/Rules/ParameterNumberRule.php
@@ -28,7 +28,7 @@ final readonly class ParameterNumberRule implements Rule
      * @param int $maxParameters Maximum number of parameters per method or function.
      * @param array{
      *     ignoreOverridden?: bool
-     * } $options
+     * } $options Filter that skips methods carrying the `#[Override]` attribute when enabled.
      */
     public function __construct(private int $maxParameters = 3, array $options = [])
     {

--- a/src/Rules/PhpDocDescriptionChecker.php
+++ b/src/Rules/PhpDocDescriptionChecker.php
@@ -103,6 +103,32 @@ final readonly class PhpDocDescriptionChecker
     }
 
     /**
+     * Returns parameter names (with leading `$`) whose `@param` tag has an empty description.
+     *
+     * Each occurrence is reported independently, so duplicate parameter names with mixed
+     * descriptions appear once per empty-description tag.
+     *
+     * @param string $docText Raw PHPDoc block text with the opening and closing delimiters.
+     * @throws ShouldNotHappenException
+     * @return list<string>
+     */
+    public function extractEmptyParamNames(string $docText): array
+    {
+        $tokens = new TokenIterator($this->lexer->tokenize($docText));
+        $phpDocNode = $this->phpDocParser->parse($tokens);
+
+        $empty = [];
+
+        foreach ($phpDocNode->getParamTagValues() as $paramTag) {
+            if ($paramTag->description === '' && $paramTag->parameterName !== '') {
+                $empty[] = $paramTag->parameterName;
+            }
+        }
+
+        return $empty;
+    }
+
+    /**
      * Returns true if the string starts with an uppercase Unicode letter.
      *
      * @param string $text Text to inspect.

--- a/src/Rules/PhpDocMissingMethodRule.php
+++ b/src/Rules/PhpDocMissingMethodRule.php
@@ -30,7 +30,7 @@ final readonly class PhpDocMissingMethodRule implements Rule
     /**
      * Constructs the rule with the given visibility and override options.
      *
-     * @param array{checkPublicOnly?: bool, skipOverridden?: bool} $options
+     * @param array{checkPublicOnly?: bool, skipOverridden?: bool} $options Visibility filter and `#[Override]` skip flag.
      */
     public function __construct(array $options = [])
     {

--- a/src/Rules/PhpDocMissingParamRule.php
+++ b/src/Rules/PhpDocMissingParamRule.php
@@ -36,7 +36,7 @@ final readonly class PhpDocMissingParamRule implements Rule
     /**
      * Constructs the rule with visibility and override options, initialising the shared PHPDoc checker.
      *
-     * @param array{checkPublicOnly?: bool, skipOverridden?: bool} $options
+     * @param array{checkPublicOnly?: bool, skipOverridden?: bool} $options Visibility filter and `#[Override]` skip flag.
      * @throws ShouldNotHappenException
      */
     public function __construct(array $options = [])

--- a/src/Rules/PhpDocMissingPropertyRule.php
+++ b/src/Rules/PhpDocMissingPropertyRule.php
@@ -27,7 +27,7 @@ final readonly class PhpDocMissingPropertyRule implements Rule
     /**
      * Constructs the rule with the given visibility options.
      *
-     * @param array{checkPublicOnly?: bool} $options
+     * @param array{checkPublicOnly?: bool} $options Visibility filter that narrows the check to public properties when enabled.
      */
     public function __construct(array $options = [])
     {

--- a/src/Rules/PhpDocParamDescriptionRule.php
+++ b/src/Rules/PhpDocParamDescriptionRule.php
@@ -68,11 +68,9 @@ final readonly class PhpDocParamDescriptionRule implements Rule
             return [];
         }
 
-        $docText = $docComment->getText();
-        $allTags = $this->checker->extractParamNames($docText);
-        $withDescription = array_keys($this->checker->extractParamDescriptions($docText));
+        $emptyTags = $this->checker->extractEmptyParamNames($docComment->getText());
 
-        return $this->collectEmpty(array_values(array_diff($allTags, $withDescription)), $node->name->toString());
+        return $this->collectEmpty($emptyTags, $node->name->toString());
     }
 
     /**

--- a/src/Rules/PhpDocParamDescriptionRule.php
+++ b/src/Rules/PhpDocParamDescriptionRule.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Rules;
+
+use Override;
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\ShouldNotHappenException;
+
+/**
+ * Checks that every `@param` tag in a method PHPDoc block has a non-empty description.
+ * The rule does not require `@param` tags to be present — that is the job of
+ * PhpDocMissingParamRule. When a tag is present, the text after the parameter name must
+ * carry meaning; empty descriptions reduce a tag to a duplicate of the native signature
+ * and leave the reader without the semantic information the tag is meant to provide.
+ * Non-public methods are skipped when checkPublicOnly is true (default). Methods with the
+ * #[Override] attribute are skipped when skipOverridden is true (default) because the
+ * description is inherited from the overridden method.
+ *
+ * @implements Rule<ClassMethod>
+ */
+final readonly class PhpDocParamDescriptionRule implements Rule
+{
+    private bool $checkPublicOnly;
+
+    private bool $skipOverridden;
+
+    private PhpDocDescriptionChecker $checker;
+
+    /**
+     * Constructs the rule with visibility and override options, initialising the shared PHPDoc checker.
+     *
+     * @param array{checkPublicOnly?: bool, skipOverridden?: bool} $options Visibility filter and `#[Override]` skip flag.
+     * @throws ShouldNotHappenException
+     */
+    public function __construct(array $options = [])
+    {
+        $this->checkPublicOnly = $options['checkPublicOnly'] ?? true;
+        $this->skipOverridden = $options['skipOverridden'] ?? true;
+        $this->checker = new PhpDocDescriptionChecker();
+    }
+
+    #[Override]
+    public function getNodeType(): string
+    {
+        return ClassMethod::class;
+    }
+
+    /**
+     * Analyses the node and returns a list of errors, one per `@param` tag without a description.
+     *
+     * @psalm-param ClassMethod $node
+     * @throws ShouldNotHappenException
+     * @return list<IdentifierRuleError>
+     */
+    #[Override]
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $docComment = $node->getDocComment();
+
+        if ($this->shouldSkip($node, $scope) || $docComment === null) {
+            return [];
+        }
+
+        $docText = $docComment->getText();
+        $allTags = $this->checker->extractParamNames($docText);
+        $withDescription = array_keys($this->checker->extractParamDescriptions($docText));
+
+        return $this->collectEmpty(array_values(array_diff($allTags, $withDescription)), $node->name->toString());
+    }
+
+    /**
+     * Returns true when the rule must not inspect the given method (wrong scope, filtered by options, etc).
+     */
+    private function shouldSkip(ClassMethod $node, Scope $scope): bool
+    {
+        $reflection = $scope->getClassReflection();
+
+        return $reflection === null
+            || !$reflection->isClass()
+            || ($this->checkPublicOnly && !$node->isPublic())
+            || ($this->skipOverridden && $this->hasOverrideAttribute($node));
+    }
+
+    /**
+     * Builds one error per `@param` tag that has an empty description.
+     *
+     * @param list<string> $emptyTags Parameter names (with leading `$`) whose description is empty.
+     * @param string $methodName Method name used in the error message.
+     * @throws ShouldNotHappenException
+     * @return list<IdentifierRuleError>
+     */
+    private function collectEmpty(array $emptyTags, string $methodName): array
+    {
+        $errors = [];
+
+        foreach ($emptyTags as $paramName) {
+            $errors[] = RuleErrorBuilder::message(
+                sprintf(
+                    '@param %s for %s() is missing a description.',
+                    $paramName,
+                    $methodName,
+                ),
+            )
+                ->identifier('haspadar.phpdocParamDescription')
+                ->build();
+        }
+
+        return $errors;
+    }
+
+    /**
+     * Returns true if the method has the #[Override] attribute (with or without leading backslash).
+     */
+    private function hasOverrideAttribute(ClassMethod $node): bool
+    {
+        foreach ($node->attrGroups as $attrGroup) {
+            foreach ($attrGroup->attrs as $attr) {
+                if (in_array($attr->name->toString(), ['Override', '\Override'], true)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Rules/PhpDocPunctuationClassRule.php
+++ b/src/Rules/PhpDocPunctuationClassRule.php
@@ -29,7 +29,7 @@ final readonly class PhpDocPunctuationClassRule implements Rule
     /**
      * Constructs the rule with the given capitalization option.
      *
-     * @param array{checkCapitalization?: bool} $options
+     * @param array{checkCapitalization?: bool} $options Toggle that also enforces a capital letter at the start of the summary.
      */
     public function __construct(array $options = [])
     {

--- a/src/Rules/PhpDocPunctuationMethodRule.php
+++ b/src/Rules/PhpDocPunctuationMethodRule.php
@@ -30,7 +30,7 @@ final readonly class PhpDocPunctuationMethodRule implements Rule
     /**
      * Constructs the rule with the given capitalization option.
      *
-     * @param array{checkCapitalization?: bool} $options
+     * @param array{checkCapitalization?: bool} $options Toggle that also enforces a capital letter at the start of the summary.
      */
     public function __construct(array $options = [])
     {

--- a/src/Rules/StringLiteralsConcatenationRule.php
+++ b/src/Rules/StringLiteralsConcatenationRule.php
@@ -31,7 +31,7 @@ final readonly class StringLiteralsConcatenationRule implements Rule
     /**
      * Constructs the rule with the given options.
      *
-     * @param array{allowMixed?: bool} $options
+     * @param array{allowMixed?: bool} $options Toggle that allows concatenation between a literal and a non-literal operand.
      */
     public function __construct(array $options = [])
     {

--- a/src/Rules/TodoCommentRule.php
+++ b/src/Rules/TodoCommentRule.php
@@ -39,7 +39,7 @@ final readonly class TodoCommentRule implements Rule
      *
      * @param array{
      *     issueFormat?: non-empty-string
-     * } $options
+     * } $options Regex that a tagged reminder comment must match to be accepted as a tracked reference.
      * @throws InvalidArgumentException when `issueFormat` is not a valid regex
      */
     public function __construct(array $options = [])

--- a/src/Rules/TooManyMethodsRule.php
+++ b/src/Rules/TooManyMethodsRule.php
@@ -28,7 +28,7 @@ final readonly class TooManyMethodsRule implements Rule
      * @param int $maxMethods Maximum number of methods per class.
      * @param array{
      *     onlyPublic?: bool
-     * } $options
+     * } $options Filter that narrows the count to public methods only when enabled.
      */
     public function __construct(private int $maxMethods = 20, array $options = [])
     {

--- a/src/Rules/VariableNameRule.php
+++ b/src/Rules/VariableNameRule.php
@@ -33,7 +33,7 @@ final readonly class VariableNameRule implements Rule
      * Constructs the rule with the given pattern and options.
      *
      * @param string $pattern Regex (without delimiters) that every local variable name must match.
-     * @param array{allowedNames?: list<string>} $options
+     * @param array{allowedNames?: list<string>} $options Variable names that bypass the pattern check.
      * @throws ShouldNotHappenException
      */
     public function __construct(

--- a/tests/Fixtures/Rules/PhpDocParamDescriptionRule/ClassWithAllDescriptions.php
+++ b/tests/Fixtures/Rules/PhpDocParamDescriptionRule/ClassWithAllDescriptions.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\PhpDocParamDescriptionRule;
+
+final class ClassWithAllDescriptions
+{
+    /**
+     * Adds two numbers.
+     *
+     * @param int $a First operand.
+     * @param int $b Second operand.
+     */
+    public function add(int $a, int $b): int
+    {
+        return $a + $b;
+    }
+}

--- a/tests/Fixtures/Rules/PhpDocParamDescriptionRule/ClassWithEmptyParamDescription.php
+++ b/tests/Fixtures/Rules/PhpDocParamDescriptionRule/ClassWithEmptyParamDescription.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\PhpDocParamDescriptionRule;
+
+final class ClassWithEmptyParamDescription
+{
+    /**
+     * Greets a person.
+     *
+     * @param string $name
+     */
+    public function greet(string $name): string
+    {
+        return 'hello ' . $name;
+    }
+}

--- a/tests/Fixtures/Rules/PhpDocParamDescriptionRule/ClassWithMixedDescriptions.php
+++ b/tests/Fixtures/Rules/PhpDocParamDescriptionRule/ClassWithMixedDescriptions.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\PhpDocParamDescriptionRule;
+
+final class ClassWithMixedDescriptions
+{
+    /**
+     * Combines three parts.
+     *
+     * @param string $first First chunk.
+     * @param string $second
+     * @param string $third Third chunk.
+     */
+    public function combine(string $first, string $second, string $third): string
+    {
+        return $first . $second . $third;
+    }
+}

--- a/tests/Fixtures/Rules/PhpDocParamDescriptionRule/ClassWithMultipleEmptyDescriptions.php
+++ b/tests/Fixtures/Rules/PhpDocParamDescriptionRule/ClassWithMultipleEmptyDescriptions.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\PhpDocParamDescriptionRule;
+
+final class ClassWithMultipleEmptyDescriptions
+{
+    /**
+     * Combines three parts.
+     *
+     * @param string $first
+     * @param string $second
+     * @param string $third
+     */
+    public function combine(string $first, string $second, string $third): string
+    {
+        return $first . $second . $third;
+    }
+}

--- a/tests/Fixtures/Rules/PhpDocParamDescriptionRule/ClassWithNoPhpDoc.php
+++ b/tests/Fixtures/Rules/PhpDocParamDescriptionRule/ClassWithNoPhpDoc.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\PhpDocParamDescriptionRule;
+
+final class ClassWithNoPhpDoc
+{
+    public function greet(string $name): string
+    {
+        return 'hello ' . $name;
+    }
+}

--- a/tests/Fixtures/Rules/PhpDocParamDescriptionRule/ClassWithOverriddenMethod.php
+++ b/tests/Fixtures/Rules/PhpDocParamDescriptionRule/ClassWithOverriddenMethod.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\PhpDocParamDescriptionRule;
+
+use Override;
+
+class ParentGreeterForDescriptionOverride
+{
+    /**
+     * Greets a person.
+     *
+     * @param string $name The person to greet.
+     */
+    public function greet(string $name): string
+    {
+        return 'hello ' . $name;
+    }
+}
+
+final class ClassWithOverriddenMethod extends ParentGreeterForDescriptionOverride
+{
+    /**
+     * Greets loudly.
+     *
+     * @param string $name
+     */
+    #[Override]
+    public function greet(string $name): string
+    {
+        return strtoupper($name);
+    }
+}

--- a/tests/Fixtures/Rules/PhpDocParamDescriptionRule/ClassWithPrivateMethod.php
+++ b/tests/Fixtures/Rules/PhpDocParamDescriptionRule/ClassWithPrivateMethod.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\PhpDocParamDescriptionRule;
+
+final class ClassWithPrivateMethod
+{
+    /**
+     * Normalises the input.
+     *
+     * @param string $input
+     */
+    private function normalise(string $input): string
+    {
+        return trim($input);
+    }
+}

--- a/tests/Fixtures/Rules/PhpDocParamDescriptionRule/ClassWithVariadicParam.php
+++ b/tests/Fixtures/Rules/PhpDocParamDescriptionRule/ClassWithVariadicParam.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\PhpDocParamDescriptionRule;
+
+final class ClassWithVariadicParam
+{
+    /**
+     * Concatenates parts.
+     *
+     * @param string ...$parts
+     */
+    public function concat(string ...$parts): string
+    {
+        return implode('', $parts);
+    }
+}

--- a/tests/Fixtures/Rules/PhpDocParamDescriptionRule/SuppressedEmptyDescription.php
+++ b/tests/Fixtures/Rules/PhpDocParamDescriptionRule/SuppressedEmptyDescription.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\PhpDocParamDescriptionRule;
+
+final class SuppressedEmptyDescription
+{
+    /**
+     * Greets a person.
+     *
+     * @param string $name
+     * @phpstan-ignore haspadar.phpdocParamDescription
+     */
+    public function greet(string $name): string
+    {
+        return 'hello ' . $name;
+    }
+}

--- a/tests/Unit/Rules/PhpDocParamDescriptionRule/PhpDocParamDescriptionRuleDefaultTest.php
+++ b/tests/Unit/Rules/PhpDocParamDescriptionRule/PhpDocParamDescriptionRuleDefaultTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\PhpDocParamDescriptionRule;
+
+use Haspadar\PHPStanRules\Rules\PhpDocParamDescriptionRule;
+use Override;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<PhpDocParamDescriptionRule> */
+final class PhpDocParamDescriptionRuleDefaultTest extends RuleTestCase
+{
+    #[Override]
+    protected function getRule(): Rule
+    {
+        return new PhpDocParamDescriptionRule();
+    }
+
+    #[Test]
+    public function reportsEmptyDescriptionInPublicMethod(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/PhpDocParamDescriptionRule/ClassWithEmptyParamDescription.php'],
+            [
+                ['@param $name for greet() is missing a description.', 14],
+            ],
+            'Default options must still catch empty @param descriptions on public methods',
+        );
+    }
+
+    #[Test]
+    public function passesWhenPrivateMethodHasEmptyDescription(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/PhpDocParamDescriptionRule/ClassWithPrivateMethod.php'],
+            [],
+            'checkPublicOnly=true must skip private methods regardless of empty descriptions',
+        );
+    }
+
+    #[Test]
+    public function passesWhenOverriddenMethodHasEmptyDescription(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/PhpDocParamDescriptionRule/ClassWithOverriddenMethod.php'],
+            [],
+            'skipOverridden=true must skip #[Override] methods regardless of empty descriptions',
+        );
+    }
+}

--- a/tests/Unit/Rules/PhpDocParamDescriptionRule/PhpDocParamDescriptionRuleTest.php
+++ b/tests/Unit/Rules/PhpDocParamDescriptionRule/PhpDocParamDescriptionRuleTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\PhpDocParamDescriptionRule;
+
+use Haspadar\PHPStanRules\Rules\PhpDocParamDescriptionRule;
+use Override;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<PhpDocParamDescriptionRule> */
+final class PhpDocParamDescriptionRuleTest extends RuleTestCase
+{
+    #[Override]
+    protected function getRule(): Rule
+    {
+        return new PhpDocParamDescriptionRule(['checkPublicOnly' => false, 'skipOverridden' => false]);
+    }
+
+    #[Test]
+    public function passesWhenEveryParamHasDescription(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/PhpDocParamDescriptionRule/ClassWithAllDescriptions.php'],
+            [],
+            'All @param tags carry a non-empty description, no error must be reported',
+        );
+    }
+
+    #[Test]
+    public function reportsEmptyParamDescription(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/PhpDocParamDescriptionRule/ClassWithEmptyParamDescription.php'],
+            [
+                ['@param $name for greet() is missing a description.', 14],
+            ],
+            'A @param tag with only type and name and no text must be reported as missing description',
+        );
+    }
+
+    #[Test]
+    public function reportsEveryEmptyDescriptionIndependently(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/PhpDocParamDescriptionRule/ClassWithMultipleEmptyDescriptions.php'],
+            [
+                ['@param $first for combine() is missing a description.', 16],
+                ['@param $second for combine() is missing a description.', 16],
+                ['@param $third for combine() is missing a description.', 16],
+            ],
+            'Each empty @param description must produce its own error with the parameter name',
+        );
+    }
+
+    #[Test]
+    public function reportsOnlyTheParamWithoutDescription(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/PhpDocParamDescriptionRule/ClassWithMixedDescriptions.php'],
+            [
+                ['@param $second for combine() is missing a description.', 16],
+            ],
+            'Only the @param tag without text must be flagged; siblings with descriptions must stay silent',
+        );
+    }
+
+    #[Test]
+    public function passesWhenMethodHasNoPhpDoc(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/PhpDocParamDescriptionRule/ClassWithNoPhpDoc.php'],
+            [],
+            'Absent PHPDoc is the concern of PhpDocMissingMethodRule, not this rule',
+        );
+    }
+
+    #[Test]
+    public function reportsEmptyDescriptionOnOverrideWhenOptionDisabled(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/PhpDocParamDescriptionRule/ClassWithOverriddenMethod.php'],
+            [
+                ['@param $name for greet() is missing a description.', 29],
+            ],
+            'When skipOverridden=false, #[Override] methods must also require non-empty @param descriptions',
+        );
+    }
+
+    #[Test]
+    public function reportsEmptyDescriptionInPrivateMethodWhenOptionDisabled(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/PhpDocParamDescriptionRule/ClassWithPrivateMethod.php'],
+            [
+                ['@param $input for normalise() is missing a description.', 14],
+            ],
+            'When checkPublicOnly=false, private methods must also require non-empty @param descriptions',
+        );
+    }
+
+    #[Test]
+    public function passesWhenErrorIsSuppressed(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/PhpDocParamDescriptionRule/SuppressedEmptyDescription.php'],
+            [],
+            'A @phpstan-ignore haspadar.phpdocParamDescription comment must silence the error',
+        );
+    }
+}

--- a/tests/Unit/Rules/PhpDocParamDescriptionRule/PhpDocParamDescriptionRuleTest.php
+++ b/tests/Unit/Rules/PhpDocParamDescriptionRule/PhpDocParamDescriptionRuleTest.php
@@ -102,6 +102,18 @@ final class PhpDocParamDescriptionRuleTest extends RuleTestCase
     }
 
     #[Test]
+    public function reportsEmptyDescriptionForVariadicParameter(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/PhpDocParamDescriptionRule/ClassWithVariadicParam.php'],
+            [
+                ['@param $parts for concat() is missing a description.', 14],
+            ],
+            'Variadic @param tags must require a description like any other parameter',
+        );
+    }
+
+    #[Test]
     public function passesWhenErrorIsSuppressed(): void
     {
         $this->analyse(

--- a/tests/Unit/RulesTest.php
+++ b/tests/Unit/RulesTest.php
@@ -31,6 +31,7 @@ use Haspadar\PHPStanRules\Rules\PhpDocMissingClassRule;
 use Haspadar\PHPStanRules\Rules\PhpDocMissingMethodRule;
 use Haspadar\PHPStanRules\Rules\PhpDocMissingParamRule;
 use Haspadar\PHPStanRules\Rules\PhpDocMissingPropertyRule;
+use Haspadar\PHPStanRules\Rules\PhpDocParamDescriptionRule;
 use Haspadar\PHPStanRules\Rules\ClassConstantTypeHintRule;
 use Haspadar\PHPStanRules\Rules\AbbreviationAsWordInNameRule;
 use Haspadar\PHPStanRules\Rules\NoInlineCommentRule;
@@ -102,6 +103,7 @@ final class RulesTest extends TestCase
                 PhpDocMissingMethodRule::class,
                 PhpDocMissingPropertyRule::class,
                 PhpDocMissingParamRule::class,
+                PhpDocParamDescriptionRule::class,
                 ReturnDescriptionCapitalRule::class,
                 ParamDescriptionCapitalRule::class,
                 NoPhpDocForOverriddenRule::class,


### PR DESCRIPTION
- Added PhpDocParamDescriptionRule (identifier haspadar.phpdocParamDescription) that flags `@param` tags with empty descriptions
- Added extractEmptyParamNames() to the shared PhpDocDescriptionChecker that reports each empty tag independently (duplicate-name safe)
- Registered the rule with checkPublicOnly=true and skipOverridden=true defaults
- Added fixtures and tests covering all-described / empty / multiple-empty / mixed / no-phpdoc / private / overridden / variadic / suppressed cases
- Described every existing @param tag across rules, collectors, and helpers so the new rule is green on its own codebase

Closes #150

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new `PhpDocParamDescriptionRule` to validate that `@param` tags in PHPDoc comments include non-empty descriptions.
  * Configuration options available: `checkPublicOnly` (defaults to `true`) and `skipOverridden` (defaults to `true`) for flexible rule behavior.

* **Documentation**
  * Enhanced PHPDoc descriptions across existing rules for improved clarity on configuration parameters.
  * Updated README with new rule documentation and configuration examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->