### PR TITLE
Forbid Null Literals as Call Arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@
 | `NeverReturnNullRule`            | Method and standalone function return types must not be nullable, `return null` is forbidden |
 | `NoNullAssignmentRule`           | Plain assignments of the `null` literal (variable, property, array element) are forbidden |
 | `NoNullablePropertyRule`         | Class property types must not be nullable (`?Type`, `Type\|null`, `null\|Type`, `null`) |
+| `NoNullArgumentRule`             | Passing the `null` literal to user-defined functions, methods, or constructors is forbidden |
 | `NeverUsePublicConstantsRule`    | Class constants must not be public (explicitly or implicitly)                      |
 
 ### Error-prone patterns

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@
 | `NeverReturnNullRule`            | Method and standalone function return types must not be nullable, `return null` is forbidden |
 | `NoNullAssignmentRule`           | Plain assignments of the `null` literal (variable, property, array element) are forbidden |
 | `NoNullablePropertyRule`         | Class property types must not be nullable (`?Type`, `Type\|null`, `null\|Type`, `null`) |
-| `NoNullArgumentRule`             | Passing the `null` literal to user-defined functions, methods, or constructors is forbidden |
+| `NoNullArgumentRule`             | Passing the `null` literal to user-defined functions, methods (including static and nullsafe), or constructors is forbidden |
 | `NeverUsePublicConstantsRule`    | Class constants must not be public (explicitly or implicitly)                      |
 
 ### Error-prone patterns

--- a/rules.neon
+++ b/rules.neon
@@ -584,6 +584,12 @@ services:
         tags:
             - phpstan.rules.rule
     -
+        class: Haspadar\PHPStanRules\Rules\Internal\BuiltinCallDetector
+    -
+        class: Haspadar\PHPStanRules\Rules\NoNullArgumentRule
+        tags:
+            - phpstan.rules.rule
+    -
         class: Haspadar\PHPStanRules\Rules\NeverUsePublicConstantsRule
         tags:
             - phpstan.rules.rule

--- a/src/Rules.php
+++ b/src/Rules.php
@@ -64,6 +64,7 @@ final class Rules
         Rules\NeverReturnNullRule::class,
         Rules\NoNullAssignmentRule::class,
         Rules\NoNullablePropertyRule::class,
+        Rules\NoNullArgumentRule::class,
         Rules\NeverUsePublicConstantsRule::class,
         Rules\WeightedMethodsPerClassRule::class,
         Rules\AfferentCouplingRule::class,

--- a/src/Rules/Internal/BuiltinCallDetector.php
+++ b/src/Rules/Internal/BuiltinCallDetector.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Rules\Internal;
+
+use PhpParser\Node\Expr\CallLike;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Expr\NullsafeMethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ReflectionProvider;
+
+/**
+ * Detects whether a call expression targets a PHP built-in function, method, or class.
+ *
+ * Dynamic calls where the target cannot be resolved are reported as built-in so that
+ * rules using this detector skip vendor-sensitive code paths by default.
+ */
+final readonly class BuiltinCallDetector
+{
+    /**
+     * Accepts the PHPStan reflection provider used to resolve call targets.
+     *
+     * @param ReflectionProvider $reflectionProvider Shared PHPStan reflection used to resolve call targets
+     */
+    public function __construct(private ReflectionProvider $reflectionProvider) {}
+
+    /**
+     * Returns true when the call targets a PHP built-in function, method, or class.
+     *
+     * @param CallLike $node Call expression under analysis
+     * @param Scope $scope PHPStan scope providing type information for the call
+     */
+    public function isBuiltin(CallLike $node, Scope $scope): bool
+    {
+        if ($node instanceof FuncCall) {
+            return $this->isBuiltinFunction($node, $scope);
+        }
+
+        if ($node instanceof MethodCall || $node instanceof NullsafeMethodCall) {
+            return $this->isBuiltinMethod($node, $scope);
+        }
+
+        if ($node instanceof StaticCall) {
+            return $this->isBuiltinStatic($node, $scope);
+        }
+
+        if ($node instanceof New_) {
+            return $this->isBuiltinConstructor($node, $scope);
+        }
+
+        return true;
+    }
+
+    /**
+     * Resolves a function call and checks whether the target is a PHP built-in.
+     */
+    private function isBuiltinFunction(FuncCall $node, Scope $scope): bool
+    {
+        if (!$node->name instanceof Name) {
+            return true;
+        }
+
+        if (!$this->reflectionProvider->hasFunction($node->name, $scope)) {
+            return true;
+        }
+
+        return $this->reflectionProvider->getFunction($node->name, $scope)->isBuiltin();
+    }
+
+    /**
+     * Resolves an instance or nullsafe method call and checks whether it targets a PHP built-in.
+     */
+    private function isBuiltinMethod(MethodCall|NullsafeMethodCall $node, Scope $scope): bool
+    {
+        if (!$node->name instanceof Identifier) {
+            return true;
+        }
+
+        foreach ($scope->getType($node->var)->getObjectClassReflections() as $classReflection) {
+            if (!$classReflection->hasMethod($node->name->toString())) {
+                continue;
+            }
+
+            return $classReflection->getMethod($node->name->toString(), $scope)
+                ->getDeclaringClass()
+                ->isBuiltin();
+        }
+
+        return true;
+    }
+
+    /**
+     * Resolves a static method call and checks whether the declaring class is a PHP built-in.
+     */
+    private function isBuiltinStatic(StaticCall $node, Scope $scope): bool
+    {
+        if (!$node->class instanceof Name || !$node->name instanceof Identifier) {
+            return true;
+        }
+
+        $className = $scope->resolveName($node->class);
+
+        if (!$this->reflectionProvider->hasClass($className)) {
+            return true;
+        }
+
+        $classReflection = $this->reflectionProvider->getClass($className);
+
+        if (!$classReflection->hasMethod($node->name->toString())) {
+            return true;
+        }
+
+        return $classReflection->getMethod($node->name->toString(), $scope)
+            ->getDeclaringClass()
+            ->isBuiltin();
+    }
+
+    /**
+     * Resolves a constructor call and checks whether the instantiated class is a PHP built-in.
+     */
+    private function isBuiltinConstructor(New_ $node, Scope $scope): bool
+    {
+        if (!$node->class instanceof Name) {
+            return true;
+        }
+
+        $className = $scope->resolveName($node->class);
+
+        if (!$this->reflectionProvider->hasClass($className)) {
+            return true;
+        }
+
+        return $this->reflectionProvider->getClass($className)->isBuiltin();
+    }
+}

--- a/src/Rules/Internal/BuiltinCallDetector.php
+++ b/src/Rules/Internal/BuiltinCallDetector.php
@@ -12,6 +12,7 @@ use PhpParser\Node\Expr\NullsafeMethodCall;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\Class_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ReflectionProvider;
 
@@ -74,7 +75,10 @@ final readonly class BuiltinCallDetector
     }
 
     /**
-     * Resolves an instance or nullsafe method call and checks whether it targets a PHP built-in.
+     * Resolves an instance or nullsafe method call and checks whether every declaring class is a PHP built-in.
+     *
+     * For a union receiver where several classes declare the same method, any user-defined declaring
+     * class makes the call user-defined so that the rule still inspects its arguments.
      */
     private function isBuiltinMethod(MethodCall|NullsafeMethodCall $node, Scope $scope): bool
     {
@@ -82,17 +86,22 @@ final readonly class BuiltinCallDetector
             return true;
         }
 
+        $methodName = $node->name->toString();
+        $foundAny = false;
+
         foreach ($scope->getType($node->var)->getObjectClassReflections() as $classReflection) {
-            if (!$classReflection->hasMethod($node->name->toString())) {
+            if (!$classReflection->hasMethod($methodName)) {
                 continue;
             }
 
-            return $classReflection->getMethod($node->name->toString(), $scope)
-                ->getDeclaringClass()
-                ->isBuiltin();
+            $foundAny = true;
+
+            if (!$classReflection->getMethod($methodName, $scope)->getDeclaringClass()->isBuiltin()) {
+                return false;
+            }
         }
 
-        return true;
+        return !$foundAny;
     }
 
     /**
@@ -123,9 +132,16 @@ final readonly class BuiltinCallDetector
 
     /**
      * Resolves a constructor call and checks whether the instantiated class is a PHP built-in.
+     *
+     * Anonymous classes are always user-defined, so `new class(null) {}` is inspected by the rule.
+     * Dynamic `new` where the class is an arbitrary expression cannot be resolved and is treated as built-in.
      */
     private function isBuiltinConstructor(New_ $node, Scope $scope): bool
     {
+        if ($node->class instanceof Class_) {
+            return false;
+        }
+
         if (!$node->class instanceof Name) {
             return true;
         }

--- a/src/Rules/Internal/BuiltinCallDetector.php
+++ b/src/Rules/Internal/BuiltinCallDetector.php
@@ -87,21 +87,18 @@ final readonly class BuiltinCallDetector
         }
 
         $methodName = $node->name->toString();
-        $foundAny = false;
 
         foreach ($scope->getType($node->var)->getObjectClassReflections() as $classReflection) {
             if (!$classReflection->hasMethod($methodName)) {
                 continue;
             }
 
-            $foundAny = true;
-
             if (!$classReflection->getMethod($methodName, $scope)->getDeclaringClass()->isBuiltin()) {
                 return false;
             }
         }
 
-        return !$foundAny;
+        return true;
     }
 
     /**

--- a/src/Rules/NoNullArgumentRule.php
+++ b/src/Rules/NoNullArgumentRule.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Rules;
+
+use Haspadar\PHPStanRules\Rules\Internal\BuiltinCallDetector;
+use Override;
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\CallLike;
+use PhpParser\Node\Expr\ConstFetch;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Expr\NullsafeMethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\ShouldNotHappenException;
+
+/**
+ * Reports the `null` literal passed as an argument to user-defined function, method, or constructor calls.
+ * Follows psalm-eo-rules `NoNullChecker`: absence must be modelled explicitly through a Null Object,
+ * Optional, or a sensible default value. Internal PHP functions and methods are skipped via PHPStan
+ * reflection so that standard-library idioms (for example `str_replace` with null subject) keep working.
+ * Dynamic calls where the target cannot be resolved are skipped as well.
+ *
+ * @implements Rule<CallLike>
+ */
+final readonly class NoNullArgumentRule implements Rule
+{
+    /**
+     * Accepts the built-in call detector used to skip PHP-native targets.
+     *
+     * @param BuiltinCallDetector $builtinCallDetector Helper that recognises built-in call targets
+     */
+    public function __construct(private BuiltinCallDetector $builtinCallDetector) {}
+
+    #[Override]
+    public function getNodeType(): string
+    {
+        return CallLike::class;
+    }
+
+    /**
+     * Returns one error per null literal passed as an argument.
+     *
+     * @param CallLike $node
+     * @throws ShouldNotHappenException
+     * @return list<IdentifierRuleError>
+     */
+    #[Override]
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if ($this->isNullBranchOfNullsafeCall($node, $scope)) {
+            return [];
+        }
+
+        if ($this->builtinCallDetector->isBuiltin($node, $scope)) {
+            return [];
+        }
+
+        $label = $this->callLabel($node, $scope);
+        $errors = [];
+        $index = 0;
+
+        foreach ($node->getArgs() as $arg) {
+            if (!$this->isNullLiteral($arg)) {
+                $index++;
+
+                continue;
+            }
+
+            $errors[] = RuleErrorBuilder::message(
+                sprintf(
+                    'Passing null as argument %s to %s is prohibited. Model absence explicitly (Null Object, Optional).',
+                    $this->argumentLabel($arg, $index),
+                    $label,
+                ),
+            )
+                ->identifier('haspadar.noNullArgument')
+                ->line($arg->getStartLine())
+                ->build();
+
+            $index++;
+        }
+
+        return $errors;
+    }
+
+    /**
+     * Returns true when the argument value is the `null` constant.
+     */
+    private function isNullLiteral(Arg $arg): bool
+    {
+        return $arg->value instanceof ConstFetch
+            && $arg->value->name->toLowerString() === 'null';
+    }
+
+    /**
+     * Produces a quoted name for a named argument or a `#<index>` token for a positional one.
+     */
+    private function argumentLabel(Arg $arg, int $index): string
+    {
+        if ($arg->name instanceof Identifier) {
+            return sprintf('"%s"', $arg->name->toString());
+        }
+
+        return sprintf('#%d', $index);
+    }
+
+    /**
+     * PHPStan visits a nullsafe method call twice — once per scope branch (null and non-null).
+     * Only the first-level statement branch runs the method body, so analysing just that one
+     * avoids duplicate errors for the same argument.
+     */
+    private function isNullBranchOfNullsafeCall(CallLike $node, Scope $scope): bool
+    {
+        return $node instanceof NullsafeMethodCall && !$scope->isInFirstLevelStatement();
+    }
+
+    /**
+     * Builds a human-readable label for the call target such as `function X()`, `method C::m()`, or `constructor C`.
+     */
+    private function callLabel(CallLike $node, Scope $scope): string
+    {
+        if ($node instanceof FuncCall && $node->name instanceof Name) {
+            return sprintf('function %s()', $node->name->toString());
+        }
+
+        if (($node instanceof MethodCall || $node instanceof NullsafeMethodCall) && $node->name instanceof Identifier) {
+            return sprintf('method %s()', $node->name->toString());
+        }
+
+        if ($node instanceof StaticCall && $node->class instanceof Name && $node->name instanceof Identifier) {
+            return sprintf('method %s::%s()', $scope->resolveName($node->class), $node->name->toString());
+        }
+
+        if ($node instanceof New_ && $node->class instanceof Name) {
+            return sprintf('constructor %s', $scope->resolveName($node->class));
+        }
+
+        return 'call';
+    }
+}

--- a/src/Rules/NoNullArgumentRule.php
+++ b/src/Rules/NoNullArgumentRule.php
@@ -103,7 +103,7 @@ final readonly class NoNullArgumentRule implements Rule
     }
 
     /**
-     * Produces a quoted name for a named argument or a `#<index>` token for a positional one.
+     * Produces a quoted name for a named argument or a 1-based `#<position>` token for a positional one.
      */
     private function argumentLabel(Arg $arg, int $index): string
     {
@@ -111,7 +111,7 @@ final readonly class NoNullArgumentRule implements Rule
             return sprintf('"%s"', $arg->name->toString());
         }
 
-        return sprintf('#%d', $index);
+        return sprintf('#%d', $index + 1);
     }
 
     /**
@@ -134,7 +134,7 @@ final readonly class NoNullArgumentRule implements Rule
         }
 
         if (($node instanceof MethodCall || $node instanceof NullsafeMethodCall) && $node->name instanceof Identifier) {
-            return sprintf('method %s()', $node->name->toString());
+            return $this->methodCallLabel($node, $scope);
         }
 
         if ($node instanceof StaticCall && $node->class instanceof Name && $node->name instanceof Identifier) {
@@ -146,5 +146,22 @@ final readonly class NoNullArgumentRule implements Rule
         }
 
         return 'call';
+    }
+
+    /**
+     * Resolves the receiver type of an instance or nullsafe method call and builds a FQN-qualified label.
+     */
+    private function methodCallLabel(MethodCall|NullsafeMethodCall $node, Scope $scope): string
+    {
+        assert($node->name instanceof Identifier);
+
+        $methodName = $node->name->toString();
+        $classNames = $scope->getType($node->var)->getObjectClassNames();
+
+        if ($classNames === []) {
+            return sprintf('method %s()', $methodName);
+        }
+
+        return sprintf('method %s::%s()', $classNames[0], $methodName);
     }
 }

--- a/src/Rules/NoNullArgumentRule.php
+++ b/src/Rules/NoNullArgumentRule.php
@@ -174,6 +174,6 @@ final readonly class NoNullArgumentRule implements Rule
             return sprintf('method %s()', $methodName);
         }
 
-        return sprintf('method %s::%s()', $classNames[0], $methodName);
+        return sprintf('method %s::%s()', implode('|', $classNames), $methodName);
     }
 }

--- a/src/Rules/NoNullArgumentRule.php
+++ b/src/Rules/NoNullArgumentRule.php
@@ -17,6 +17,7 @@ use PhpParser\Node\Expr\NullsafeMethodCall;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\Class_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\Rule;
@@ -136,7 +137,23 @@ final readonly class NoNullArgumentRule implements Rule
             return sprintf('method %s::%s()', $scope->resolveName($node->class), $node->name->toString());
         }
 
-        if ($node instanceof New_ && $node->class instanceof Name) {
+        if ($node instanceof New_) {
+            return $this->constructorCallLabel($node, $scope);
+        }
+
+        return 'call';
+    }
+
+    /**
+     * Builds a label for `new Class(...)` or `new class {}` expressions.
+     */
+    private function constructorCallLabel(New_ $node, Scope $scope): string
+    {
+        if ($node->class instanceof Class_) {
+            return 'anonymous class constructor';
+        }
+
+        if ($node->class instanceof Name) {
             return sprintf('constructor %s', $scope->resolveName($node->class));
         }
 

--- a/src/Rules/NoNullArgumentRule.php
+++ b/src/Rules/NoNullArgumentRule.php
@@ -67,12 +67,9 @@ final readonly class NoNullArgumentRule implements Rule
 
         $label = $this->callLabel($node, $scope);
         $errors = [];
-        $index = 0;
 
-        foreach ($node->getArgs() as $arg) {
+        foreach (array_values($node->getArgs()) as $index => $arg) {
             if (!$this->isNullLiteral($arg)) {
-                $index++;
-
                 continue;
             }
 
@@ -86,8 +83,6 @@ final readonly class NoNullArgumentRule implements Rule
                 ->identifier('haspadar.noNullArgument')
                 ->line($arg->getStartLine())
                 ->build();
-
-            $index++;
         }
 
         return $errors;

--- a/tests/Fixtures/Rules/NoNullArgumentRule/ClassWithMultipleNullArguments.php
+++ b/tests/Fixtures/Rules/NoNullArgumentRule/ClassWithMultipleNullArguments.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullArgumentRule;
+
+function multiArgumentTarget(?string $a, ?int $b, ?float $c): string
+{
+    return sprintf('%s %d %.1f', $a ?? '', $b ?? 0, $c ?? 0.0);
+}
+
+final class ClassWithMultipleNullArguments
+{
+    public function run(): string
+    {
+        return multiArgumentTarget(null, null, null);
+    }
+}

--- a/tests/Fixtures/Rules/NoNullArgumentRule/ClassWithNamedNullArgument.php
+++ b/tests/Fixtures/Rules/NoNullArgumentRule/ClassWithNamedNullArgument.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullArgumentRule;
+
+function namedArgumentTarget(?string $name = null, ?int $age = null): string
+{
+    return sprintf('%s %d', $name ?? '', $age ?? 0);
+}
+
+final class ClassWithNamedNullArgument
+{
+    public function run(): string
+    {
+        return namedArgumentTarget(name: null);
+    }
+}

--- a/tests/Fixtures/Rules/NoNullArgumentRule/ClassWithNullArgumentInAnonymousClassConstructor.php
+++ b/tests/Fixtures/Rules/NoNullArgumentRule/ClassWithNullArgumentInAnonymousClassConstructor.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullArgumentRule;
+
+final class ClassWithNullArgumentInAnonymousClassConstructor
+{
+    public function run(): object
+    {
+        return new class (null) {
+            public function __construct(public ?string $value)
+            {
+            }
+        };
+    }
+}

--- a/tests/Fixtures/Rules/NoNullArgumentRule/ClassWithNullArgumentInConstructor.php
+++ b/tests/Fixtures/Rules/NoNullArgumentRule/ClassWithNullArgumentInConstructor.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullArgumentRule;
+
+final class ClassWithNullArgumentInConstructor
+{
+    public function run(): ConstructorTarget
+    {
+        return new ConstructorTarget(null);
+    }
+}

--- a/tests/Fixtures/Rules/NoNullArgumentRule/ClassWithNullArgumentInFunctionCall.php
+++ b/tests/Fixtures/Rules/NoNullArgumentRule/ClassWithNullArgumentInFunctionCall.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullArgumentRule;
+
+function userDefinedGreet(?string $name): string
+{
+    return $name ?? 'unknown';
+}
+
+final class ClassWithNullArgumentInFunctionCall
+{
+    public function run(): string
+    {
+        return userDefinedGreet(null);
+    }
+}

--- a/tests/Fixtures/Rules/NoNullArgumentRule/ClassWithNullArgumentInInternalCall.php
+++ b/tests/Fixtures/Rules/NoNullArgumentRule/ClassWithNullArgumentInInternalCall.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullArgumentRule;
+
+final class ClassWithNullArgumentInInternalCall
+{
+    public function run(): string
+    {
+        return str_replace('a', 'b', 'banana', null);
+    }
+}

--- a/tests/Fixtures/Rules/NoNullArgumentRule/ClassWithNullArgumentInInternalMethodCall.php
+++ b/tests/Fixtures/Rules/NoNullArgumentRule/ClassWithNullArgumentInInternalMethodCall.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullArgumentRule;
+
+use ArrayObject;
+
+final class ClassWithNullArgumentInInternalMethodCall
+{
+    public function run(): void
+    {
+        $container = new ArrayObject(['x']);
+        $container->offsetSet(null, 'v');
+    }
+}

--- a/tests/Fixtures/Rules/NoNullArgumentRule/ClassWithNullArgumentInMethodCall.php
+++ b/tests/Fixtures/Rules/NoNullArgumentRule/ClassWithNullArgumentInMethodCall.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullArgumentRule;
+
+final class ClassWithNullArgumentInMethodCall
+{
+    public function run(MethodCallTarget $target): string
+    {
+        return $target->accept(null);
+    }
+}

--- a/tests/Fixtures/Rules/NoNullArgumentRule/ClassWithNullArgumentInNullsafeMethodCall.php
+++ b/tests/Fixtures/Rules/NoNullArgumentRule/ClassWithNullArgumentInNullsafeMethodCall.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullArgumentRule;
+
+final class ClassWithNullArgumentInNullsafeMethodCall
+{
+    public function run(NullsafeMethodCallTarget $target): string
+    {
+        return $target?->accept(null);
+    }
+}

--- a/tests/Fixtures/Rules/NoNullArgumentRule/ClassWithNullArgumentInNullsafeMethodCall.php
+++ b/tests/Fixtures/Rules/NoNullArgumentRule/ClassWithNullArgumentInNullsafeMethodCall.php
@@ -6,7 +6,7 @@ namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullArgumentRule;
 
 final class ClassWithNullArgumentInNullsafeMethodCall
 {
-    public function run(NullsafeMethodCallTarget $target): string
+    public function run(?NullsafeMethodCallTarget $target): ?string
     {
         return $target?->accept(null);
     }

--- a/tests/Fixtures/Rules/NoNullArgumentRule/ClassWithNullArgumentInStaticCall.php
+++ b/tests/Fixtures/Rules/NoNullArgumentRule/ClassWithNullArgumentInStaticCall.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullArgumentRule;
+
+final class ClassWithNullArgumentInStaticCall
+{
+    public function run(): string
+    {
+        return StaticCallTarget::accept(null);
+    }
+}

--- a/tests/Fixtures/Rules/NoNullArgumentRule/ClassWithNullLiteralOutsideCall.php
+++ b/tests/Fixtures/Rules/NoNullArgumentRule/ClassWithNullLiteralOutsideCall.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullArgumentRule;
+
+final class ClassWithNullLiteralOutsideCall
+{
+    public function run(): ?string
+    {
+        $value = null;
+
+        return $value;
+    }
+}

--- a/tests/Fixtures/Rules/NoNullArgumentRule/ClassWithNullsafeInCompoundExpression.php
+++ b/tests/Fixtures/Rules/NoNullArgumentRule/ClassWithNullsafeInCompoundExpression.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullArgumentRule;
+
+final class ClassWithNullsafeInCompoundExpression
+{
+    public function run(?NullsafeMethodCallTarget $target): string
+    {
+        return $target?->accept(null) ?? 'fallback';
+    }
+}

--- a/tests/Fixtures/Rules/NoNullArgumentRule/ClassWithoutNullArgument.php
+++ b/tests/Fixtures/Rules/NoNullArgumentRule/ClassWithoutNullArgument.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullArgumentRule;
+
+function nonNullTarget(string $name, int $age): string
+{
+    return sprintf('%s %d', $name, $age);
+}
+
+final class ClassWithoutNullArgument
+{
+    public function run(): string
+    {
+        return nonNullTarget('Alice', 30);
+    }
+}

--- a/tests/Fixtures/Rules/NoNullArgumentRule/ConstructorTarget.php
+++ b/tests/Fixtures/Rules/NoNullArgumentRule/ConstructorTarget.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullArgumentRule;
+
+final class ConstructorTarget
+{
+    public function __construct(public ?string $value)
+    {
+    }
+}

--- a/tests/Fixtures/Rules/NoNullArgumentRule/MethodCallTarget.php
+++ b/tests/Fixtures/Rules/NoNullArgumentRule/MethodCallTarget.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullArgumentRule;
+
+final class MethodCallTarget
+{
+    public function accept(?string $value): string
+    {
+        return $value ?? '';
+    }
+}

--- a/tests/Fixtures/Rules/NoNullArgumentRule/NullsafeMethodCallTarget.php
+++ b/tests/Fixtures/Rules/NoNullArgumentRule/NullsafeMethodCallTarget.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullArgumentRule;
+
+final class NullsafeMethodCallTarget
+{
+    public function accept(?string $value): string
+    {
+        return $value ?? '';
+    }
+}

--- a/tests/Fixtures/Rules/NoNullArgumentRule/StaticCallTarget.php
+++ b/tests/Fixtures/Rules/NoNullArgumentRule/StaticCallTarget.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullArgumentRule;
+
+final class StaticCallTarget
+{
+    public static function accept(?string $value): string
+    {
+        return $value ?? '';
+    }
+}

--- a/tests/Fixtures/Rules/NoNullArgumentRule/SuppressedNullArgument.php
+++ b/tests/Fixtures/Rules/NoNullArgumentRule/SuppressedNullArgument.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullArgumentRule;
+
+function suppressedTarget(?string $value): string
+{
+    return $value ?? '';
+}
+
+final class SuppressedNullArgument
+{
+    public function run(): string
+    {
+        /** @phpstan-ignore haspadar.noNullArgument */
+        return suppressedTarget(null);
+    }
+}

--- a/tests/Unit/Rules/NoNullArgumentRule/NoNullArgumentRuleTest.php
+++ b/tests/Unit/Rules/NoNullArgumentRule/NoNullArgumentRuleTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\NoNullArgumentRule;
+
+use Haspadar\PHPStanRules\Rules\Internal\BuiltinCallDetector;
+use Haspadar\PHPStanRules\Rules\NoNullArgumentRule;
+use Override;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<NoNullArgumentRule> */
+final class NoNullArgumentRuleTest extends RuleTestCase
+{
+    #[Override]
+    protected function getRule(): Rule
+    {
+        return new NoNullArgumentRule(new BuiltinCallDetector($this->createReflectionProvider()));
+    }
+
+    #[Test]
+    public function reportsNullArgumentInFunctionCall(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NoNullArgumentRule/ClassWithNullArgumentInFunctionCall.php'],
+            [
+                ['Passing null as argument #0 to function userDefinedGreet() is prohibited. Model absence explicitly (Null Object, Optional).', 16],
+            ],
+            'Passing null to a user-defined function must be reported',
+        );
+    }
+
+    #[Test]
+    public function reportsNullArgumentInMethodCall(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NoNullArgumentRule/ClassWithNullArgumentInMethodCall.php'],
+            [
+                ['Passing null as argument #0 to method accept() is prohibited. Model absence explicitly (Null Object, Optional).', 11],
+            ],
+            'Passing null to an instance method must be reported',
+        );
+    }
+
+    #[Test]
+    public function reportsNullArgumentInNullsafeMethodCall(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NoNullArgumentRule/ClassWithNullArgumentInNullsafeMethodCall.php'],
+            [
+                ['Passing null as argument #0 to method accept() is prohibited. Model absence explicitly (Null Object, Optional).', 11],
+            ],
+            'Passing null to a nullsafe method call must be reported',
+        );
+    }
+
+    #[Test]
+    public function reportsNullArgumentInStaticCall(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NoNullArgumentRule/ClassWithNullArgumentInStaticCall.php'],
+            [
+                ['Passing null as argument #0 to method Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullArgumentRule\StaticCallTarget::accept() is prohibited. Model absence explicitly (Null Object, Optional).', 11],
+            ],
+            'Passing null to a static method call must be reported',
+        );
+    }
+
+    #[Test]
+    public function reportsNullArgumentInConstructor(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NoNullArgumentRule/ClassWithNullArgumentInConstructor.php'],
+            [
+                ['Passing null as argument #0 to constructor Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullArgumentRule\ConstructorTarget is prohibited. Model absence explicitly (Null Object, Optional).', 11],
+            ],
+            'Passing null to a user-defined constructor must be reported',
+        );
+    }
+
+    #[Test]
+    public function reportsNamedNullArgument(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NoNullArgumentRule/ClassWithNamedNullArgument.php'],
+            [
+                ['Passing null as argument "name" to function namedArgumentTarget() is prohibited. Model absence explicitly (Null Object, Optional).', 16],
+            ],
+            'Named null arguments must be reported using their name label',
+        );
+    }
+
+    #[Test]
+    public function reportsEveryNullArgumentSeparately(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NoNullArgumentRule/ClassWithMultipleNullArguments.php'],
+            [
+                ['Passing null as argument #0 to function multiArgumentTarget() is prohibited. Model absence explicitly (Null Object, Optional).', 16],
+                ['Passing null as argument #1 to function multiArgumentTarget() is prohibited. Model absence explicitly (Null Object, Optional).', 16],
+                ['Passing null as argument #2 to function multiArgumentTarget() is prohibited. Model absence explicitly (Null Object, Optional).', 16],
+            ],
+            'Every null argument in the same call must produce a separate error',
+        );
+    }
+
+    #[Test]
+    public function passesWhenCallIsInternal(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NoNullArgumentRule/ClassWithNullArgumentInInternalCall.php'],
+            [],
+            'Calls to PHP built-in functions must not be flagged',
+        );
+    }
+
+    #[Test]
+    public function passesWhenArgumentsAreNotNull(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NoNullArgumentRule/ClassWithoutNullArgument.php'],
+            [],
+            'Calls without null arguments must never be reported',
+        );
+    }
+
+    #[Test]
+    public function passesWhenNullIsOutsideCall(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NoNullArgumentRule/ClassWithNullLiteralOutsideCall.php'],
+            [],
+            'Null literals outside call expressions belong to other rules',
+        );
+    }
+
+    #[Test]
+    public function passesWhenErrorIsSuppressed(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NoNullArgumentRule/SuppressedNullArgument.php'],
+            [],
+            'A @phpstan-ignore haspadar.noNullArgument comment must silence the error',
+        );
+    }
+}

--- a/tests/Unit/Rules/NoNullArgumentRule/NoNullArgumentRuleTest.php
+++ b/tests/Unit/Rules/NoNullArgumentRule/NoNullArgumentRuleTest.php
@@ -134,9 +134,12 @@ final class NoNullArgumentRuleTest extends RuleTestCase
     public function passesWhenCallIsInternal(): void
     {
         $this->analyse(
-            [__DIR__ . '/../../../Fixtures/Rules/NoNullArgumentRule/ClassWithNullArgumentInInternalCall.php'],
+            [
+                __DIR__ . '/../../../Fixtures/Rules/NoNullArgumentRule/ClassWithNullArgumentInInternalCall.php',
+                __DIR__ . '/../../../Fixtures/Rules/NoNullArgumentRule/ClassWithNullArgumentInInternalMethodCall.php',
+            ],
             [],
-            'Calls to PHP built-in functions must not be flagged',
+            'Calls to PHP built-in functions and methods must not be flagged',
         );
     }
 

--- a/tests/Unit/Rules/NoNullArgumentRule/NoNullArgumentRuleTest.php
+++ b/tests/Unit/Rules/NoNullArgumentRule/NoNullArgumentRuleTest.php
@@ -26,7 +26,7 @@ final class NoNullArgumentRuleTest extends RuleTestCase
         $this->analyse(
             [__DIR__ . '/../../../Fixtures/Rules/NoNullArgumentRule/ClassWithNullArgumentInFunctionCall.php'],
             [
-                ['Passing null as argument #0 to function userDefinedGreet() is prohibited. Model absence explicitly (Null Object, Optional).', 16],
+                ['Passing null as argument #1 to function userDefinedGreet() is prohibited. Model absence explicitly (Null Object, Optional).', 16],
             ],
             'Passing null to a user-defined function must be reported',
         );
@@ -38,9 +38,9 @@ final class NoNullArgumentRuleTest extends RuleTestCase
         $this->analyse(
             [__DIR__ . '/../../../Fixtures/Rules/NoNullArgumentRule/ClassWithNullArgumentInMethodCall.php'],
             [
-                ['Passing null as argument #0 to method accept() is prohibited. Model absence explicitly (Null Object, Optional).', 11],
+                ['Passing null as argument #1 to method Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullArgumentRule\MethodCallTarget::accept() is prohibited. Model absence explicitly (Null Object, Optional).', 11],
             ],
-            'Passing null to an instance method must be reported',
+            'Passing null to an instance method must be reported with the fully qualified class name',
         );
     }
 
@@ -50,7 +50,7 @@ final class NoNullArgumentRuleTest extends RuleTestCase
         $this->analyse(
             [__DIR__ . '/../../../Fixtures/Rules/NoNullArgumentRule/ClassWithNullArgumentInNullsafeMethodCall.php'],
             [
-                ['Passing null as argument #0 to method accept() is prohibited. Model absence explicitly (Null Object, Optional).', 11],
+                ['Passing null as argument #1 to method Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullArgumentRule\NullsafeMethodCallTarget::accept() is prohibited. Model absence explicitly (Null Object, Optional).', 11],
             ],
             'Passing null to a nullsafe method call must be reported',
         );
@@ -62,7 +62,7 @@ final class NoNullArgumentRuleTest extends RuleTestCase
         $this->analyse(
             [__DIR__ . '/../../../Fixtures/Rules/NoNullArgumentRule/ClassWithNullsafeInCompoundExpression.php'],
             [
-                ['Passing null as argument #0 to method accept() is prohibited. Model absence explicitly (Null Object, Optional).', 11],
+                ['Passing null as argument #1 to method Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullArgumentRule\NullsafeMethodCallTarget::accept() is prohibited. Model absence explicitly (Null Object, Optional).', 11],
             ],
             'A nullsafe method call embedded in a larger expression must still produce the error exactly once',
         );
@@ -74,7 +74,7 @@ final class NoNullArgumentRuleTest extends RuleTestCase
         $this->analyse(
             [__DIR__ . '/../../../Fixtures/Rules/NoNullArgumentRule/ClassWithNullArgumentInStaticCall.php'],
             [
-                ['Passing null as argument #0 to method Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullArgumentRule\StaticCallTarget::accept() is prohibited. Model absence explicitly (Null Object, Optional).', 11],
+                ['Passing null as argument #1 to method Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullArgumentRule\StaticCallTarget::accept() is prohibited. Model absence explicitly (Null Object, Optional).', 11],
             ],
             'Passing null to a static method call must be reported',
         );
@@ -86,7 +86,7 @@ final class NoNullArgumentRuleTest extends RuleTestCase
         $this->analyse(
             [__DIR__ . '/../../../Fixtures/Rules/NoNullArgumentRule/ClassWithNullArgumentInConstructor.php'],
             [
-                ['Passing null as argument #0 to constructor Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullArgumentRule\ConstructorTarget is prohibited. Model absence explicitly (Null Object, Optional).', 11],
+                ['Passing null as argument #1 to constructor Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoNullArgumentRule\ConstructorTarget is prohibited. Model absence explicitly (Null Object, Optional).', 11],
             ],
             'Passing null to a user-defined constructor must be reported',
         );
@@ -110,9 +110,9 @@ final class NoNullArgumentRuleTest extends RuleTestCase
         $this->analyse(
             [__DIR__ . '/../../../Fixtures/Rules/NoNullArgumentRule/ClassWithMultipleNullArguments.php'],
             [
-                ['Passing null as argument #0 to function multiArgumentTarget() is prohibited. Model absence explicitly (Null Object, Optional).', 16],
                 ['Passing null as argument #1 to function multiArgumentTarget() is prohibited. Model absence explicitly (Null Object, Optional).', 16],
                 ['Passing null as argument #2 to function multiArgumentTarget() is prohibited. Model absence explicitly (Null Object, Optional).', 16],
+                ['Passing null as argument #3 to function multiArgumentTarget() is prohibited. Model absence explicitly (Null Object, Optional).', 16],
             ],
             'Every null argument in the same call must produce a separate error',
         );

--- a/tests/Unit/Rules/NoNullArgumentRule/NoNullArgumentRuleTest.php
+++ b/tests/Unit/Rules/NoNullArgumentRule/NoNullArgumentRuleTest.php
@@ -93,6 +93,18 @@ final class NoNullArgumentRuleTest extends RuleTestCase
     }
 
     #[Test]
+    public function reportsNullArgumentInAnonymousClassConstructor(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NoNullArgumentRule/ClassWithNullArgumentInAnonymousClassConstructor.php'],
+            [
+                ['Passing null as argument #1 to anonymous class constructor is prohibited. Model absence explicitly (Null Object, Optional).', 11],
+            ],
+            'Passing null to an anonymous-class constructor must be reported',
+        );
+    }
+
+    #[Test]
     public function reportsNamedNullArgument(): void
     {
         $this->analyse(

--- a/tests/Unit/Rules/NoNullArgumentRule/NoNullArgumentRuleTest.php
+++ b/tests/Unit/Rules/NoNullArgumentRule/NoNullArgumentRuleTest.php
@@ -57,6 +57,18 @@ final class NoNullArgumentRuleTest extends RuleTestCase
     }
 
     #[Test]
+    public function reportsNullArgumentInNullsafeInsideCompoundExpression(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NoNullArgumentRule/ClassWithNullsafeInCompoundExpression.php'],
+            [
+                ['Passing null as argument #0 to method accept() is prohibited. Model absence explicitly (Null Object, Optional).', 11],
+            ],
+            'A nullsafe method call embedded in a larger expression must still produce the error exactly once',
+        );
+    }
+
+    #[Test]
     public function reportsNullArgumentInStaticCall(): void
     {
         $this->analyse(

--- a/tests/Unit/RulesTest.php
+++ b/tests/Unit/RulesTest.php
@@ -58,6 +58,7 @@ use Haspadar\PHPStanRules\Rules\NeverAcceptNullArgumentsRule;
 use Haspadar\PHPStanRules\Rules\NeverReturnNullRule;
 use Haspadar\PHPStanRules\Rules\NeverUsePublicConstantsRule;
 use Haspadar\PHPStanRules\Rules\NoNullablePropertyRule;
+use Haspadar\PHPStanRules\Rules\NoNullArgumentRule;
 use Haspadar\PHPStanRules\Rules\NoNullAssignmentRule;
 use Haspadar\PHPStanRules\Rules\WeightedMethodsPerClassRule;
 use Haspadar\PHPStanRules\Rules\AfferentCouplingRule;
@@ -129,6 +130,7 @@ final class RulesTest extends TestCase
                 NeverReturnNullRule::class,
                 NoNullAssignmentRule::class,
                 NoNullablePropertyRule::class,
+                NoNullArgumentRule::class,
                 NeverUsePublicConstantsRule::class,
                 WeightedMethodsPerClassRule::class,
                 AfferentCouplingRule::class,


### PR DESCRIPTION
- Added NoNullArgumentRule to flag null literals in function, method, nullsafe, static, and constructor calls
- Added BuiltinCallDetector helper to skip PHP-native call targets via reflection
- Registered the rule in Rules::all and services under identifier haspadar.noNullArgument
- Added fixtures and unit tests covering every call shape, named arguments, internal calls, and suppression
- Updated README with an entry in the Design rules table

Closes #160

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a static analysis rule that flags null literal arguments passed to user-defined functions, methods, constructors, and static calls, including per-argument diagnostics and named-argument labels.

* **Documentation**
  * README updated with guidance for the new null-argument detection rule.

* **Tests**
  * Added comprehensive test suite and fixtures covering function/method/static/constructor calls, nullsafe and compound expressions, named arguments, anonymous constructors, and suppression behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->