### PR TITLE
Whitelist-based Actor Suffix Rule for -er/-or Class Names

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@
 | `ParameterNameRule`               | `^(id\|[a-z]{3,})$` | Method parameter name must match the configured pattern           |
 | `CatchParameterNameRule`          | `^(e\|ex\|[a-z]{3,12})$` | Catch parameter name must match the configured pattern       |
 | `ForbiddenClassSuffixRule`        | 12 suffixes | Class name must not end with a generic suffix (Manager, Helper, Util, ...) |
+| `NoActorSuffixRule`               | 23 words, 6 ns prefixes | Class ending with -er/-or must match the allowedWords whitelist, or extend a class from a framework namespace |
 
 ### PHPDoc style
 
@@ -216,6 +217,40 @@ parameters:
             allowedSuffixes:
                 - EventHandler
                 - CommandHandler
+        noActorSuffix:
+            allowedWords:
+                - User
+                - Order
+                - Number
+                - Member
+                - Owner
+                - Customer
+                - Folder
+                - Header
+                - Footer
+                - Buffer
+                - Layer
+                - Marker
+                - Parameter
+                - Character
+                - Identifier
+                - Integer
+                - Error
+                - Color
+                - Vendor
+                - Vector
+                - Factor
+                - Ancestor
+                - Descriptor
+            excludedParentNamespaces:
+                - 'Symfony\'
+                - 'Illuminate\'
+                - 'Doctrine\'
+                - 'Laminas\'
+                - 'Yii\'
+                - 'Laravel\'
+            excludedClasses:
+                - App\Legacy\UserManager
         afferentCoupling:
             maxAfferent: 10
             ignoreInterfaces: true
@@ -235,6 +270,16 @@ parameters:
 ```
 
 Default values match the defaults described in the rules table above. Omitting a parameter keeps the default. Diagnostic identifier for `AtclauseOrderRule`: `haspadar.atclauseOrder` (for targeted ignores, e.g. `@phpstan-ignore haspadar.atclauseOrder`).
+
+### NoActorSuffixRule — allowedWords vs renaming
+
+When the rule reports a class like `UserDispatcher`, pick one of three fixes:
+
+1. **Rename the class to a domain noun (preferred).** `UserDispatcher` becomes `User`, `UserEvent`, `UserNotification` — whatever the class actually *is*, not what it does.
+2. **Extend `allowedWords` if the suffix is a real English noun describing an entity**, not an action. Good candidates: `Container`, `Director`, `Editor`, `Descriptor`. Bad candidates (these are actors, not entities): `Manager`, `Controller`, `Handler`, `Dispatcher`, `Coordinator`, `Orchestrator`, `Processor`.
+3. **Add a framework namespace to `excludedParentNamespaces` if the class is framework-managed** (extends a controller base, implements an event-subscriber interface, etc.). Do not put `Controller` or `Handler` into `allowedWords` for this — it defeats the rule.
+
+Rule of thumb: if the suffix describes *what the class is*, extend `allowedWords`. If it describes *what the class does*, rename.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -285,6 +285,8 @@ When the rule reports a class like `UserDispatcher`, pick one of three fixes:
 
 Rule of thumb: if the suffix describes *what the class is*, extend `allowedWords`. If it describes *what the class does*, rename.
 
+`allowedWords` is matched **case-sensitively** against the last PascalCase segment of the class name. PHP class names follow PascalCase convention, so entries must be capitalized (`User`, not `user`).
+
 ---
 
 ## Experimental rules

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@
 | `ParameterNameRule`               | `^(id\|[a-z]{3,})$` | Method parameter name must match the configured pattern           |
 | `CatchParameterNameRule`          | `^(e\|ex\|[a-z]{3,12})$` | Catch parameter name must match the configured pattern       |
 | `ForbiddenClassSuffixRule`        | 12 suffixes | Class name must not end with a generic suffix (Manager, Helper, Util, ...) |
-| `NoActorSuffixRule`               | 23 words, 6 ns prefixes | Class ending with -er/-or must match the allowedWords whitelist, or extend a class from a framework namespace |
+| `NoActorSuffixRule`               | 27 words, 6 ns prefixes | Class ending with -er/-or must match the allowedWords whitelist, or extend a class from a framework namespace |
 
 ### PHPDoc style
 
@@ -235,11 +235,15 @@ parameters:
                 - Character
                 - Identifier
                 - Integer
+                - Author
+                - Visitor
                 - Error
                 - Color
                 - Vendor
                 - Vector
                 - Factor
+                - Actor
+                - Director
                 - Ancestor
                 - Descriptor
             excludedParentNamespaces:
@@ -276,7 +280,7 @@ Default values match the defaults described in the rules table above. Omitting a
 When the rule reports a class like `UserDispatcher`, pick one of three fixes:
 
 1. **Rename the class to a domain noun (preferred).** `UserDispatcher` becomes `User`, `UserEvent`, `UserNotification` — whatever the class actually *is*, not what it does.
-2. **Extend `allowedWords` if the suffix is a real English noun describing an entity**, not an action. Good candidates: `Container`, `Director`, `Editor`, `Descriptor`. Bad candidates (these are actors, not entities): `Manager`, `Controller`, `Handler`, `Dispatcher`, `Coordinator`, `Orchestrator`, `Processor`.
+2. **Extend `allowedWords` if the suffix is a real English noun describing an entity**, not an action. Good candidates: `Container`, `Editor`, `Monitor`, `Sensor`. Bad candidates (these are actors, not entities): `Manager`, `Controller`, `Handler`, `Dispatcher`, `Coordinator`, `Orchestrator`, `Processor`.
 3. **Add a framework namespace to `excludedParentNamespaces` if the class is framework-managed** (extends a controller base, implements an event-subscriber interface, etc.). Do not put `Controller` or `Handler` into `allowedWords` for this — it defeats the rule.
 
 Rule of thumb: if the suffix describes *what the class is*, extend `allowedWords`. If it describes *what the class does*, rename.

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,10 @@
     "autoload-dev": {
         "psr-4": {
             "Haspadar\\PHPStanRules\\Tests\\": "tests/"
-        }
+        },
+        "classmap": [
+            "tests/Fixtures/Rules/NoActorSuffixRule/VendorStubs/"
+        ]
     },
     "authors": [
         {

--- a/rules-ignore.neon
+++ b/rules-ignore.neon
@@ -23,3 +23,13 @@ parameters:
                 - src/Rules/MethodLengthRule.php
         -
             identifier: haspadar.noActorSuffix
+            paths:
+                - src/Collectors/ClassDependencyCollector.php
+                - src/PhpDoc/SummaryExtractor.php
+                - src/Rules/ConstantUsage/ExemptScalarCollector.php
+                - src/Rules/CouplingBetweenObjectsRule/MethodBodyTypeCollector.php
+                - src/Rules/CouplingBetweenObjectsRule/TypeNameExtractor.php
+                - src/Rules/Internal/BuiltinCallDetector.php
+                - src/Rules/LackOfCohesionRule/AdjacencyBuilder.php
+                - src/Rules/PhpDocDescriptionChecker.php
+                - src/Rules/VariableCollector.php

--- a/rules-ignore.neon
+++ b/rules-ignore.neon
@@ -21,3 +21,5 @@ parameters:
             paths:
                 - src/Rules/CouplingBetweenObjectsRule.php
                 - src/Rules/MethodLengthRule.php
+        -
+            identifier: haspadar.noActorSuffix

--- a/rules.neon
+++ b/rules.neon
@@ -145,11 +145,15 @@ parameters:
                 - Character
                 - Identifier
                 - Integer
+                - Author
+                - Visitor
                 - Error
                 - Color
                 - Vendor
                 - Vector
                 - Factor
+                - Actor
+                - Director
                 - Ancestor
                 - Descriptor
             excludedParentNamespaces:

--- a/rules.neon
+++ b/rules.neon
@@ -127,6 +127,39 @@ parameters:
             minMethods: 7
             minProperties: 3
             excludedClasses: []
+        noActorSuffix:
+            allowedWords:
+                - User
+                - Order
+                - Number
+                - Member
+                - Owner
+                - Customer
+                - Folder
+                - Header
+                - Footer
+                - Buffer
+                - Layer
+                - Marker
+                - Parameter
+                - Character
+                - Identifier
+                - Integer
+                - Error
+                - Color
+                - Vendor
+                - Vector
+                - Factor
+                - Ancestor
+                - Descriptor
+            excludedParentNamespaces:
+                - 'Symfony\'
+                - 'Illuminate\'
+                - 'Doctrine\'
+                - 'Laminas\'
+                - 'Yii\'
+                - 'Laravel\'
+            excludedClasses: []
 
 parametersSchema:
     haspadar: structure([
@@ -259,6 +292,11 @@ parametersSchema:
             maxLcom: int(),
             minMethods: int(),
             minProperties: int(),
+            excludedClasses: listOf(string()),
+        ]),
+        noActorSuffix: structure([
+            allowedWords: listOf(string()),
+            excludedParentNamespaces: listOf(string()),
             excludedClasses: listOf(string()),
         ]),
     ])
@@ -629,5 +667,14 @@ services:
                 minMethods: %haspadar.lackOfCohesion.minMethods%
                 minProperties: %haspadar.lackOfCohesion.minProperties%
                 excludedClasses: %haspadar.lackOfCohesion.excludedClasses%
+        tags:
+            - phpstan.rules.rule
+    -
+        class: Haspadar\PHPStanRules\Rules\NoActorSuffixRule
+        arguments:
+            options:
+                allowedWords: %haspadar.noActorSuffix.allowedWords%
+                excludedParentNamespaces: %haspadar.noActorSuffix.excludedParentNamespaces%
+                excludedClasses: %haspadar.noActorSuffix.excludedClasses%
         tags:
             - phpstan.rules.rule

--- a/src/Rules.php
+++ b/src/Rules.php
@@ -71,6 +71,7 @@ final class Rules
         Rules\InheritanceDepthRule::class,
         Rules\LackOfCohesionRule::class,
         Rules\InstabilityRule::class,
+        Rules\NoActorSuffixRule::class,
     ];
 
     /**

--- a/src/Rules/NoActorSuffixRule.php
+++ b/src/Rules/NoActorSuffixRule.php
@@ -47,7 +47,8 @@ final readonly class NoActorSuffixRule implements Rule
      *     allowedWords?: list<string>,
      *     excludedParentNamespaces?: list<string>,
      *     excludedClasses?: list<string>
-     * } $options Whitelist of real noun-entities ending in -er/-or, framework namespace prefixes, and FQCN exclusions
+     * } $options Whitelist of real noun-entities ending in -er/-or (matched case-sensitively against the
+     *     last PascalCase segment), framework namespace prefixes, and FQCN exclusions
      */
     public function __construct(private ReflectionProvider $reflectionProvider, array $options = [])
     {
@@ -119,7 +120,7 @@ final readonly class NoActorSuffixRule implements Rule
      */
     private function endsWithActorSuffix(string $className): bool
     {
-        return preg_match('/(?:er|or)$/', $className) === 1;
+        return str_ends_with($className, 'er') || str_ends_with($className, 'or');
     }
 
     /**

--- a/src/Rules/NoActorSuffixRule.php
+++ b/src/Rules/NoActorSuffixRule.php
@@ -104,7 +104,7 @@ final readonly class NoActorSuffixRule implements Rule
         return [
             RuleErrorBuilder::message(
                 sprintf(
-                    'Class %s must not end with actor suffix "%s". Classes are nouns, not procedures. Rename to a domain noun, or see README for when to extend allowedWords / excludedParentNamespaces.',
+                    "Class %s must not end with actor suffix '%s'. Classes are nouns, not procedures. Rename to a domain noun, or see README for when to extend allowedWords / excludedParentNamespaces.",
                     $className,
                     $lastWord,
                 ),
@@ -115,11 +115,11 @@ final readonly class NoActorSuffixRule implements Rule
     }
 
     /**
-     * Checks whether the class name ends with -er or -or (case-insensitive).
+     * Checks whether the class name ends with lowercase -er or -or, as produced by PascalCase naming.
      */
     private function endsWithActorSuffix(string $className): bool
     {
-        return preg_match('/(er|or)$/i', $className) === 1;
+        return preg_match('/(er|or)$/', $className) === 1;
     }
 
     /**

--- a/src/Rules/NoActorSuffixRule.php
+++ b/src/Rules/NoActorSuffixRule.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Rules;
+
+use Override;
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\ShouldNotHappenException;
+
+/**
+ * Forbids actor-like class name suffixes ending with -er or -or.
+ *
+ * A class whose name ends with -er or -or is rejected unless (a) its last
+ * PascalCase word is on the allowedWords whitelist of real noun-entities
+ * (User, Order, Number, Error, ...), or (b) any of its transitive parent
+ * classes, implemented interfaces, or used traits lives under a namespace
+ * prefix from excludedParentNamespaces (Symfony\, Illuminate\, ...), or
+ * (c) its fully qualified name is in excludedClasses. Anonymous classes
+ * are never reported.
+ *
+ * @implements Rule<Class_>
+ */
+final readonly class NoActorSuffixRule implements Rule
+{
+    /** @var list<string> */
+    private array $allowedWords;
+
+    /** @var list<string> */
+    private array $excludedParentNamespaces;
+
+    /** @var list<string> */
+    private array $excludedClasses;
+
+    /**
+     * Constructs the rule with the whitelist and framework exclusions.
+     *
+     * @param ReflectionProvider $reflectionProvider PHPStan reflection provider used to resolve ancestor classes
+     * @param array{
+     *     allowedWords?: list<string>,
+     *     excludedParentNamespaces?: list<string>,
+     *     excludedClasses?: list<string>
+     * } $options Whitelist of real noun-entities ending in -er/-or, framework namespace prefixes, and FQCN exclusions
+     */
+    public function __construct(private ReflectionProvider $reflectionProvider, array $options = [])
+    {
+        $this->allowedWords = $options['allowedWords'] ?? [];
+        $this->excludedParentNamespaces = $options['excludedParentNamespaces'] ?? [];
+        $this->excludedClasses = array_map(
+            static fn(string $class): string => strtolower(ltrim($class, '\\')),
+            $options['excludedClasses'] ?? [],
+        );
+    }
+
+    #[Override]
+    public function getNodeType(): string
+    {
+        return Class_::class;
+    }
+
+    /**
+     * Analyses the node and returns a list of errors.
+     *
+     * @psalm-param Class_ $node
+     * @throws ShouldNotHappenException
+     * @return list<IdentifierRuleError>
+     */
+    #[Override]
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if ($node->isAnonymous() || $node->name === null || $node->namespacedName === null) {
+            return [];
+        }
+
+        $className = $node->name->toString();
+
+        if (!$this->endsWithActorSuffix($className)) {
+            return [];
+        }
+
+        $fqcn = $node->namespacedName->toString();
+
+        if (in_array(strtolower($fqcn), $this->excludedClasses, true)) {
+            return [];
+        }
+
+        $lastWord = $this->lastPascalCaseWord($className);
+
+        if (in_array($lastWord, $this->allowedWords, true)) {
+            return [];
+        }
+
+        if ($this->hasExcludedParent($fqcn)) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message(
+                sprintf(
+                    'Class %s must not end with actor suffix "%s". Classes are nouns, not procedures. Rename to a domain noun, or see README for when to extend allowedWords / excludedParentNamespaces.',
+                    $className,
+                    $lastWord,
+                ),
+            )
+                ->identifier('haspadar.noActorSuffix')
+                ->build(),
+        ];
+    }
+
+    /**
+     * Checks whether the class name ends with -er or -or (case-insensitive).
+     */
+    private function endsWithActorSuffix(string $className): bool
+    {
+        return preg_match('/(er|or)$/i', $className) === 1;
+    }
+
+    /**
+     * Returns the last PascalCase word of the class name.
+     *
+     * Splits on lowercase-to-uppercase transitions and acronym-to-word
+     * boundaries so that HTTPParameter yields "Parameter" and UserManager
+     * yields "Manager".
+     */
+    private function lastPascalCaseWord(string $className): string
+    {
+        $words = preg_split('/(?<=[a-z])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])/', $className);
+
+        if ($words === false) {
+            return $className;
+        }
+
+        return $words[count($words) - 1];
+    }
+
+    /**
+     * Returns true if any ancestor FQCN starts with one of the excluded namespace prefixes.
+     */
+    private function hasExcludedParent(string $fqcn): bool
+    {
+        if ($this->excludedParentNamespaces === []) {
+            return false;
+        }
+
+        if (!$this->reflectionProvider->hasClass($fqcn)) {
+            return false;
+        }
+
+        foreach ($this->collectAncestorNames($this->reflectionProvider->getClass($fqcn)) as $ancestorName) {
+            foreach ($this->excludedParentNamespaces as $prefix) {
+                if (str_starts_with($ancestorName, $prefix)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Collects FQCNs of all transitive parents, interfaces, and traits.
+     *
+     * @return list<string>
+     */
+    private function collectAncestorNames(ClassReflection $classReflection): array
+    {
+        $names = [];
+
+        foreach ($classReflection->getParents() as $parent) {
+            $names[] = $parent->getName();
+        }
+
+        foreach ($classReflection->getInterfaces() as $interface) {
+            $names[] = $interface->getName();
+        }
+
+        foreach ($classReflection->getTraits(true) as $trait) {
+            $names[] = $trait->getName();
+        }
+
+        return $names;
+    }
+}

--- a/src/Rules/NoActorSuffixRule.php
+++ b/src/Rules/NoActorSuffixRule.php
@@ -119,7 +119,7 @@ final readonly class NoActorSuffixRule implements Rule
      */
     private function endsWithActorSuffix(string $className): bool
     {
-        return preg_match('/(er|or)$/', $className) === 1;
+        return preg_match('/(?:er|or)$/', $className) === 1;
     }
 
     /**

--- a/tests/Fixtures/Rules/NoActorSuffixRule/AnonymousClassCall.php
+++ b/tests/Fixtures/Rules/NoActorSuffixRule/AnonymousClassCall.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoActorSuffixRule;
+
+final class AnonymousClassCall
+{
+    public function make(): object
+    {
+        return new class {
+            public function run(): void
+            {
+            }
+        };
+    }
+}

--- a/tests/Fixtures/Rules/NoActorSuffixRule/AppBaseController.php
+++ b/tests/Fixtures/Rules/NoActorSuffixRule/AppBaseController.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoActorSuffixRule;
+
+abstract class AppBaseController extends \Symfony\Stub\Bundle\FrameworkBundle\Controller\AbstractController
+{
+}

--- a/tests/Fixtures/Rules/NoActorSuffixRule/ExcludedLegacyManager.php
+++ b/tests/Fixtures/Rules/NoActorSuffixRule/ExcludedLegacyManager.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoActorSuffixRule;
+
+final class ExcludedLegacyManager
+{
+}

--- a/tests/Fixtures/Rules/NoActorSuffixRule/HttpHeader.php
+++ b/tests/Fixtures/Rules/NoActorSuffixRule/HttpHeader.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoActorSuffixRule;
+
+final class HttpHeader
+{
+}

--- a/tests/Fixtures/Rules/NoActorSuffixRule/LaravelStyleController.php
+++ b/tests/Fixtures/Rules/NoActorSuffixRule/LaravelStyleController.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoActorSuffixRule;
+
+final class LaravelStyleController implements \Illuminate\Stub\Contracts\Queue\ShouldQueue
+{
+}

--- a/tests/Fixtures/Rules/NoActorSuffixRule/Money.php
+++ b/tests/Fixtures/Rules/NoActorSuffixRule/Money.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoActorSuffixRule;
+
+final class Money
+{
+}

--- a/tests/Fixtures/Rules/NoActorSuffixRule/OrderCreationTrigger.php
+++ b/tests/Fixtures/Rules/NoActorSuffixRule/OrderCreationTrigger.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoActorSuffixRule;
+
+trait OrderCreationTrigger
+{
+}

--- a/tests/Fixtures/Rules/NoActorSuffixRule/OrderNumber.php
+++ b/tests/Fixtures/Rules/NoActorSuffixRule/OrderNumber.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoActorSuffixRule;
+
+final class OrderNumber
+{
+}

--- a/tests/Fixtures/Rules/NoActorSuffixRule/PaymentCoordinator.php
+++ b/tests/Fixtures/Rules/NoActorSuffixRule/PaymentCoordinator.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoActorSuffixRule;
+
+final class PaymentCoordinator
+{
+}

--- a/tests/Fixtures/Rules/NoActorSuffixRule/PaymentHandler.php
+++ b/tests/Fixtures/Rules/NoActorSuffixRule/PaymentHandler.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoActorSuffixRule;
+
+interface PaymentHandler
+{
+}

--- a/tests/Fixtures/Rules/NoActorSuffixRule/StandaloneController.php
+++ b/tests/Fixtures/Rules/NoActorSuffixRule/StandaloneController.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoActorSuffixRule;
+
+final class StandaloneController
+{
+}

--- a/tests/Fixtures/Rules/NoActorSuffixRule/SuppressedActor.php
+++ b/tests/Fixtures/Rules/NoActorSuffixRule/SuppressedActor.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoActorSuffixRule;
+
+/** @phpstan-ignore haspadar.noActorSuffix */
+final class SuppressedActor
+{
+}

--- a/tests/Fixtures/Rules/NoActorSuffixRule/SuppressedManager.php
+++ b/tests/Fixtures/Rules/NoActorSuffixRule/SuppressedManager.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoActorSuffixRule;
+
+/** @phpstan-ignore haspadar.noActorSuffix */
+final class SuppressedManager
+{
+}

--- a/tests/Fixtures/Rules/NoActorSuffixRule/SymfonyStyleController.php
+++ b/tests/Fixtures/Rules/NoActorSuffixRule/SymfonyStyleController.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoActorSuffixRule;
+
+final class SymfonyStyleController extends \Symfony\Stub\Bundle\FrameworkBundle\Controller\AbstractController
+{
+}

--- a/tests/Fixtures/Rules/NoActorSuffixRule/TraitUsingFrameworkController.php
+++ b/tests/Fixtures/Rules/NoActorSuffixRule/TraitUsingFrameworkController.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoActorSuffixRule;
 
-/** @phpstan-ignore haspadar.noActorSuffix */
-final class SuppressedActor
+final class TraitUsingFrameworkController
 {
+    use \Symfony\Stub\Contracts\Cache\CacheTrait;
 }

--- a/tests/Fixtures/Rules/NoActorSuffixRule/TransitiveFrameworkController.php
+++ b/tests/Fixtures/Rules/NoActorSuffixRule/TransitiveFrameworkController.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoActorSuffixRule;
+
+final class TransitiveFrameworkController extends AppBaseController
+{
+}

--- a/tests/Fixtures/Rules/NoActorSuffixRule/User.php
+++ b/tests/Fixtures/Rules/NoActorSuffixRule/User.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoActorSuffixRule;
+
+final class User
+{
+}

--- a/tests/Fixtures/Rules/NoActorSuffixRule/UserDispatcher.php
+++ b/tests/Fixtures/Rules/NoActorSuffixRule/UserDispatcher.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoActorSuffixRule;
+
+final class UserDispatcher
+{
+}

--- a/tests/Fixtures/Rules/NoActorSuffixRule/UserOrchestrator.php
+++ b/tests/Fixtures/Rules/NoActorSuffixRule/UserOrchestrator.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NoActorSuffixRule;
+
+final class UserOrchestrator
+{
+}

--- a/tests/Fixtures/Rules/NoActorSuffixRule/VendorStubs/AbstractController.php
+++ b/tests/Fixtures/Rules/NoActorSuffixRule/VendorStubs/AbstractController.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\Stub\Bundle\FrameworkBundle\Controller;
+
+/** @phpstan-ignore haspadar.noActorSuffix */
+abstract class AbstractController
+{
+}

--- a/tests/Fixtures/Rules/NoActorSuffixRule/VendorStubs/AbstractController.php
+++ b/tests/Fixtures/Rules/NoActorSuffixRule/VendorStubs/AbstractController.php
@@ -4,7 +4,13 @@ declare(strict_types=1);
 
 namespace Symfony\Stub\Bundle\FrameworkBundle\Controller;
 
-/** @phpstan-ignore haspadar.noActorSuffix */
+/**
+ * Stub for a Symfony base controller — the fixture itself has no parent, so
+ * the only way to pass the rule while being loaded as an analysed file is a
+ * suppress comment. Classes under this stub never reach it directly.
+ *
+ * @phpstan-ignore haspadar.noActorSuffix
+ */
 abstract class AbstractController
 {
 }

--- a/tests/Fixtures/Rules/NoActorSuffixRule/VendorStubs/CacheTrait.php
+++ b/tests/Fixtures/Rules/NoActorSuffixRule/VendorStubs/CacheTrait.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\Stub\Contracts\Cache;
+
+trait CacheTrait
+{
+}

--- a/tests/Fixtures/Rules/NoActorSuffixRule/VendorStubs/ShouldQueue.php
+++ b/tests/Fixtures/Rules/NoActorSuffixRule/VendorStubs/ShouldQueue.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Stub\Contracts\Queue;
+
+interface ShouldQueue
+{
+}

--- a/tests/Unit/Rules/NoActorSuffixRule/NoActorSuffixRuleAllowedWordsTest.php
+++ b/tests/Unit/Rules/NoActorSuffixRule/NoActorSuffixRuleAllowedWordsTest.php
@@ -33,7 +33,7 @@ final class NoActorSuffixRuleAllowedWordsTest extends RuleTestCase
             [__DIR__ . '/../../../Fixtures/Rules/NoActorSuffixRule/OrderNumber.php'],
             [
                 [
-                    'Class OrderNumber must not end with actor suffix "Number". Classes are nouns, not procedures. Rename to a domain noun, or see README for when to extend allowedWords / excludedParentNamespaces.',
+                    'Class OrderNumber must not end with actor suffix \'Number\'. Classes are nouns, not procedures. Rename to a domain noun, or see README for when to extend allowedWords / excludedParentNamespaces.',
                     7,
                 ],
             ],

--- a/tests/Unit/Rules/NoActorSuffixRule/NoActorSuffixRuleAllowedWordsTest.php
+++ b/tests/Unit/Rules/NoActorSuffixRule/NoActorSuffixRuleAllowedWordsTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\NoActorSuffixRule;
+
+use Haspadar\PHPStanRules\Rules\NoActorSuffixRule;
+use Override;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<NoActorSuffixRule> */
+final class NoActorSuffixRuleAllowedWordsTest extends RuleTestCase
+{
+    #[Override]
+    protected function getRule(): Rule
+    {
+        return new NoActorSuffixRule(
+            $this->createReflectionProvider(),
+            [
+                'allowedWords' => ['User'],
+                'excludedParentNamespaces' => [],
+                'excludedClasses' => [],
+            ],
+        );
+    }
+
+    #[Test]
+    public function reportsWhenLastWordIsNotInShortenedWhitelist(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NoActorSuffixRule/OrderNumber.php'],
+            [
+                [
+                    'Class OrderNumber must not end with actor suffix "Number". Classes are nouns, not procedures. Rename to a domain noun, or see README for when to extend allowedWords / excludedParentNamespaces.',
+                    7,
+                ],
+            ],
+            'Removing Number from allowedWords must turn OrderNumber into a reported class',
+        );
+    }
+
+    #[Test]
+    public function passesWhenLastWordIsInShortenedWhitelist(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NoActorSuffixRule/User.php'],
+            [],
+            'A whitelist of just [User] must still pass User',
+        );
+    }
+}

--- a/tests/Unit/Rules/NoActorSuffixRule/NoActorSuffixRuleExcludedClassesTest.php
+++ b/tests/Unit/Rules/NoActorSuffixRule/NoActorSuffixRuleExcludedClassesTest.php
@@ -45,7 +45,7 @@ final class NoActorSuffixRuleExcludedClassesTest extends RuleTestCase
             [__DIR__ . '/../../../Fixtures/Rules/NoActorSuffixRule/UserDispatcher.php'],
             [
                 [
-                    'Class UserDispatcher must not end with actor suffix "Dispatcher". Classes are nouns, not procedures. Rename to a domain noun, or see README for when to extend allowedWords / excludedParentNamespaces.',
+                    'Class UserDispatcher must not end with actor suffix \'Dispatcher\'. Classes are nouns, not procedures. Rename to a domain noun, or see README for when to extend allowedWords / excludedParentNamespaces.',
                     7,
                 ],
             ],

--- a/tests/Unit/Rules/NoActorSuffixRule/NoActorSuffixRuleExcludedClassesTest.php
+++ b/tests/Unit/Rules/NoActorSuffixRule/NoActorSuffixRuleExcludedClassesTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\NoActorSuffixRule;
+
+use Haspadar\PHPStanRules\Rules\NoActorSuffixRule;
+use Override;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<NoActorSuffixRule> */
+final class NoActorSuffixRuleExcludedClassesTest extends RuleTestCase
+{
+    #[Override]
+    protected function getRule(): Rule
+    {
+        return new NoActorSuffixRule(
+            $this->createReflectionProvider(),
+            [
+                'allowedWords' => [],
+                'excludedParentNamespaces' => [],
+                'excludedClasses' => [
+                    'Haspadar\\PHPStanRules\\Tests\\Fixtures\\Rules\\NoActorSuffixRule\\ExcludedLegacyManager',
+                ],
+            ],
+        );
+    }
+
+    #[Test]
+    public function passesWhenFullyQualifiedClassNameIsExcluded(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NoActorSuffixRule/ExcludedLegacyManager.php'],
+            [],
+            'A class whose FQCN is in excludedClasses must be skipped unconditionally',
+        );
+    }
+
+    #[Test]
+    public function reportsWhenFullyQualifiedClassNameIsNotInExcludedList(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NoActorSuffixRule/UserDispatcher.php'],
+            [
+                [
+                    'Class UserDispatcher must not end with actor suffix "Dispatcher". Classes are nouns, not procedures. Rename to a domain noun, or see README for when to extend allowedWords / excludedParentNamespaces.',
+                    7,
+                ],
+            ],
+            'A class whose FQCN is not in excludedClasses must be reported',
+        );
+    }
+}

--- a/tests/Unit/Rules/NoActorSuffixRule/NoActorSuffixRuleExcludedParentNamespacesTest.php
+++ b/tests/Unit/Rules/NoActorSuffixRule/NoActorSuffixRuleExcludedParentNamespacesTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\NoActorSuffixRule;
+
+use Haspadar\PHPStanRules\Rules\NoActorSuffixRule;
+use Override;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<NoActorSuffixRule> */
+final class NoActorSuffixRuleExcludedParentNamespacesTest extends RuleTestCase
+{
+    #[Override]
+    protected function getRule(): Rule
+    {
+        return new NoActorSuffixRule(
+            $this->createReflectionProvider(),
+            [
+                'allowedWords' => [],
+                'excludedParentNamespaces' => ['Symfony\\', 'Illuminate\\'],
+                'excludedClasses' => [],
+            ],
+        );
+    }
+
+    #[Test]
+    public function passesWhenParentClassLivesUnderExcludedNamespace(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/../../../Fixtures/Rules/NoActorSuffixRule/VendorStubs/AbstractController.php',
+                __DIR__ . '/../../../Fixtures/Rules/NoActorSuffixRule/SymfonyStyleController.php',
+            ],
+            [],
+            'A class whose parent lives under Symfony\\ must be skipped',
+        );
+    }
+
+    #[Test]
+    public function passesWhenImplementedInterfaceLivesUnderExcludedNamespace(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/../../../Fixtures/Rules/NoActorSuffixRule/VendorStubs/ShouldQueue.php',
+                __DIR__ . '/../../../Fixtures/Rules/NoActorSuffixRule/LaravelStyleController.php',
+            ],
+            [],
+            'A class implementing an interface under Illuminate\\ must be skipped',
+        );
+    }
+
+    #[Test]
+    public function passesWhenTransitiveAncestorLivesUnderExcludedNamespace(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/../../../Fixtures/Rules/NoActorSuffixRule/VendorStubs/AbstractController.php',
+                __DIR__ . '/../../../Fixtures/Rules/NoActorSuffixRule/AppBaseController.php',
+                __DIR__ . '/../../../Fixtures/Rules/NoActorSuffixRule/TransitiveFrameworkController.php',
+            ],
+            [],
+            'A class whose grandparent lives under Symfony\\ must be skipped via transitive reflection',
+        );
+    }
+
+    #[Test]
+    public function reportsWhenNoAncestorMatchesExcludedNamespaces(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NoActorSuffixRule/UserDispatcher.php'],
+            [
+                [
+                    'Class UserDispatcher must not end with actor suffix "Dispatcher". Classes are nouns, not procedures. Rename to a domain noun, or see README for when to extend allowedWords / excludedParentNamespaces.',
+                    7,
+                ],
+            ],
+            'A class without framework-managed ancestors must still be reported',
+        );
+    }
+}

--- a/tests/Unit/Rules/NoActorSuffixRule/NoActorSuffixRuleExcludedParentNamespacesTest.php
+++ b/tests/Unit/Rules/NoActorSuffixRule/NoActorSuffixRuleExcludedParentNamespacesTest.php
@@ -67,13 +67,26 @@ final class NoActorSuffixRuleExcludedParentNamespacesTest extends RuleTestCase
     }
 
     #[Test]
+    public function passesWhenUsedTraitLivesUnderExcludedNamespace(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/../../../Fixtures/Rules/NoActorSuffixRule/VendorStubs/CacheTrait.php',
+                __DIR__ . '/../../../Fixtures/Rules/NoActorSuffixRule/TraitUsingFrameworkController.php',
+            ],
+            [],
+            'A class using a trait under Symfony\\ must be skipped',
+        );
+    }
+
+    #[Test]
     public function reportsWhenNoAncestorMatchesExcludedNamespaces(): void
     {
         $this->analyse(
             [__DIR__ . '/../../../Fixtures/Rules/NoActorSuffixRule/UserDispatcher.php'],
             [
                 [
-                    'Class UserDispatcher must not end with actor suffix "Dispatcher". Classes are nouns, not procedures. Rename to a domain noun, or see README for when to extend allowedWords / excludedParentNamespaces.',
+                    'Class UserDispatcher must not end with actor suffix \'Dispatcher\'. Classes are nouns, not procedures. Rename to a domain noun, or see README for when to extend allowedWords / excludedParentNamespaces.',
                     7,
                 ],
             ],

--- a/tests/Unit/Rules/NoActorSuffixRule/NoActorSuffixRuleTest.php
+++ b/tests/Unit/Rules/NoActorSuffixRule/NoActorSuffixRuleTest.php
@@ -36,11 +36,15 @@ final class NoActorSuffixRuleTest extends RuleTestCase
                     'Character',
                     'Identifier',
                     'Integer',
+                    'Author',
+                    'Visitor',
                     'Error',
                     'Color',
                     'Vendor',
                     'Vector',
                     'Factor',
+                    'Actor',
+                    'Director',
                     'Ancestor',
                     'Descriptor',
                 ],
@@ -64,7 +68,7 @@ final class NoActorSuffixRuleTest extends RuleTestCase
             [__DIR__ . '/../../../Fixtures/Rules/NoActorSuffixRule/UserDispatcher.php'],
             [
                 [
-                    'Class UserDispatcher must not end with actor suffix "Dispatcher". Classes are nouns, not procedures. Rename to a domain noun, or see README for when to extend allowedWords / excludedParentNamespaces.',
+                    'Class UserDispatcher must not end with actor suffix \'Dispatcher\'. Classes are nouns, not procedures. Rename to a domain noun, or see README for when to extend allowedWords / excludedParentNamespaces.',
                     7,
                 ],
             ],
@@ -79,7 +83,7 @@ final class NoActorSuffixRuleTest extends RuleTestCase
             [__DIR__ . '/../../../Fixtures/Rules/NoActorSuffixRule/UserOrchestrator.php'],
             [
                 [
-                    'Class UserOrchestrator must not end with actor suffix "Orchestrator". Classes are nouns, not procedures. Rename to a domain noun, or see README for when to extend allowedWords / excludedParentNamespaces.',
+                    'Class UserOrchestrator must not end with actor suffix \'Orchestrator\'. Classes are nouns, not procedures. Rename to a domain noun, or see README for when to extend allowedWords / excludedParentNamespaces.',
                     7,
                 ],
             ],
@@ -94,7 +98,7 @@ final class NoActorSuffixRuleTest extends RuleTestCase
             [__DIR__ . '/../../../Fixtures/Rules/NoActorSuffixRule/PaymentCoordinator.php'],
             [
                 [
-                    'Class PaymentCoordinator must not end with actor suffix "Coordinator". Classes are nouns, not procedures. Rename to a domain noun, or see README for when to extend allowedWords / excludedParentNamespaces.',
+                    'Class PaymentCoordinator must not end with actor suffix \'Coordinator\'. Classes are nouns, not procedures. Rename to a domain noun, or see README for when to extend allowedWords / excludedParentNamespaces.',
                     7,
                 ],
             ],
@@ -109,7 +113,7 @@ final class NoActorSuffixRuleTest extends RuleTestCase
             [__DIR__ . '/../../../Fixtures/Rules/NoActorSuffixRule/StandaloneController.php'],
             [
                 [
-                    'Class StandaloneController must not end with actor suffix "Controller". Classes are nouns, not procedures. Rename to a domain noun, or see README for when to extend allowedWords / excludedParentNamespaces.',
+                    'Class StandaloneController must not end with actor suffix \'Controller\'. Classes are nouns, not procedures. Rename to a domain noun, or see README for when to extend allowedWords / excludedParentNamespaces.',
                     7,
                 ],
             ],
@@ -171,9 +175,29 @@ final class NoActorSuffixRuleTest extends RuleTestCase
     public function passesWhenSuppressed(): void
     {
         $this->analyse(
-            [__DIR__ . '/../../../Fixtures/Rules/NoActorSuffixRule/SuppressedActor.php'],
+            [__DIR__ . '/../../../Fixtures/Rules/NoActorSuffixRule/SuppressedManager.php'],
             [],
             'A @phpstan-ignore haspadar.noActorSuffix comment must silence the report',
+        );
+    }
+
+    #[Test]
+    public function passesForInterfacesEvenWithActorSuffix(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NoActorSuffixRule/PaymentHandler.php'],
+            [],
+            'Interfaces are not Class_ nodes and must never be reported',
+        );
+    }
+
+    #[Test]
+    public function passesForTraitsEvenWithActorSuffix(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NoActorSuffixRule/OrderCreationTrigger.php'],
+            [],
+            'Traits are not Class_ nodes and must never be reported',
         );
     }
 }

--- a/tests/Unit/Rules/NoActorSuffixRule/NoActorSuffixRuleTest.php
+++ b/tests/Unit/Rules/NoActorSuffixRule/NoActorSuffixRuleTest.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\NoActorSuffixRule;
+
+use Haspadar\PHPStanRules\Rules\NoActorSuffixRule;
+use Override;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<NoActorSuffixRule> */
+final class NoActorSuffixRuleTest extends RuleTestCase
+{
+    #[Override]
+    protected function getRule(): Rule
+    {
+        return new NoActorSuffixRule(
+            $this->createReflectionProvider(),
+            [
+                'allowedWords' => [
+                    'User',
+                    'Order',
+                    'Number',
+                    'Member',
+                    'Owner',
+                    'Customer',
+                    'Folder',
+                    'Header',
+                    'Footer',
+                    'Buffer',
+                    'Layer',
+                    'Marker',
+                    'Parameter',
+                    'Character',
+                    'Identifier',
+                    'Integer',
+                    'Error',
+                    'Color',
+                    'Vendor',
+                    'Vector',
+                    'Factor',
+                    'Ancestor',
+                    'Descriptor',
+                ],
+                'excludedParentNamespaces' => [
+                    'Symfony\\',
+                    'Illuminate\\',
+                    'Doctrine\\',
+                    'Laminas\\',
+                    'Yii\\',
+                    'Laravel\\',
+                ],
+                'excludedClasses' => [],
+            ],
+        );
+    }
+
+    #[Test]
+    public function reportsActorSuffixEndingInEr(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NoActorSuffixRule/UserDispatcher.php'],
+            [
+                [
+                    'Class UserDispatcher must not end with actor suffix "Dispatcher". Classes are nouns, not procedures. Rename to a domain noun, or see README for when to extend allowedWords / excludedParentNamespaces.',
+                    7,
+                ],
+            ],
+            'A class ending in -er whose last word is not in allowedWords must be reported',
+        );
+    }
+
+    #[Test]
+    public function reportsActorSuffixEndingInOr(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NoActorSuffixRule/UserOrchestrator.php'],
+            [
+                [
+                    'Class UserOrchestrator must not end with actor suffix "Orchestrator". Classes are nouns, not procedures. Rename to a domain noun, or see README for when to extend allowedWords / excludedParentNamespaces.',
+                    7,
+                ],
+            ],
+            'A class ending in -or whose last word is not in allowedWords must be reported',
+        );
+    }
+
+    #[Test]
+    public function reportsAnotherActorSuffixEndingInOr(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NoActorSuffixRule/PaymentCoordinator.php'],
+            [
+                [
+                    'Class PaymentCoordinator must not end with actor suffix "Coordinator". Classes are nouns, not procedures. Rename to a domain noun, or see README for when to extend allowedWords / excludedParentNamespaces.',
+                    7,
+                ],
+            ],
+            'Every class ending in -or must be reported individually',
+        );
+    }
+
+    #[Test]
+    public function reportsControllerWithoutFrameworkBase(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NoActorSuffixRule/StandaloneController.php'],
+            [
+                [
+                    'Class StandaloneController must not end with actor suffix "Controller". Classes are nouns, not procedures. Rename to a domain noun, or see README for when to extend allowedWords / excludedParentNamespaces.',
+                    7,
+                ],
+            ],
+            'A class named Controller without a framework base must be reported',
+        );
+    }
+
+    #[Test]
+    public function passesWhenLastWordIsInAllowedWords(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NoActorSuffixRule/User.php'],
+            [],
+            'A class whose name matches an entry in allowedWords must pass',
+        );
+    }
+
+    #[Test]
+    public function passesWhenLastPascalCaseWordIsInAllowedWords(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NoActorSuffixRule/OrderNumber.php'],
+            [],
+            'A compound class name must be split into PascalCase words and matched by the last one',
+        );
+    }
+
+    #[Test]
+    public function passesWhenLastWordIsHeader(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NoActorSuffixRule/HttpHeader.php'],
+            [],
+            'A compound class name ending with an allowed word must pass',
+        );
+    }
+
+    #[Test]
+    public function passesWhenClassNameDoesNotEndInErOrOr(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NoActorSuffixRule/Money.php'],
+            [],
+            'Classes without -er/-or suffix are outside this rule scope',
+        );
+    }
+
+    #[Test]
+    public function passesForAnonymousClasses(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NoActorSuffixRule/AnonymousClassCall.php'],
+            [],
+            'Anonymous classes are never reported',
+        );
+    }
+
+    #[Test]
+    public function passesWhenSuppressed(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NoActorSuffixRule/SuppressedActor.php'],
+            [],
+            'A @phpstan-ignore haspadar.noActorSuffix comment must silence the report',
+        );
+    }
+}

--- a/tests/Unit/RulesTest.php
+++ b/tests/Unit/RulesTest.php
@@ -66,6 +66,7 @@ use Haspadar\PHPStanRules\Rules\InheritanceDepthRule;
 use Haspadar\PHPStanRules\Rules\InstabilityRule;
 use Haspadar\PHPStanRules\Rules\PhpDocParamOrderRule;
 use Haspadar\PHPStanRules\Rules\LackOfCohesionRule;
+use Haspadar\PHPStanRules\Rules\NoActorSuffixRule;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -137,6 +138,7 @@ final class RulesTest extends TestCase
                 InheritanceDepthRule::class,
                 LackOfCohesionRule::class,
                 InstabilityRule::class,
+                NoActorSuffixRule::class,
             ],
             (new Rules())->all(),
             'Rules::all() must list every registered rule class',


### PR DESCRIPTION
- Added NoActorSuffixRule checking classes ending in -er or -or against a whitelist of real noun-entities
- Added framework-namespace exclusion via excludedParentNamespaces for Symfony, Illuminate, Doctrine, Laminas, Yii, Laravel prefixes
- Added excludedClasses option for point-wise FQCN exclusions
- Updated README with configuration example and guidance on extending allowedWords vs renaming

Closes #162

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added NoActorSuffixRule to detect class names ending in actor-like suffixes (-er/-or) with configurable allowed words, excluded classes, and excluded parent namespaces.

* **Documentation**
  * Expanded guide with configuration examples and resolution workflow for addressing actor suffixes.

* **Tests**
  * Added comprehensive unit tests and fixtures covering allowed words, exclusions, framework ancestry, anonymous classes, interfaces/traits, and suppression behavior.

* **Chores**
  * Updated development autoloading so test fixtures and vendor stubs are discoverable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->