### PR TITLE
Add NoNullAssignmentRule to forbid null literal assignments

### DIFF
--- a/.piqule.yaml
+++ b/.piqule.yaml
@@ -10,6 +10,7 @@ override:
     phpmetrics.complexity.max_cyclomatic_per_method: [12]
     phpmetrics.structure.max_methods_per_class: [11]
     phpmd.cyclomatic: [12]
+    shellcheck.ignore_dirs: ["vendor", "tests", ".git", ".claude"]
     sonar.organization: haspadar-org
     sonar.projectKey: haspadar_phpstan-rules
     sonar.exclusions: ["tests/**"]

--- a/.piqule.yaml
+++ b/.piqule.yaml
@@ -11,6 +11,7 @@ override:
     phpmetrics.structure.max_methods_per_class: [11]
     phpmd.cyclomatic: [12]
     shellcheck.ignore_dirs: ["vendor", "tests", ".git", ".claude"]
+    yamllint.ignore: ["vendor/**", "tests/**", ".git/**", ".piqule/**/html/**", ".piqule/**/coverage-report/**", ".piqule/config.yaml", ".claude/**"]
     sonar.organization: haspadar-org
     sonar.projectKey: haspadar_phpstan-rules
     sonar.exclusions: ["tests/**"]

--- a/.piqule/shellcheck/command.sh
+++ b/.piqule/shellcheck/command.sh
@@ -25,6 +25,7 @@ done < <(
     ! -path "./vendor/*" \
     ! -path "./tests/*" \
     ! -path "./.git/*" \
+    ! -path "./.claude/*" \
     -print0
 )
 

--- a/.piqule/yamllint/.yamllint.yml
+++ b/.piqule/yamllint/.yamllint.yml
@@ -6,6 +6,8 @@ ignore: |
   .git/**
   .piqule/**/html/**
   .piqule/**/coverage-report/**
+  .piqule/config.yaml
+  .claude/**
 
 rules:
   document-start: disable

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@
 | `KeepInterfacesShortRule`        | Interfaces must not declare too many methods (default: 10)                         |
 | `NeverAcceptNullArgumentsRule`   | Method and standalone function parameters must not be nullable                     |
 | `NeverReturnNullRule`            | Method and standalone function return types must not be nullable, `return null` is forbidden |
+| `NoNullAssignmentRule`           | Plain assignments of the `null` literal (variable, property, array element) are forbidden |
 | `NeverUsePublicConstantsRule`    | Class constants must not be public (explicitly or implicitly)                      |
 
 ### Error-prone patterns

--- a/rules.neon
+++ b/rules.neon
@@ -576,6 +576,10 @@ services:
         tags:
             - phpstan.rules.rule
     -
+        class: Haspadar\PHPStanRules\Rules\NoNullAssignmentRule
+        tags:
+            - phpstan.rules.rule
+    -
         class: Haspadar\PHPStanRules\Rules\NeverUsePublicConstantsRule
         tags:
             - phpstan.rules.rule

--- a/src/Rules.php
+++ b/src/Rules.php
@@ -62,6 +62,7 @@ final class Rules
         Rules\KeepInterfacesShortRule::class,
         Rules\NeverAcceptNullArgumentsRule::class,
         Rules\NeverReturnNullRule::class,
+        Rules\NoNullAssignmentRule::class,
         Rules\NeverUsePublicConstantsRule::class,
         Rules\WeightedMethodsPerClassRule::class,
         Rules\AfferentCouplingRule::class,

--- a/src/Rules/NoNullAssignmentRule.php
+++ b/src/Rules/NoNullAssignmentRule.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Rules;
+
+use Override;
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\ArrayDimFetch;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\ConstFetch;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\StaticPropertyFetch;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\ShouldNotHappenException;
+
+/**
+ * Reports plain assignments of the `null` literal to variables, properties, and array elements.
+ * Follows psalm-eo-rules `NoNullChecker`: `null` represents absence and breaks object integrity;
+ * absence must be modelled explicitly through a Null Object, Optional, or a sensible default
+ * value. Coalesce-assign `$x ??= null` is not flagged because it is represented by a different
+ * AST node (`AssignOp\Coalesce`) and the rule subscribes only to `Assign`. Property defaults
+ * `public ?Type $x = null` and nullable parameter declarations are declarations, not runtime
+ * assignments, and fall under NoNullablePropertyRule and NeverAcceptNullArgumentsRule.
+ *
+ * @implements Rule<Assign>
+ */
+final readonly class NoNullAssignmentRule implements Rule
+{
+    #[Override]
+    public function getNodeType(): string
+    {
+        return Assign::class;
+    }
+
+    /**
+     * Reports an error when the right-hand side is the `null` literal.
+     *
+     * @psalm-param Assign $node
+     * @throws ShouldNotHappenException
+     * @return list<IdentifierRuleError>
+     */
+    #[Override]
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!$this->isNullLiteral($node->expr)) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message(
+                sprintf(
+                    'Assignment of null to %s is prohibited. Model absence explicitly (Null Object, Optional).',
+                    $this->targetDescription($node->var),
+                ),
+            )
+                ->identifier('haspadar.noNullAssignment')
+                ->build(),
+        ];
+    }
+
+    /**
+     * Returns true when the expression is the constant `null` (case-insensitive).
+     */
+    private function isNullLiteral(Expr $expr): bool
+    {
+        return $expr instanceof ConstFetch
+            && $expr->name->toLowerString() === 'null';
+    }
+
+    /**
+     * Produces a short human-readable label for the assignment target used in the error message.
+     */
+    private function targetDescription(Expr $target): string
+    {
+        if ($target instanceof Variable && is_string($target->name)) {
+            return sprintf('$%s', $target->name);
+        }
+
+        if ($target instanceof PropertyFetch && $target->name instanceof Identifier) {
+            return sprintf('$this->%s', $target->name->toString());
+        }
+
+        if ($target instanceof StaticPropertyFetch
+            && $target->class instanceof Name
+            && $target->name instanceof Identifier
+        ) {
+            return sprintf('%s::$%s', $target->class->toString(), $target->name->toString());
+        }
+
+        if ($target instanceof ArrayDimFetch) {
+            return 'array element';
+        }
+
+        return 'target';
+    }
+}

--- a/src/Rules/NoNullAssignmentRule.php
+++ b/src/Rules/NoNullAssignmentRule.php
@@ -85,7 +85,13 @@ final readonly class NoNullAssignmentRule implements Rule
         }
 
         if ($target instanceof PropertyFetch && $target->name instanceof Identifier) {
-            return sprintf('$this->%s', $target->name->toString());
+            $property = $target->name->toString();
+
+            if ($target->var instanceof Variable && is_string($target->var->name)) {
+                return sprintf('$%s->%s', $target->var->name, $property);
+            }
+
+            return sprintf('property $%s', $property);
         }
 
         if ($target instanceof StaticPropertyFetch

--- a/tests/Fixtures/Rules/NoNullAssignmentRule/ClassWithCoalesceAssignment.php
+++ b/tests/Fixtures/Rules/NoNullAssignmentRule/ClassWithCoalesceAssignment.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullAssignmentRule;
+
+final class ClassWithCoalesceAssignment
+{
+    /**
+     * @param array<string, int> $input
+     */
+    public function pickFirst(array $input): int
+    {
+        $result = $input['first'] ?? 0;
+        return $result;
+    }
+}

--- a/tests/Fixtures/Rules/NoNullAssignmentRule/ClassWithCoalesceAssignment.php
+++ b/tests/Fixtures/Rules/NoNullAssignmentRule/ClassWithCoalesceAssignment.php
@@ -7,11 +7,11 @@ namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullAssignmentRule;
 final class ClassWithCoalesceAssignment
 {
     /**
-     * @param array<string, int> $input
+     * @param array<string, int|null> $input
      */
-    public function pickFirst(array $input): int
+    public function normalise(array $input): int
     {
-        $result = $input['first'] ?? 0;
-        return $result;
+        $input['first'] ??= null;
+        return $input['first'] ?? 0;
     }
 }

--- a/tests/Fixtures/Rules/NoNullAssignmentRule/ClassWithMultipleNullAssignments.php
+++ b/tests/Fixtures/Rules/NoNullAssignmentRule/ClassWithMultipleNullAssignments.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullAssignmentRule;
+
+final class ClassWithMultipleNullAssignments
+{
+    /** @var array<string, mixed> */
+    private array $data = [];
+
+    public function reset(): void
+    {
+        $first = null;
+        $this->data = null;
+        $this->data['key'] = null;
+    }
+}

--- a/tests/Fixtures/Rules/NoNullAssignmentRule/ClassWithNullAssignmentToArrayElement.php
+++ b/tests/Fixtures/Rules/NoNullAssignmentRule/ClassWithNullAssignmentToArrayElement.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullAssignmentRule;
+
+final class ClassWithNullAssignmentToArrayElement
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function build(): array
+    {
+        $result = [];
+        $result['cached'] = null;
+        return $result;
+    }
+}

--- a/tests/Fixtures/Rules/NoNullAssignmentRule/ClassWithNullAssignmentToForeignProperty.php
+++ b/tests/Fixtures/Rules/NoNullAssignmentRule/ClassWithNullAssignmentToForeignProperty.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullAssignmentRule;
+
+final class ForeignTargetForNullAssignment
+{
+    public string $cache = '';
+}
+
+final class ClassWithNullAssignmentToForeignProperty
+{
+    public function reset(ForeignTargetForNullAssignment $service): void
+    {
+        $service->cache = null;
+    }
+}

--- a/tests/Fixtures/Rules/NoNullAssignmentRule/ClassWithNullAssignmentToProperty.php
+++ b/tests/Fixtures/Rules/NoNullAssignmentRule/ClassWithNullAssignmentToProperty.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullAssignmentRule;
+
+final class ClassWithNullAssignmentToProperty
+{
+    private string $cache = '';
+
+    public function reset(): void
+    {
+        $this->cache = null;
+    }
+}

--- a/tests/Fixtures/Rules/NoNullAssignmentRule/ClassWithNullAssignmentToStaticProperty.php
+++ b/tests/Fixtures/Rules/NoNullAssignmentRule/ClassWithNullAssignmentToStaticProperty.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullAssignmentRule;
+
+final class ClassWithNullAssignmentToStaticProperty
+{
+    public static ?string $cache = '';
+
+    public function reset(): void
+    {
+        self::$cache = null;
+    }
+}

--- a/tests/Fixtures/Rules/NoNullAssignmentRule/ClassWithNullAssignmentToVariable.php
+++ b/tests/Fixtures/Rules/NoNullAssignmentRule/ClassWithNullAssignmentToVariable.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullAssignmentRule;
+
+final class ClassWithNullAssignmentToVariable
+{
+    public function demo(): void
+    {
+        $value = null;
+    }
+}

--- a/tests/Fixtures/Rules/NoNullAssignmentRule/ClassWithNullableParameter.php
+++ b/tests/Fixtures/Rules/NoNullAssignmentRule/ClassWithNullableParameter.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullAssignmentRule;
+
+final class ClassWithNullableParameter
+{
+    public function greet(?string $name = null): string
+    {
+        return 'hello ' . ($name ?? 'world');
+    }
+}

--- a/tests/Fixtures/Rules/NoNullAssignmentRule/ClassWithNullablePropertyDefault.php
+++ b/tests/Fixtures/Rules/NoNullAssignmentRule/ClassWithNullablePropertyDefault.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullAssignmentRule;
+
+final class ClassWithNullablePropertyDefault
+{
+    private ?string $cache = null;
+
+    public function value(): string
+    {
+        return $this->cache ?? '';
+    }
+}

--- a/tests/Fixtures/Rules/NoNullAssignmentRule/ClassWithoutNullAssignment.php
+++ b/tests/Fixtures/Rules/NoNullAssignmentRule/ClassWithoutNullAssignment.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullAssignmentRule;
+
+final class ClassWithoutNullAssignment
+{
+    public function demo(): int
+    {
+        $value = 42;
+        return $value;
+    }
+}

--- a/tests/Fixtures/Rules/NoNullAssignmentRule/SuppressedNullAssignment.php
+++ b/tests/Fixtures/Rules/NoNullAssignmentRule/SuppressedNullAssignment.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullAssignmentRule;
+
+final class SuppressedNullAssignment
+{
+    public function demo(): void
+    {
+        /** @phpstan-ignore haspadar.noNullAssignment */
+        $legacyCompat = null;
+    }
+}

--- a/tests/Unit/Rules/NoNullAssignmentRule/NoNullAssignmentRuleTest.php
+++ b/tests/Unit/Rules/NoNullAssignmentRule/NoNullAssignmentRuleTest.php
@@ -44,6 +44,18 @@ final class NoNullAssignmentRuleTest extends RuleTestCase
     }
 
     #[Test]
+    public function reportsNullAssignmentToStaticProperty(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NoNullAssignmentRule/ClassWithNullAssignmentToStaticProperty.php'],
+            [
+                ['Assignment of null to self::$cache is prohibited. Model absence explicitly (Null Object, Optional).', 13],
+            ],
+            'A null literal assigned to a static property must be reported as Class::$name',
+        );
+    }
+
+    #[Test]
     public function reportsNullAssignmentToArrayElement(): void
     {
         $this->analyse(

--- a/tests/Unit/Rules/NoNullAssignmentRule/NoNullAssignmentRuleTest.php
+++ b/tests/Unit/Rules/NoNullAssignmentRule/NoNullAssignmentRuleTest.php
@@ -112,6 +112,28 @@ final class NoNullAssignmentRuleTest extends RuleTestCase
     }
 
     #[Test]
+    public function reportsNullAssignmentToForeignProperty(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NoNullAssignmentRule/ClassWithNullAssignmentToForeignProperty.php'],
+            [
+                ['Assignment of null to $service->cache is prohibited. Model absence explicitly (Null Object, Optional).', 16],
+            ],
+            'The error message must include the actual object variable, not a hard-coded $this',
+        );
+    }
+
+    #[Test]
+    public function passesWhenNullAppearsOnlyInNullablePropertyDefault(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NoNullAssignmentRule/ClassWithNullablePropertyDefault.php'],
+            [],
+            'Nullable property defaults are declarations, not runtime assignments, and must not be flagged',
+        );
+    }
+
+    #[Test]
     public function passesWhenErrorIsSuppressed(): void
     {
         $this->analyse(

--- a/tests/Unit/Rules/NoNullAssignmentRule/NoNullAssignmentRuleTest.php
+++ b/tests/Unit/Rules/NoNullAssignmentRule/NoNullAssignmentRuleTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\NoNullAssignmentRule;
+
+use Haspadar\PHPStanRules\Rules\NoNullAssignmentRule;
+use Override;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<NoNullAssignmentRule> */
+final class NoNullAssignmentRuleTest extends RuleTestCase
+{
+    #[Override]
+    protected function getRule(): Rule
+    {
+        return new NoNullAssignmentRule();
+    }
+
+    #[Test]
+    public function reportsNullAssignmentToVariable(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NoNullAssignmentRule/ClassWithNullAssignmentToVariable.php'],
+            [
+                ['Assignment of null to $value is prohibited. Model absence explicitly (Null Object, Optional).', 11],
+            ],
+            'A null literal assigned to a local variable must be reported',
+        );
+    }
+
+    #[Test]
+    public function reportsNullAssignmentToProperty(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NoNullAssignmentRule/ClassWithNullAssignmentToProperty.php'],
+            [
+                ['Assignment of null to $this->cache is prohibited. Model absence explicitly (Null Object, Optional).', 13],
+            ],
+            'A null literal assigned to a property must be reported with the property name',
+        );
+    }
+
+    #[Test]
+    public function reportsNullAssignmentToArrayElement(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NoNullAssignmentRule/ClassWithNullAssignmentToArrayElement.php'],
+            [
+                ['Assignment of null to array element is prohibited. Model absence explicitly (Null Object, Optional).', 15],
+            ],
+            'A null literal assigned to an array element must be reported',
+        );
+    }
+
+    #[Test]
+    public function reportsEveryNullAssignmentInTheSameMethod(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NoNullAssignmentRule/ClassWithMultipleNullAssignments.php'],
+            [
+                ['Assignment of null to $first is prohibited. Model absence explicitly (Null Object, Optional).', 14],
+                ['Assignment of null to $this->data is prohibited. Model absence explicitly (Null Object, Optional).', 15],
+                ['Assignment of null to array element is prohibited. Model absence explicitly (Null Object, Optional).', 16],
+            ],
+            'Each null assignment must produce its own error with the target described',
+        );
+    }
+
+    #[Test]
+    public function passesWhenAssignedValueIsNotNull(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NoNullAssignmentRule/ClassWithoutNullAssignment.php'],
+            [],
+            'Assignments of non-null values must never produce an error',
+        );
+    }
+
+    #[Test]
+    public function passesWhenNullAppearsOnlyInNullableDefault(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NoNullAssignmentRule/ClassWithNullableParameter.php'],
+            [],
+            'Nullable parameter defaults are declarations, not runtime assignments, and must not be flagged',
+        );
+    }
+
+    #[Test]
+    public function passesWhenNullAppearsOnlyInCoalesceOperand(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NoNullAssignmentRule/ClassWithCoalesceAssignment.php'],
+            [],
+            'Coalescing expressions on the right-hand side without a null literal must not be flagged',
+        );
+    }
+
+    #[Test]
+    public function passesWhenErrorIsSuppressed(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NoNullAssignmentRule/SuppressedNullAssignment.php'],
+            [],
+            'A @phpstan-ignore haspadar.noNullAssignment comment must silence the error',
+        );
+    }
+}

--- a/tests/Unit/RulesTest.php
+++ b/tests/Unit/RulesTest.php
@@ -57,6 +57,7 @@ use Haspadar\PHPStanRules\Rules\KeepInterfacesShortRule;
 use Haspadar\PHPStanRules\Rules\NeverAcceptNullArgumentsRule;
 use Haspadar\PHPStanRules\Rules\NeverReturnNullRule;
 use Haspadar\PHPStanRules\Rules\NeverUsePublicConstantsRule;
+use Haspadar\PHPStanRules\Rules\NoNullAssignmentRule;
 use Haspadar\PHPStanRules\Rules\WeightedMethodsPerClassRule;
 use Haspadar\PHPStanRules\Rules\AfferentCouplingRule;
 use Haspadar\PHPStanRules\Rules\InheritanceDepthRule;
@@ -125,6 +126,7 @@ final class RulesTest extends TestCase
                 KeepInterfacesShortRule::class,
                 NeverAcceptNullArgumentsRule::class,
                 NeverReturnNullRule::class,
+                NoNullAssignmentRule::class,
                 NeverUsePublicConstantsRule::class,
                 WeightedMethodsPerClassRule::class,
                 AfferentCouplingRule::class,


### PR DESCRIPTION
- Added NoNullAssignmentRule (identifier haspadar.noNullAssignment) that flags plain assignments of the null literal to variables, properties, static properties, and array elements
- Registered the rule as an on/off service (no options) in rules.neon
- Added fixtures and tests covering null→variable, null→property, null→static-property, null→array-element, multiple assignments, nullable parameter default (passes), coalesce operator (passes), and error suppression
- Documented the rule in README
- Excluded .claude/worktrees and generated .piqule/config.yaml from shellcheck and yamllint so parallel git worktrees do not break the pre-push hook

Closes #154

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added NoNullAssignmentRule static analysis rule that identifies null assignments to variables, properties, and array elements.

* **Documentation**
  * Updated design rules documentation to include NoNullAssignmentRule reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->