### PR TITLE
Add PhpDocParamOrderRule to require @param order matching signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@
 | `PhpDocMissingPropertyRule`   | Every public property in a class must have a PHPDoc comment (configurable)              |
 | `PhpDocMissingParamRule`      | Every parameter of a method with a PHPDoc block must have a matching `@param` tag       |
 | `PhpDocParamDescriptionRule`  | Every `@param` tag must have a non-empty description after the parameter name           |
+| `PhpDocParamOrderRule`        | `@param` tags must appear in the same order as the parameters of the method signature   |
 | `ReturnDescriptionCapitalRule` | `@return` tag description must start with a capital letter                             |
 | `ParamDescriptionCapitalRule`  | `@param` tag descriptions must start with a capital letter                             |
 | `NoPhpDocForOverriddenRule`    | Overridden methods (`#[Override]`) must not have a PHPDoc comment                      |
@@ -154,6 +155,9 @@ parameters:
             checkPublicOnly: true
             skipOverridden: true
         phpDocParamDescription:
+            checkPublicOnly: true
+            skipOverridden: true
+        phpdocParamOrder:
             checkPublicOnly: true
             skipOverridden: true
         abbreviation:

--- a/rules.neon
+++ b/rules.neon
@@ -63,6 +63,9 @@ parameters:
         phpDocParamDescription:
             checkPublicOnly: true
             skipOverridden: true
+        phpdocParamOrder:
+            checkPublicOnly: true
+            skipOverridden: true
         abbreviation:
             maxAllowedConsecutiveCapitals: 4
             allowedAbbreviations: []
@@ -197,6 +200,10 @@ parametersSchema:
             skipOverridden: bool(),
         ]),
         phpDocParamDescription: structure([
+            checkPublicOnly: bool(),
+            skipOverridden: bool(),
+        ]),
+        phpdocParamOrder: structure([
             checkPublicOnly: bool(),
             skipOverridden: bool(),
         ]),
@@ -450,6 +457,14 @@ services:
             options:
                 checkPublicOnly: %haspadar.phpDocParamDescription.checkPublicOnly%
                 skipOverridden: %haspadar.phpDocParamDescription.skipOverridden%
+        tags:
+            - phpstan.rules.rule
+    -
+        class: Haspadar\PHPStanRules\Rules\PhpDocParamOrderRule
+        arguments:
+            options:
+                checkPublicOnly: %haspadar.phpdocParamOrder.checkPublicOnly%
+                skipOverridden: %haspadar.phpdocParamOrder.skipOverridden%
         tags:
             - phpstan.rules.rule
     -

--- a/src/Rules.php
+++ b/src/Rules.php
@@ -42,6 +42,7 @@ final class Rules
         Rules\PhpDocMissingPropertyRule::class,
         Rules\PhpDocMissingParamRule::class,
         Rules\PhpDocParamDescriptionRule::class,
+        Rules\PhpDocParamOrderRule::class,
         Rules\ReturnDescriptionCapitalRule::class,
         Rules\ParamDescriptionCapitalRule::class,
         Rules\NoPhpDocForOverriddenRule::class,

--- a/src/Rules/PhpDocParamOrderRule.php
+++ b/src/Rules/PhpDocParamOrderRule.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Rules;
+
+use Override;
+use PhpParser\Node;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\ShouldNotHappenException;
+
+/**
+ * Checks that `@param` tags appear in the same order as the parameters of the method signature.
+ * Extra tags (for names absent from the signature) and missing tags are both ignored — those are
+ * the concern of PhpDocMissingParamRule. Only the relative order of tags that intersect with the
+ * signature is inspected: the signature names filtered by presence in the tags must equal the tag
+ * names filtered by presence in the signature. Non-public methods are skipped when checkPublicOnly
+ * is true (default). Methods carrying the #[Override] attribute are skipped when skipOverridden is
+ * true (default) because their parameter contract is inherited from the overridden method.
+ *
+ * @implements Rule<ClassMethod>
+ */
+final readonly class PhpDocParamOrderRule implements Rule
+{
+    private bool $checkPublicOnly;
+
+    private bool $skipOverridden;
+
+    private PhpDocDescriptionChecker $checker;
+
+    /**
+     * Constructs the rule with visibility and override options, initialising the shared PHPDoc checker.
+     *
+     * @param array{checkPublicOnly?: bool, skipOverridden?: bool} $options Visibility filter and `#[Override]` skip flag.
+     * @throws ShouldNotHappenException
+     */
+    public function __construct(array $options = [])
+    {
+        $this->checkPublicOnly = $options['checkPublicOnly'] ?? true;
+        $this->skipOverridden = $options['skipOverridden'] ?? true;
+        $this->checker = new PhpDocDescriptionChecker();
+    }
+
+    #[Override]
+    public function getNodeType(): string
+    {
+        return ClassMethod::class;
+    }
+
+    /**
+     * Analyses the node and returns at most one error when the `@param` order does not match the signature.
+     *
+     * @psalm-param ClassMethod $node
+     * @throws ShouldNotHappenException
+     * @return list<IdentifierRuleError>
+     */
+    #[Override]
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $docComment = $node->getDocComment();
+
+        if ($this->shouldSkip($node, $scope) || $docComment === null) {
+            return [];
+        }
+
+        $signatureNames = $this->signatureParamNames($node);
+        $tagNames = $this->checker->extractParamNames($docComment->getText());
+
+        $expectedOrder = array_values(array_intersect($signatureNames, $tagNames));
+        $actualOrder = array_values(array_intersect($tagNames, $signatureNames));
+
+        if ($expectedOrder === $actualOrder) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message(
+                sprintf(
+                    '@param order for %s() does not match the signature: expected %s, got %s.',
+                    $node->name->toString(),
+                    implode(', ', $expectedOrder),
+                    implode(', ', $actualOrder),
+                ),
+            )
+                ->identifier('haspadar.phpdocParamOrder')
+                ->build(),
+        ];
+    }
+
+    /**
+     * Returns true when the rule must not inspect the given method (wrong scope, filtered by options, etc).
+     */
+    private function shouldSkip(ClassMethod $node, Scope $scope): bool
+    {
+        $reflection = $scope->getClassReflection();
+
+        return $reflection === null
+            || !$reflection->isClass()
+            || ($this->checkPublicOnly && !$node->isPublic())
+            || ($this->skipOverridden && $this->hasOverrideAttribute($node));
+    }
+
+    /**
+     * Returns parameter names (with leading `$`) from the signature in declaration order.
+     *
+     * @return list<string>
+     */
+    private function signatureParamNames(ClassMethod $node): array
+    {
+        $names = [];
+
+        foreach ($node->params as $param) {
+            if (!$param->var instanceof Variable || !is_string($param->var->name)) {
+                continue;
+            }
+
+            $names[] = sprintf('$%s', $param->var->name);
+        }
+
+        return $names;
+    }
+
+    /**
+     * Returns true if the method has the #[Override] attribute (with or without leading backslash).
+     */
+    private function hasOverrideAttribute(ClassMethod $node): bool
+    {
+        foreach ($node->attrGroups as $attrGroup) {
+            foreach ($attrGroup->attrs as $attr) {
+                if (in_array($attr->name->toString(), ['Override', '\Override'], true)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/Fixtures/Rules/PhpDocParamOrderRule/ClassWithCorrectOrder.php
+++ b/tests/Fixtures/Rules/PhpDocParamOrderRule/ClassWithCorrectOrder.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\PhpDocParamOrderRule;
+
+final class ClassWithCorrectOrder
+{
+    /**
+     * Adds two numbers.
+     *
+     * @param int $a First operand.
+     * @param int $b Second operand.
+     */
+    public function add(int $a, int $b): int
+    {
+        return $a + $b;
+    }
+}

--- a/tests/Fixtures/Rules/PhpDocParamOrderRule/ClassWithNoPhpDoc.php
+++ b/tests/Fixtures/Rules/PhpDocParamOrderRule/ClassWithNoPhpDoc.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\PhpDocParamOrderRule;
+
+final class ClassWithNoPhpDoc
+{
+    public function add(int $a, int $b): int
+    {
+        return $a + $b;
+    }
+}

--- a/tests/Fixtures/Rules/PhpDocParamOrderRule/ClassWithOverriddenMethod.php
+++ b/tests/Fixtures/Rules/PhpDocParamOrderRule/ClassWithOverriddenMethod.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\PhpDocParamOrderRule;
+
+use Override;
+
+class ParentForParamOrderOverride
+{
+    /**
+     * Adds two numbers.
+     *
+     * @param int $a First operand.
+     * @param int $b Second operand.
+     */
+    public function add(int $a, int $b): int
+    {
+        return $a + $b;
+    }
+}
+
+final class ClassWithOverriddenMethod extends ParentForParamOrderOverride
+{
+    /**
+     * Adds two numbers louder.
+     *
+     * @param int $b Second.
+     * @param int $a First.
+     */
+    #[Override]
+    public function add(int $a, int $b): int
+    {
+        return ($a + $b) * 2;
+    }
+}

--- a/tests/Fixtures/Rules/PhpDocParamOrderRule/ClassWithPrivateMethod.php
+++ b/tests/Fixtures/Rules/PhpDocParamOrderRule/ClassWithPrivateMethod.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\PhpDocParamOrderRule;
+
+final class ClassWithPrivateMethod
+{
+    /**
+     * Normalises two inputs.
+     *
+     * @param string $second Second.
+     * @param string $first First.
+     */
+    private function normalise(string $first, string $second): string
+    {
+        return trim($first . $second);
+    }
+}

--- a/tests/Fixtures/Rules/PhpDocParamOrderRule/ClassWithPromotedParameters.php
+++ b/tests/Fixtures/Rules/PhpDocParamOrderRule/ClassWithPromotedParameters.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\PhpDocParamOrderRule;
+
+final class ClassWithPromotedParameters
+{
+    /**
+     * Builds a user.
+     *
+     * @param int    $age  Age in years.
+     * @param string $name Display name.
+     */
+    public function __construct(public string $name, public int $age)
+    {
+    }
+}

--- a/tests/Fixtures/Rules/PhpDocParamOrderRule/ClassWithSubsetInOrder.php
+++ b/tests/Fixtures/Rules/PhpDocParamOrderRule/ClassWithSubsetInOrder.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\PhpDocParamOrderRule;
+
+final class ClassWithSubsetInOrder
+{
+    /**
+     * Sums three numbers.
+     *
+     * @param int $a First.
+     * @param int $c Third.
+     */
+    public function sum(int $a, int $b, int $c): int
+    {
+        return $a + $b + $c;
+    }
+}

--- a/tests/Fixtures/Rules/PhpDocParamOrderRule/ClassWithSubsetWrongOrder.php
+++ b/tests/Fixtures/Rules/PhpDocParamOrderRule/ClassWithSubsetWrongOrder.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\PhpDocParamOrderRule;
+
+final class ClassWithSubsetWrongOrder
+{
+    /**
+     * Sums three numbers.
+     *
+     * @param int $c Third.
+     * @param int $a First.
+     */
+    public function sum(int $a, int $b, int $c): int
+    {
+        return $a + $b + $c;
+    }
+}

--- a/tests/Fixtures/Rules/PhpDocParamOrderRule/ClassWithThreeSwapped.php
+++ b/tests/Fixtures/Rules/PhpDocParamOrderRule/ClassWithThreeSwapped.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\PhpDocParamOrderRule;
+
+final class ClassWithThreeSwapped
+{
+    /**
+     * Sums three numbers.
+     *
+     * @param int $c Third.
+     * @param int $a First.
+     * @param int $b Second.
+     */
+    public function sum(int $a, int $b, int $c): int
+    {
+        return $a + $b + $c;
+    }
+}

--- a/tests/Fixtures/Rules/PhpDocParamOrderRule/ClassWithVariadicParam.php
+++ b/tests/Fixtures/Rules/PhpDocParamOrderRule/ClassWithVariadicParam.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\PhpDocParamOrderRule;
+
+final class ClassWithVariadicParam
+{
+    /**
+     * Concatenates a prefix with parts.
+     *
+     * @param string    ...$parts Parts to concatenate.
+     * @param string    $prefix   Prefix placed before the parts.
+     */
+    public function concat(string $prefix, string ...$parts): string
+    {
+        return $prefix . implode('', $parts);
+    }
+}

--- a/tests/Fixtures/Rules/PhpDocParamOrderRule/ClassWithWrongOrder.php
+++ b/tests/Fixtures/Rules/PhpDocParamOrderRule/ClassWithWrongOrder.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\PhpDocParamOrderRule;
+
+final class ClassWithWrongOrder
+{
+    /**
+     * Adds two numbers.
+     *
+     * @param int $b Second operand.
+     * @param int $a First operand.
+     */
+    public function add(int $a, int $b): int
+    {
+        return $a + $b;
+    }
+}

--- a/tests/Fixtures/Rules/PhpDocParamOrderRule/SuppressedWrongOrder.php
+++ b/tests/Fixtures/Rules/PhpDocParamOrderRule/SuppressedWrongOrder.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\PhpDocParamOrderRule;
+
+final class SuppressedWrongOrder
+{
+    /**
+     * Adds two numbers.
+     *
+     * @param int $b Second.
+     * @param int $a First.
+     * @phpstan-ignore haspadar.phpdocParamOrder
+     */
+    public function add(int $a, int $b): int
+    {
+        return $a + $b;
+    }
+}

--- a/tests/Unit/Rules/PhpDocParamOrderRule/PhpDocParamOrderRuleDefaultTest.php
+++ b/tests/Unit/Rules/PhpDocParamOrderRule/PhpDocParamOrderRuleDefaultTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\PhpDocParamOrderRule;
+
+use Haspadar\PHPStanRules\Rules\PhpDocParamOrderRule;
+use Override;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<PhpDocParamOrderRule> */
+final class PhpDocParamOrderRuleDefaultTest extends RuleTestCase
+{
+    #[Override]
+    protected function getRule(): Rule
+    {
+        return new PhpDocParamOrderRule();
+    }
+
+    #[Test]
+    public function reportsWrongOrderInPublicMethod(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/PhpDocParamOrderRule/ClassWithWrongOrder.php'],
+            [
+                ['@param order for add() does not match the signature: expected $a, $b, got $b, $a.', 15],
+            ],
+            'Default options must still catch wrong @param order on public methods',
+        );
+    }
+
+    #[Test]
+    public function passesWhenPrivateMethodHasWrongOrder(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/PhpDocParamOrderRule/ClassWithPrivateMethod.php'],
+            [],
+            'checkPublicOnly=true must skip private methods regardless of the @param order',
+        );
+    }
+
+    #[Test]
+    public function passesWhenOverriddenMethodHasWrongOrder(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/PhpDocParamOrderRule/ClassWithOverriddenMethod.php'],
+            [],
+            'skipOverridden=true must skip #[Override] methods regardless of the @param order',
+        );
+    }
+}

--- a/tests/Unit/Rules/PhpDocParamOrderRule/PhpDocParamOrderRuleTest.php
+++ b/tests/Unit/Rules/PhpDocParamOrderRule/PhpDocParamOrderRuleTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\PhpDocParamOrderRule;
+
+use Haspadar\PHPStanRules\Rules\PhpDocParamOrderRule;
+use Override;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<PhpDocParamOrderRule> */
+final class PhpDocParamOrderRuleTest extends RuleTestCase
+{
+    #[Override]
+    protected function getRule(): Rule
+    {
+        return new PhpDocParamOrderRule(['checkPublicOnly' => false, 'skipOverridden' => false]);
+    }
+
+    #[Test]
+    public function passesWhenTagsMatchSignatureOrder(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/PhpDocParamOrderRule/ClassWithCorrectOrder.php'],
+            [],
+            'Tags in the same order as the signature must not produce any error',
+        );
+    }
+
+    #[Test]
+    public function reportsSwappedPairOfTags(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/PhpDocParamOrderRule/ClassWithWrongOrder.php'],
+            [
+                ['@param order for add() does not match the signature: expected $a, $b, got $b, $a.', 15],
+            ],
+            'Two @param tags in the opposite order to the signature must be reported once',
+        );
+    }
+
+    #[Test]
+    public function reportsThreeSwappedTags(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/PhpDocParamOrderRule/ClassWithThreeSwapped.php'],
+            [
+                ['@param order for sum() does not match the signature: expected $a, $b, $c, got $c, $a, $b.', 16],
+            ],
+            'A larger permutation must be reported once with expected and actual order listed',
+        );
+    }
+
+    #[Test]
+    public function passesWhenSubsetOfTagsAppearsInSignatureOrder(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/PhpDocParamOrderRule/ClassWithSubsetInOrder.php'],
+            [],
+            'A subset of @param tags in the signature order must not produce any error; missing tags are another rule',
+        );
+    }
+
+    #[Test]
+    public function reportsSubsetOfTagsInWrongOrder(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/PhpDocParamOrderRule/ClassWithSubsetWrongOrder.php'],
+            [
+                ['@param order for sum() does not match the signature: expected $a, $c, got $c, $a.', 15],
+            ],
+            'Even a partial set of @param tags must follow the signature order',
+        );
+    }
+
+    #[Test]
+    public function passesWhenMethodHasNoPhpDoc(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/PhpDocParamOrderRule/ClassWithNoPhpDoc.php'],
+            [],
+            'Absent PHPDoc is the concern of PhpDocMissingMethodRule, not this rule',
+        );
+    }
+
+    #[Test]
+    public function reportsWrongOrderOnOverrideWhenOptionDisabled(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/PhpDocParamOrderRule/ClassWithOverriddenMethod.php'],
+            [
+                ['@param order for add() does not match the signature: expected $a, $b, got $b, $a.', 31],
+            ],
+            'When skipOverridden=false, #[Override] methods must also require matching @param order',
+        );
+    }
+
+    #[Test]
+    public function reportsWrongOrderInPrivateMethodWhenOptionDisabled(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/PhpDocParamOrderRule/ClassWithPrivateMethod.php'],
+            [
+                ['@param order for normalise() does not match the signature: expected $first, $second, got $second, $first.', 15],
+            ],
+            'When checkPublicOnly=false, private methods must also require matching @param order',
+        );
+    }
+
+    #[Test]
+    public function passesWhenErrorIsSuppressed(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/PhpDocParamOrderRule/SuppressedWrongOrder.php'],
+            [],
+            'A @phpstan-ignore haspadar.phpdocParamOrder comment must silence the error',
+        );
+    }
+}

--- a/tests/Unit/Rules/PhpDocParamOrderRule/PhpDocParamOrderRuleTest.php
+++ b/tests/Unit/Rules/PhpDocParamOrderRule/PhpDocParamOrderRuleTest.php
@@ -110,6 +110,30 @@ final class PhpDocParamOrderRuleTest extends RuleTestCase
     }
 
     #[Test]
+    public function reportsWrongOrderForVariadicParameter(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/PhpDocParamOrderRule/ClassWithVariadicParam.php'],
+            [
+                ['@param order for concat() does not match the signature: expected $prefix, $parts, got $parts, $prefix.', 15],
+            ],
+            'Variadic parameters are matched by their bare name and must follow the signature order',
+        );
+    }
+
+    #[Test]
+    public function reportsWrongOrderForPromotedParameters(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/PhpDocParamOrderRule/ClassWithPromotedParameters.php'],
+            [
+                ['@param order for __construct() does not match the signature: expected $name, $age, got $age, $name.', 15],
+            ],
+            'Constructor property promotion parameters must be checked like ordinary parameters',
+        );
+    }
+
+    #[Test]
     public function passesWhenErrorIsSuppressed(): void
     {
         $this->analyse(

--- a/tests/Unit/RulesTest.php
+++ b/tests/Unit/RulesTest.php
@@ -61,6 +61,7 @@ use Haspadar\PHPStanRules\Rules\WeightedMethodsPerClassRule;
 use Haspadar\PHPStanRules\Rules\AfferentCouplingRule;
 use Haspadar\PHPStanRules\Rules\InheritanceDepthRule;
 use Haspadar\PHPStanRules\Rules\InstabilityRule;
+use Haspadar\PHPStanRules\Rules\PhpDocParamOrderRule;
 use Haspadar\PHPStanRules\Rules\LackOfCohesionRule;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -104,6 +105,7 @@ final class RulesTest extends TestCase
                 PhpDocMissingPropertyRule::class,
                 PhpDocMissingParamRule::class,
                 PhpDocParamDescriptionRule::class,
+                PhpDocParamOrderRule::class,
                 ReturnDescriptionCapitalRule::class,
                 ParamDescriptionCapitalRule::class,
                 NoPhpDocForOverriddenRule::class,


### PR DESCRIPTION
- Added PhpDocParamOrderRule (identifier haspadar.phpdocParamOrder) that flags @param tags whose order differs from the method signature
- Registered the rule with checkPublicOnly=true and skipOverridden=true defaults, mirroring sibling PHPDoc rules
- Added fixtures and tests covering correct order / wrong order / three-swapped / subset-in-order / subset-wrong-order / no-phpdoc / private / overridden / variadic / promoted / suppressed cases
- Documented the rule in README

Closes #152