### PR TITLE
Nullable Property Types Are Forbidden

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@
 | `NeverAcceptNullArgumentsRule`   | Method and standalone function parameters must not be nullable                     |
 | `NeverReturnNullRule`            | Method and standalone function return types must not be nullable, `return null` is forbidden |
 | `NoNullAssignmentRule`           | Plain assignments of the `null` literal (variable, property, array element) are forbidden |
-| `NoNullablePropertyRule`         | Class property types must not be nullable (`?Type`, `Type\|null`)                  |
+| `NoNullablePropertyRule`         | Class property types must not be nullable (`?Type`, `Type\|null`, `null\|Type`, `null`) |
 | `NeverUsePublicConstantsRule`    | Class constants must not be public (explicitly or implicitly)                      |
 
 ### Error-prone patterns

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@
 | `NeverAcceptNullArgumentsRule`   | Method and standalone function parameters must not be nullable                     |
 | `NeverReturnNullRule`            | Method and standalone function return types must not be nullable, `return null` is forbidden |
 | `NoNullAssignmentRule`           | Plain assignments of the `null` literal (variable, property, array element) are forbidden |
+| `NoNullablePropertyRule`         | Class property types must not be nullable (`?Type`, `Type\|null`)                  |
 | `NeverUsePublicConstantsRule`    | Class constants must not be public (explicitly or implicitly)                      |
 
 ### Error-prone patterns

--- a/rules.neon
+++ b/rules.neon
@@ -580,6 +580,10 @@ services:
         tags:
             - phpstan.rules.rule
     -
+        class: Haspadar\PHPStanRules\Rules\NoNullablePropertyRule
+        tags:
+            - phpstan.rules.rule
+    -
         class: Haspadar\PHPStanRules\Rules\NeverUsePublicConstantsRule
         tags:
             - phpstan.rules.rule

--- a/src/Rules.php
+++ b/src/Rules.php
@@ -63,6 +63,7 @@ final class Rules
         Rules\NeverAcceptNullArgumentsRule::class,
         Rules\NeverReturnNullRule::class,
         Rules\NoNullAssignmentRule::class,
+        Rules\NoNullablePropertyRule::class,
         Rules\NeverUsePublicConstantsRule::class,
         Rules\WeightedMethodsPerClassRule::class,
         Rules\AfferentCouplingRule::class,

--- a/src/Rules/NoNullablePropertyRule.php
+++ b/src/Rules/NoNullablePropertyRule.php
@@ -68,10 +68,14 @@ final readonly class NoNullablePropertyRule implements Rule
     }
 
     /**
-     * Returns true when the property type is nullable via `?Type` or a union containing null.
+     * Returns true when the property type is nullable — standalone `null`, `?Type`, or a union containing null.
      */
     private function hasNullableType(Property $node): bool
     {
+        if ($node->type instanceof Identifier && $node->type->toLowerString() === 'null') {
+            return true;
+        }
+
         if ($node->type instanceof NullableType) {
             return true;
         }

--- a/src/Rules/NoNullablePropertyRule.php
+++ b/src/Rules/NoNullablePropertyRule.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Rules;
+
+use Override;
+use PhpParser\Node;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\NullableType;
+use PhpParser\Node\PropertyItem;
+use PhpParser\Node\Stmt\Property;
+use PhpParser\Node\UnionType;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * Reports nullable types in class property declarations.
+ *
+ * Detects two patterns on the property native type:
+ * - `?Type` (NullableType)
+ * - `Type|null` / `null|Type` (UnionType containing null)
+ *
+ * Promoted constructor properties are out of scope — handled by NeverAcceptNullArgumentsRule.
+ *
+ * @implements Rule<Property>
+ */
+final readonly class NoNullablePropertyRule implements Rule
+{
+    #[Override]
+    public function getNodeType(): string
+    {
+        return Property::class;
+    }
+
+    /**
+     * Analyses the property node and returns one error per nullable declaration.
+     *
+     * @param Property $node
+     * @return list<IdentifierRuleError>
+     */
+    #[Override]
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!$this->hasNullableType($node)) {
+            return [];
+        }
+
+        $classLabel = $this->classLabel($scope);
+        $errors = [];
+
+        foreach ($node->props as $prop) {
+            $errors[] = RuleErrorBuilder::message(
+                sprintf(
+                    'Property $%s in %s must not be nullable.',
+                    $this->propertyName($prop),
+                    $classLabel,
+                ),
+            )
+                ->identifier('haspadar.noNullableProperty')
+                ->line($node->getStartLine())
+                ->build();
+        }
+
+        return $errors;
+    }
+
+    /**
+     * Returns true when the property type is nullable via `?Type` or a union containing null.
+     */
+    private function hasNullableType(Property $node): bool
+    {
+        if ($node->type instanceof NullableType) {
+            return true;
+        }
+
+        if ($node->type instanceof UnionType) {
+            foreach ($node->type->types as $type) {
+                if ($type instanceof Identifier && $type->toLowerString() === 'null') {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Extracts the property name as a string.
+     */
+    private function propertyName(PropertyItem $prop): string
+    {
+        return $prop->name->toString();
+    }
+
+    /**
+     * Returns a human-readable label for the enclosing class.
+     */
+    private function classLabel(Scope $scope): string
+    {
+        $classReflection = $scope->getClassReflection();
+
+        if ($classReflection === null) {
+            return 'anonymous class';
+        }
+
+        return sprintf('class %s', $classReflection->getName());
+    }
+}

--- a/src/Rules/NoNullablePropertyRule.php
+++ b/src/Rules/NoNullablePropertyRule.php
@@ -60,7 +60,7 @@ final readonly class NoNullablePropertyRule implements Rule
                 ),
             )
                 ->identifier('haspadar.noNullableProperty')
-                ->line($node->getStartLine())
+                ->line($prop->getStartLine())
                 ->build();
         }
 

--- a/tests/Fixtures/Rules/NoNullablePropertyRule/ClassWithGroupedNullableProperties.php
+++ b/tests/Fixtures/Rules/NoNullablePropertyRule/ClassWithGroupedNullableProperties.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullablePropertyRule;
+
+final class ClassWithGroupedNullableProperties
+{
+    public ?string
+        $first = '',
+        $second = '';
+}

--- a/tests/Fixtures/Rules/NoNullablePropertyRule/ClassWithIntersectionTypeProperty.php
+++ b/tests/Fixtures/Rules/NoNullablePropertyRule/ClassWithIntersectionTypeProperty.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullablePropertyRule;
+
+interface FirstInterface
+{
+}
+
+interface SecondInterface
+{
+}
+
+final class ClassWithIntersectionTypeProperty
+{
+    public FirstInterface&SecondInterface $dependency;
+
+    public function __construct(FirstInterface&SecondInterface $dependency)
+    {
+        $this->dependency = $dependency;
+    }
+}

--- a/tests/Fixtures/Rules/NoNullablePropertyRule/ClassWithMultipleNullableProperties.php
+++ b/tests/Fixtures/Rules/NoNullablePropertyRule/ClassWithMultipleNullableProperties.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullablePropertyRule;
+
+final class ClassWithMultipleNullableProperties
+{
+    public ?string $name = '';
+
+    protected int|null $age = 0;
+
+    private null|float $score = 0.0;
+}

--- a/tests/Fixtures/Rules/NoNullablePropertyRule/ClassWithNullablePropertyShortSyntax.php
+++ b/tests/Fixtures/Rules/NoNullablePropertyRule/ClassWithNullablePropertyShortSyntax.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullablePropertyRule;
+
+final class ClassWithNullablePropertyShortSyntax
+{
+    public ?string $name = '';
+}

--- a/tests/Fixtures/Rules/NoNullablePropertyRule/ClassWithNullablePropertyUnionReversed.php
+++ b/tests/Fixtures/Rules/NoNullablePropertyRule/ClassWithNullablePropertyUnionReversed.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullablePropertyRule;
+
+final class ClassWithNullablePropertyUnionReversed
+{
+    public null|string $name = '';
+}

--- a/tests/Fixtures/Rules/NoNullablePropertyRule/ClassWithNullablePropertyUnionSyntax.php
+++ b/tests/Fixtures/Rules/NoNullablePropertyRule/ClassWithNullablePropertyUnionSyntax.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullablePropertyRule;
+
+final class ClassWithNullablePropertyUnionSyntax
+{
+    public string|null $name = '';
+}

--- a/tests/Fixtures/Rules/NoNullablePropertyRule/ClassWithNullableReadonlyProperty.php
+++ b/tests/Fixtures/Rules/NoNullablePropertyRule/ClassWithNullableReadonlyProperty.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullablePropertyRule;
+
+final class ClassWithNullableReadonlyProperty
+{
+    public readonly ?int $age;
+
+    public function __construct()
+    {
+        $this->age = 0;
+    }
+}

--- a/tests/Fixtures/Rules/NoNullablePropertyRule/ClassWithNullableStaticProperty.php
+++ b/tests/Fixtures/Rules/NoNullablePropertyRule/ClassWithNullableStaticProperty.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullablePropertyRule;
+
+final class ClassWithNullableStaticProperty
+{
+    public static ?string $cache = '';
+}

--- a/tests/Fixtures/Rules/NoNullablePropertyRule/ClassWithPromotedNullableProperty.php
+++ b/tests/Fixtures/Rules/NoNullablePropertyRule/ClassWithPromotedNullableProperty.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullablePropertyRule;
+
+final class ClassWithPromotedNullableProperty
+{
+    public function __construct(
+        public ?string $name = '',
+    ) {
+    }
+}

--- a/tests/Fixtures/Rules/NoNullablePropertyRule/ClassWithStandaloneNullProperty.php
+++ b/tests/Fixtures/Rules/NoNullablePropertyRule/ClassWithStandaloneNullProperty.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullablePropertyRule;
+
+final class ClassWithStandaloneNullProperty
+{
+    public null $value = null;
+}

--- a/tests/Fixtures/Rules/NoNullablePropertyRule/ClassWithThreePartUnionContainingNull.php
+++ b/tests/Fixtures/Rules/NoNullablePropertyRule/ClassWithThreePartUnionContainingNull.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullablePropertyRule;
+
+final class ClassWithThreePartUnionContainingNull
+{
+    public string|null|int $value = '';
+}

--- a/tests/Fixtures/Rules/NoNullablePropertyRule/ClassWithoutNullableProperty.php
+++ b/tests/Fixtures/Rules/NoNullablePropertyRule/ClassWithoutNullableProperty.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullablePropertyRule;
+
+final class ClassWithoutNullableProperty
+{
+    public string $name = '';
+
+    private int $age = 0;
+}

--- a/tests/Fixtures/Rules/NoNullablePropertyRule/SuppressedNullableProperty.php
+++ b/tests/Fixtures/Rules/NoNullablePropertyRule/SuppressedNullableProperty.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullablePropertyRule;
+
+final class SuppressedNullableProperty
+{
+    /** @phpstan-ignore haspadar.noNullableProperty */
+    public ?string $name = '';
+}

--- a/tests/Unit/Rules/NoNullablePropertyRule/NoNullablePropertyRuleTest.php
+++ b/tests/Unit/Rules/NoNullablePropertyRule/NoNullablePropertyRuleTest.php
@@ -80,6 +80,19 @@ final class NoNullablePropertyRuleTest extends RuleTestCase
     }
 
     #[Test]
+    public function reportsEveryPropertyInGroupedDeclaration(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NoNullablePropertyRule/ClassWithGroupedNullableProperties.php'],
+            [
+                ['Property $first in class Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullablePropertyRule\ClassWithGroupedNullableProperties must not be nullable.', 10],
+                ['Property $second in class Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullablePropertyRule\ClassWithGroupedNullableProperties must not be nullable.', 11],
+            ],
+            'Each property in a grouped declaration must be reported on its own line',
+        );
+    }
+
+    #[Test]
     public function reportsEveryNullablePropertyInTheSameClass(): void
     {
         $this->analyse(

--- a/tests/Unit/Rules/NoNullablePropertyRule/NoNullablePropertyRuleTest.php
+++ b/tests/Unit/Rules/NoNullablePropertyRule/NoNullablePropertyRuleTest.php
@@ -93,6 +93,18 @@ final class NoNullablePropertyRuleTest extends RuleTestCase
     }
 
     #[Test]
+    public function reportsPropertyDeclaredAsStandaloneNull(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NoNullablePropertyRule/ClassWithStandaloneNullProperty.php'],
+            [
+                ['Property $value in class Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullablePropertyRule\ClassWithStandaloneNullProperty must not be nullable.', 9],
+            ],
+            'A property declared with the PHP 8.2 standalone null type must be reported',
+        );
+    }
+
+    #[Test]
     public function reportsNullableWhenNullAppearsInMiddleOfUnion(): void
     {
         $this->analyse(

--- a/tests/Unit/Rules/NoNullablePropertyRule/NoNullablePropertyRuleTest.php
+++ b/tests/Unit/Rules/NoNullablePropertyRule/NoNullablePropertyRuleTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\NoNullablePropertyRule;
+
+use Haspadar\PHPStanRules\Rules\NoNullablePropertyRule;
+use Override;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<NoNullablePropertyRule> */
+final class NoNullablePropertyRuleTest extends RuleTestCase
+{
+    #[Override]
+    protected function getRule(): Rule
+    {
+        return new NoNullablePropertyRule();
+    }
+
+    #[Test]
+    public function reportsNullablePropertyWithShortSyntax(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NoNullablePropertyRule/ClassWithNullablePropertyShortSyntax.php'],
+            [
+                ['Property $name in class Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullablePropertyRule\ClassWithNullablePropertyShortSyntax must not be nullable.', 9],
+            ],
+            'A property declared with the ?Type shorthand must be reported',
+        );
+    }
+
+    #[Test]
+    public function reportsNullablePropertyWithUnionSyntax(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NoNullablePropertyRule/ClassWithNullablePropertyUnionSyntax.php'],
+            [
+                ['Property $name in class Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullablePropertyRule\ClassWithNullablePropertyUnionSyntax must not be nullable.', 9],
+            ],
+            'A property declared as Type|null union must be reported',
+        );
+    }
+
+    #[Test]
+    public function reportsNullablePropertyWithReversedUnion(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NoNullablePropertyRule/ClassWithNullablePropertyUnionReversed.php'],
+            [
+                ['Property $name in class Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullablePropertyRule\ClassWithNullablePropertyUnionReversed must not be nullable.', 9],
+            ],
+            'A property declared as null|Type union must be reported regardless of null position',
+        );
+    }
+
+    #[Test]
+    public function reportsNullableReadonlyProperty(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NoNullablePropertyRule/ClassWithNullableReadonlyProperty.php'],
+            [
+                ['Property $age in class Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullablePropertyRule\ClassWithNullableReadonlyProperty must not be nullable.', 9],
+            ],
+            'Readonly modifier must not exempt a property from the nullable-type check',
+        );
+    }
+
+    #[Test]
+    public function reportsNullableStaticProperty(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NoNullablePropertyRule/ClassWithNullableStaticProperty.php'],
+            [
+                ['Property $cache in class Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullablePropertyRule\ClassWithNullableStaticProperty must not be nullable.', 9],
+            ],
+            'Static modifier must not exempt a property from the nullable-type check',
+        );
+    }
+
+    #[Test]
+    public function reportsEveryNullablePropertyInTheSameClass(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NoNullablePropertyRule/ClassWithMultipleNullableProperties.php'],
+            [
+                ['Property $name in class Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullablePropertyRule\ClassWithMultipleNullableProperties must not be nullable.', 9],
+                ['Property $age in class Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullablePropertyRule\ClassWithMultipleNullableProperties must not be nullable.', 11],
+                ['Property $score in class Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullablePropertyRule\ClassWithMultipleNullableProperties must not be nullable.', 13],
+            ],
+            'Each nullable property in the class must produce its own error',
+        );
+    }
+
+    #[Test]
+    public function passesWhenPropertyIsNotNullable(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NoNullablePropertyRule/ClassWithoutNullableProperty.php'],
+            [],
+            'Non-nullable properties must never produce an error',
+        );
+    }
+
+    #[Test]
+    public function passesWhenPropertyIsPromoted(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NoNullablePropertyRule/ClassWithPromotedNullableProperty.php'],
+            [],
+            'Promoted constructor properties are out of scope and must be handled by NeverAcceptNullArgumentsRule',
+        );
+    }
+
+    #[Test]
+    public function passesWhenErrorIsSuppressed(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NoNullablePropertyRule/SuppressedNullableProperty.php'],
+            [],
+            'A @phpstan-ignore haspadar.noNullableProperty comment must silence the error',
+        );
+    }
+}

--- a/tests/Unit/Rules/NoNullablePropertyRule/NoNullablePropertyRuleTest.php
+++ b/tests/Unit/Rules/NoNullablePropertyRule/NoNullablePropertyRuleTest.php
@@ -93,6 +93,28 @@ final class NoNullablePropertyRuleTest extends RuleTestCase
     }
 
     #[Test]
+    public function reportsNullableWhenNullAppearsInMiddleOfUnion(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NoNullablePropertyRule/ClassWithThreePartUnionContainingNull.php'],
+            [
+                ['Property $value in class Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullablePropertyRule\ClassWithThreePartUnionContainingNull must not be nullable.', 9],
+            ],
+            'A null at any position in a multi-part union must trigger the rule',
+        );
+    }
+
+    #[Test]
+    public function passesWhenPropertyHasIntersectionType(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NoNullablePropertyRule/ClassWithIntersectionTypeProperty.php'],
+            [],
+            'An intersection type A&B never contains null and must not be reported',
+        );
+    }
+
+    #[Test]
     public function reportsEveryNullablePropertyInTheSameClass(): void
     {
         $this->analyse(

--- a/tests/Unit/RulesTest.php
+++ b/tests/Unit/RulesTest.php
@@ -57,6 +57,7 @@ use Haspadar\PHPStanRules\Rules\KeepInterfacesShortRule;
 use Haspadar\PHPStanRules\Rules\NeverAcceptNullArgumentsRule;
 use Haspadar\PHPStanRules\Rules\NeverReturnNullRule;
 use Haspadar\PHPStanRules\Rules\NeverUsePublicConstantsRule;
+use Haspadar\PHPStanRules\Rules\NoNullablePropertyRule;
 use Haspadar\PHPStanRules\Rules\NoNullAssignmentRule;
 use Haspadar\PHPStanRules\Rules\WeightedMethodsPerClassRule;
 use Haspadar\PHPStanRules\Rules\AfferentCouplingRule;
@@ -127,6 +128,7 @@ final class RulesTest extends TestCase
                 NeverAcceptNullArgumentsRule::class,
                 NeverReturnNullRule::class,
                 NoNullAssignmentRule::class,
+                NoNullablePropertyRule::class,
                 NeverUsePublicConstantsRule::class,
                 WeightedMethodsPerClassRule::class,
                 AfferentCouplingRule::class,


### PR DESCRIPTION
- Added NoNullablePropertyRule to forbid `?Type` and `Type|null` in property declarations
- Registered the rule in Rules::all and services under identifier haspadar.noNullableProperty
- Added fixtures and unit tests covering short/union/reversed syntax, readonly, static, grouped, intersection, and suppression
- Updated README with an entry in the Design rules table

Closes #158

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new static analysis rule that identifies and reports nullable property declarations in classes. The rule detects various forms of nullable syntax across all property visibility levels and modifiers. Violations can be individually suppressed via annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->