### PR TITLE
For-Loop Header Parts Excluded From Inner Assignment Rule

### DIFF
--- a/src/Rules/InnerAssignmentRule.php
+++ b/src/Rules/InnerAssignmentRule.php
@@ -48,7 +48,7 @@ final readonly class InnerAssignmentRule implements Rule
     #[Override]
     public function processNode(Node $node, Scope $scope): array
     {
-        $loopCondAssigns = $this->collectLoopConditionAssigns($node);
+        $loopHeaderAssigns = $this->collectLoopHeaderAssigns($node);
 
         $errors = [];
 
@@ -65,7 +65,7 @@ final readonly class InnerAssignmentRule implements Rule
                 continue;
             }
 
-            if (in_array($assign, $loopCondAssigns, true)) {
+            if (in_array($assign, $loopHeaderAssigns, true)) {
                 continue;
             }
 
@@ -106,7 +106,7 @@ final readonly class InnerAssignmentRule implements Rule
      *
      * @return list<Assign|AssignOp|AssignRef>
      */
-    private function collectLoopConditionAssigns(ClassMethod $method): array
+    private function collectLoopHeaderAssigns(ClassMethod $method): array
     {
         $result = [];
 

--- a/src/Rules/InnerAssignmentRule.php
+++ b/src/Rules/InnerAssignmentRule.php
@@ -24,8 +24,9 @@ use PHPStan\ShouldNotHappenException;
 /**
  * Detects assignments used as subexpressions rather than standalone statements.
  * Reports any Assign, AssignOp, or AssignRef node that is not a direct child of
- * an Expression statement. Loop idioms in while/do-while/for conditions are
- * excluded because the pattern is conventional and unambiguous.
+ * an Expression statement. Loop idioms in while/do-while conditions and in all
+ * three `for` header expressions (init, cond, loop) are excluded because the
+ * pattern is conventional and unambiguous.
  *
  * @implements Rule<ClassMethod>
  */
@@ -99,8 +100,9 @@ final readonly class InnerAssignmentRule implements Rule
     }
 
     /**
-     * Collects all assignment nodes that appear in loop conditions (while, do-while, for).
-     * These are conventional idioms and are excluded from the rule.
+     * Collects all assignment nodes that appear in loop headers (while, do-while, for).
+     * For `for` loops this includes init, cond, and loop expressions — all three parts
+     * are conventional idioms and are excluded from the rule.
      *
      * @return list<Assign|AssignOp|AssignRef>
      */
@@ -120,7 +122,7 @@ final readonly class InnerAssignmentRule implements Rule
             $condNodes = match (true) {
                 $loop instanceof While_ => [$loop->cond],
                 $loop instanceof Do_ => [$loop->cond],
-                $loop instanceof For_ => $loop->cond,
+                $loop instanceof For_ => array_merge($loop->init, $loop->cond, $loop->loop),
             };
 
             foreach ($condNodes as $cond) {

--- a/tests/Fixtures/Rules/InnerAssignmentRule/ClassWithAssignInForBody.php
+++ b/tests/Fixtures/Rules/InnerAssignmentRule/ClassWithAssignInForBody.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\InnerAssignmentRule;
+
+final class ClassWithAssignInForBody
+{
+    /** @param resource $handle */
+    public function readLines(mixed $handle): string
+    {
+        $output = '';
+
+        for ($i = 0; $i < 10; $i++) {
+            if (($line = fgets($handle)) !== false) {
+                $output .= $line;
+            }
+        }
+
+        return $output;
+    }
+}

--- a/tests/Fixtures/Rules/InnerAssignmentRule/ClassWithForLoopIdiom.php
+++ b/tests/Fixtures/Rules/InnerAssignmentRule/ClassWithForLoopIdiom.php
@@ -17,4 +17,49 @@ final class ClassWithForLoopIdiom
 
         return $output;
     }
+
+    public function classicInitAndUpdate(): int
+    {
+        $total = 0;
+
+        for ($i = 0; $i < 10; $i++) {
+            $total += $i;
+        }
+
+        return $total;
+    }
+
+    public function multipleInitExpressions(): int
+    {
+        $sum = 0;
+
+        for ($i = 0, $j = 10; $i < $j; $i++) {
+            $sum += $i;
+        }
+
+        return $sum;
+    }
+
+    public function assignOpInUpdate(): int
+    {
+        $sum = 0;
+
+        for ($i = 10; $i > 0; $i -= 1) {
+            $sum += $i;
+        }
+
+        return $sum;
+    }
+
+    /** @param resource $handle */
+    public function combinedInitCondUpdate(mixed $handle): string
+    {
+        $output = '';
+
+        for ($i = 0; ($line = fgets($handle)) !== false; $i += 1) {
+            $output .= $i . $line;
+        }
+
+        return $output;
+    }
 }

--- a/tests/Unit/Rules/InnerAssignmentRule/InnerAssignmentRuleTest.php
+++ b/tests/Unit/Rules/InnerAssignmentRule/InnerAssignmentRuleTest.php
@@ -71,6 +71,17 @@ final class InnerAssignmentRuleTest extends RuleTestCase
     }
 
     #[Test]
+    public function reportsErrorWhenAssignInForBody(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/InnerAssignmentRule/ClassWithAssignInForBody.php'],
+            [
+                ['Inner assignment found. Assignments must not be used as subexpressions.', 15],
+            ],
+        );
+    }
+
+    #[Test]
     public function suppressesErrorWhenPhpstanIgnorePresent(): void
     {
         $this->analyse(


### PR DESCRIPTION
- Fixed false positive on for-loop init and update expressions by whitelisting all three header parts
- Added fixtures covering classic, multi-init, AssignOp update, and combined for idioms
- Added regression test for assignments inside for body
- Refactored header-collector to reflect full scope, not just condition

Closes #155

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The InnerAssignmentRule now correctly recognizes assignments within for-loop headers (init, condition, and update expressions) as conventional idioms and excludes them from violation reporting.

* **Tests**
  * Added test coverage for assignment patterns in for-loop contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->