### PR TITLE
Own Missing @throws Rule For Overridden Methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,9 +292,11 @@ Rule of thumb: if the suffix describes *what the class is*, extend `allowedWords
 
 ### MissingThrowsRule — @throws inheritance for overridden methods
 
-This rule replaces PHPStan's built-in `exceptions.check.missingCheckedExceptionInThrows` so that methods overriding a parent class or implementing an interface do not have to repeat `@throws` from the parent contract.
+This rule replaces PHPStan's built-in `exceptions.check.missingCheckedExceptionInThrows` for class methods so that overrides and interface implementations do not have to repeat `@throws` from the parent contract.
 
-Including `rules.neon` from this package automatically sets `exceptions.check.missingCheckedExceptionInThrows: false` — the built-in check is replaced by `haspadar.missingThrows`. Override this explicitly in your `phpstan.neon` if you need both.
+Including `rules.neon` from this package automatically sets `exceptions.check.missingCheckedExceptionInThrows: false` — the built-in check is turned off and replaced by `haspadar.missingThrows`. Do **not** re-enable the built-in flag in your own `phpstan.neon`: both rules will then fire on the same code and you will receive duplicate errors.
+
+Current scope: only class methods are covered. Standalone functions and PHP 8.4 property hooks are not yet checked by `haspadar.missingThrows`; if your codebase needs `@throws` enforcement there, keep those analyses through separate means until the corresponding rules are shipped.
 
 - `skipOverridden: true` (default) — overridden/interface-implementing methods inherit `@throws` from the parent and are not required to declare it themselves.
 - `skipOverridden: false` — every method must declare `@throws` for every checked exception it throws, including overrides.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@
 | `ConstantUsageRule`           | Magic numbers and strings must be defined as named constants                  |
 | `StringLiteralsConcatenationRule` | String literal concatenation via `.` or `.=` is forbidden                |
 | `TodoCommentRule`             | TODO, FIXME, and XXX comments are forbidden in method bodies                  |
+| `MissingThrowsRule`           | Methods must declare `@throws` for every checked exception they throw (overridden methods inherit by default) |
 
 ### Naming
 
@@ -255,6 +256,8 @@ parameters:
                 - 'Laravel\'
             excludedClasses:
                 - App\Legacy\UserManager
+        missingThrows:
+            skipOverridden: true
         afferentCoupling:
             maxAfferent: 10
             ignoreInterfaces: true
@@ -286,6 +289,15 @@ When the rule reports a class like `UserDispatcher`, pick one of three fixes:
 Rule of thumb: if the suffix describes *what the class is*, extend `allowedWords`. If it describes *what the class does*, rename.
 
 `allowedWords` is matched **case-sensitively** against the last PascalCase segment of the class name. PHP class names follow PascalCase convention, so entries must be capitalized (`User`, not `user`).
+
+### MissingThrowsRule — @throws inheritance for overridden methods
+
+This rule replaces PHPStan's built-in `exceptions.check.missingCheckedExceptionInThrows` so that methods overriding a parent class or implementing an interface do not have to repeat `@throws` from the parent contract.
+
+Including `rules.neon` from this package automatically sets `exceptions.check.missingCheckedExceptionInThrows: false` — the built-in check is replaced by `haspadar.missingThrows`. Override this explicitly in your `phpstan.neon` if you need both.
+
+- `skipOverridden: true` (default) — overridden/interface-implementing methods inherit `@throws` from the parent and are not required to declare it themselves.
+- `skipOverridden: false` — every method must declare `@throws` for every checked exception it throws, including overrides.
 
 ---
 

--- a/rules.neon
+++ b/rules.neon
@@ -164,6 +164,11 @@ parameters:
                 - 'Yii\'
                 - 'Laravel\'
             excludedClasses: []
+        missingThrows:
+            skipOverridden: true
+    exceptions:
+        check:
+            missingCheckedExceptionInThrows: false
 
 parametersSchema:
     haspadar: structure([
@@ -302,6 +307,9 @@ parametersSchema:
             allowedWords: listOf(string()),
             excludedParentNamespaces: listOf(string()),
             excludedClasses: listOf(string()),
+        ]),
+        missingThrows: structure([
+            skipOverridden: bool(),
         ]),
     ])
 
@@ -680,5 +688,12 @@ services:
                 allowedWords: %haspadar.noActorSuffix.allowedWords%
                 excludedParentNamespaces: %haspadar.noActorSuffix.excludedParentNamespaces%
                 excludedClasses: %haspadar.noActorSuffix.excludedClasses%
+        tags:
+            - phpstan.rules.rule
+    -
+        class: Haspadar\PHPStanRules\Rules\MissingThrowsRule
+        arguments:
+            options:
+                skipOverridden: %haspadar.missingThrows.skipOverridden%
         tags:
             - phpstan.rules.rule

--- a/src/Rules.php
+++ b/src/Rules.php
@@ -72,6 +72,7 @@ final class Rules
         Rules\LackOfCohesionRule::class,
         Rules\InstabilityRule::class,
         Rules\NoActorSuffixRule::class,
+        Rules\MissingThrowsRule::class,
     ];
 
     /**

--- a/src/Rules/MissingThrowsRule.php
+++ b/src/Rules/MissingThrowsRule.php
@@ -9,6 +9,7 @@ use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Node\MethodReturnStatementsNode;
 use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\MissingMethodFromReflectionException;
 use PHPStan\Rules\Exceptions\MissingCheckedExceptionInThrowsCheck;
 use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\Rule;
@@ -53,6 +54,7 @@ final readonly class MissingThrowsRule implements Rule
      * Analyses the node and returns a list of errors.
      *
      * @psalm-param MethodReturnStatementsNode $node
+     * @throws MissingMethodFromReflectionException
      * @throws ShouldNotHappenException
      * @return list<IdentifierRuleError>
      */
@@ -93,6 +95,12 @@ final readonly class MissingThrowsRule implements Rule
 
     /**
      * Returns true if the method exists on any parent class or implemented interface.
+     *
+     * Private parent methods do not count as inherited because PHP treats them
+     * as independent declarations. Only non-private ancestor methods establish
+     * an override relationship from which @throws can be inherited.
+     *
+     * @throws MissingMethodFromReflectionException
      */
     private function isOverridden(MethodReflection $method): bool
     {
@@ -100,7 +108,7 @@ final readonly class MissingThrowsRule implements Rule
         $name = $method->getName();
         $parent = $declaringClass->getParentClass();
 
-        if ($parent !== null && $parent->hasMethod($name)) {
+        if ($parent !== null && $parent->hasMethod($name) && !$parent->getNativeMethod($name)->isPrivate()) {
             return true;
         }
 

--- a/src/Rules/MissingThrowsRule.php
+++ b/src/Rules/MissingThrowsRule.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Rules;
+
+use Override;
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\MethodReturnStatementsNode;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Rules\Exceptions\MissingCheckedExceptionInThrowsCheck;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\ShouldNotHappenException;
+
+/**
+ * Reports methods that throw a checked exception missing from the PHPDoc @throws tag.
+ *
+ * Replaces the built-in exceptions.check.missingCheckedExceptionInThrows so that
+ * overridden methods (those whose name exists on a parent class or implemented
+ * interface) inherit @throws from the parent contract and do not have to repeat
+ * it. Delegates the actual detection to PHPStan's MissingCheckedExceptionInThrowsCheck
+ * helper so the sophisticated throw-point collection stays in PHPStan core.
+ *
+ * @implements Rule<MethodReturnStatementsNode>
+ */
+final readonly class MissingThrowsRule implements Rule
+{
+    private bool $skipOverridden;
+
+    /**
+     * Constructs the rule with the shared PHPStan throw-check helper and configuration options.
+     *
+     * @param MissingCheckedExceptionInThrowsCheck $check Shared throw-point check from PHPStan core
+     * @param array{skipOverridden?: bool} $options When skipOverridden is true, methods that override a parent or implement an interface method are skipped
+     */
+    public function __construct(
+        private MissingCheckedExceptionInThrowsCheck $check,
+        array $options = [],
+    ) {
+        $this->skipOverridden = $options['skipOverridden'] ?? true;
+    }
+
+    #[Override]
+    public function getNodeType(): string
+    {
+        return MethodReturnStatementsNode::class;
+    }
+
+    /**
+     * Analyses the node and returns a list of errors.
+     *
+     * @psalm-param MethodReturnStatementsNode $node
+     * @throws ShouldNotHappenException
+     * @return list<IdentifierRuleError>
+     */
+    #[Override]
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $method = $node->getMethodReflection();
+
+        if ($this->skipOverridden && $this->isOverridden($method)) {
+            return [];
+        }
+
+        $errors = [];
+        $throwPoints = $node->getStatementResult()->getThrowPoints();
+
+        /** @phpstan-ignore phpstanApi.method */
+        $missing = $this->check->check(
+            $method->getThrowType(),
+            $throwPoints,
+        );
+
+        foreach ($missing as [$className, $throwPointNode]) {
+            $errors[] = RuleErrorBuilder::message(
+                sprintf(
+                    "Method %s::%s() throws checked exception %s but it's missing from the PHPDoc @throws tag.",
+                    $method->getDeclaringClass()->getDisplayName(),
+                    $method->getName(),
+                    $className,
+                ),
+            )
+                ->line($throwPointNode->getStartLine())
+                ->identifier('haspadar.missingThrows')
+                ->build();
+        }
+
+        return $errors;
+    }
+
+    /**
+     * Returns true if the method exists on any parent class or implemented interface.
+     */
+    private function isOverridden(MethodReflection $method): bool
+    {
+        $declaringClass = $method->getDeclaringClass();
+        $name = $method->getName();
+        $parent = $declaringClass->getParentClass();
+
+        if ($parent !== null && $parent->hasMethod($name)) {
+            return true;
+        }
+
+        foreach ($declaringClass->getInterfaces() as $interface) {
+            if ($interface->hasMethod($name)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/Fixtures/Rules/MissingThrowsRule/HasRunMethod.php
+++ b/tests/Fixtures/Rules/MissingThrowsRule/HasRunMethod.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\MissingThrowsRule;
+
+interface HasRunMethod
+{
+    public function run(): void;
+}

--- a/tests/Fixtures/Rules/MissingThrowsRule/InterfaceImplementationWithoutDeclaration.php
+++ b/tests/Fixtures/Rules/MissingThrowsRule/InterfaceImplementationWithoutDeclaration.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\MissingThrowsRule;
+
+final class InterfaceImplementationWithoutDeclaration implements HasRunMethod
+{
+    public function run(): void
+    {
+        throw new \RuntimeException();
+    }
+}

--- a/tests/Fixtures/Rules/MissingThrowsRule/NoThrowMethod.php
+++ b/tests/Fixtures/Rules/MissingThrowsRule/NoThrowMethod.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\MissingThrowsRule;
+
+final class NoThrowMethod
+{
+    public function run(): void
+    {
+    }
+}

--- a/tests/Fixtures/Rules/MissingThrowsRule/OverriddenMethodWithoutDeclaration.php
+++ b/tests/Fixtures/Rules/MissingThrowsRule/OverriddenMethodWithoutDeclaration.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\MissingThrowsRule;
+
+use Override;
+
+final class OverriddenMethodWithoutDeclaration extends ParentWithRunMethod
+{
+    #[Override]
+    public function run(): void
+    {
+        throw new \RuntimeException();
+    }
+}

--- a/tests/Fixtures/Rules/MissingThrowsRule/ParentWithRunMethod.php
+++ b/tests/Fixtures/Rules/MissingThrowsRule/ParentWithRunMethod.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\MissingThrowsRule;
+
+abstract class ParentWithRunMethod
+{
+    public function run(): void
+    {
+    }
+}

--- a/tests/Fixtures/Rules/MissingThrowsRule/SuppressedMissingThrows.php
+++ b/tests/Fixtures/Rules/MissingThrowsRule/SuppressedMissingThrows.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\MissingThrowsRule;
+
+final class SuppressedMissingThrows
+{
+    public function run(): void
+    {
+        /** @phpstan-ignore haspadar.missingThrows */
+        throw new \RuntimeException();
+    }
+}

--- a/tests/Fixtures/Rules/MissingThrowsRule/ThrowsExceptionWithDeclaration.php
+++ b/tests/Fixtures/Rules/MissingThrowsRule/ThrowsExceptionWithDeclaration.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\MissingThrowsRule;
+
+final class ThrowsExceptionWithDeclaration
+{
+    /**
+     * @throws \RuntimeException
+     */
+    public function run(): void
+    {
+        throw new \RuntimeException();
+    }
+}

--- a/tests/Fixtures/Rules/MissingThrowsRule/ThrowsExceptionWithoutDeclaration.php
+++ b/tests/Fixtures/Rules/MissingThrowsRule/ThrowsExceptionWithoutDeclaration.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\MissingThrowsRule;
+
+final class ThrowsExceptionWithoutDeclaration
+{
+    public function run(): void
+    {
+        throw new \RuntimeException();
+    }
+}

--- a/tests/Unit/Rules/MissingThrowsRule/MissingThrowsRuleSkipOverriddenDisabledTest.php
+++ b/tests/Unit/Rules/MissingThrowsRule/MissingThrowsRuleSkipOverriddenDisabledTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\MissingThrowsRule;
+
+use Haspadar\PHPStanRules\Rules\MissingThrowsRule;
+use Override;
+use PHPStan\Rules\Exceptions\MissingCheckedExceptionInThrowsCheck;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<MissingThrowsRule> */
+final class MissingThrowsRuleSkipOverriddenDisabledTest extends RuleTestCase
+{
+    #[Override]
+    protected function getRule(): Rule
+    {
+        return new MissingThrowsRule(
+            self::getContainer()->getByType(MissingCheckedExceptionInThrowsCheck::class),
+            ['skipOverridden' => false],
+        );
+    }
+
+    #[Test]
+    public function reportsOverriddenMethodThrowWithoutDeclaration(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/../../../Fixtures/Rules/MissingThrowsRule/ParentWithRunMethod.php',
+                __DIR__ . '/../../../Fixtures/Rules/MissingThrowsRule/OverriddenMethodWithoutDeclaration.php',
+            ],
+            [
+                [
+                    "Method Haspadar\\PHPStanRules\\Tests\\Fixtures\\Rules\\MissingThrowsRule\\OverriddenMethodWithoutDeclaration::run() throws checked exception RuntimeException but it's missing from the PHPDoc @throws tag.",
+                    14,
+                ],
+            ],
+            'With skipOverridden disabled, an overridden method must be reported like any other',
+        );
+    }
+}

--- a/tests/Unit/Rules/MissingThrowsRule/MissingThrowsRuleTest.php
+++ b/tests/Unit/Rules/MissingThrowsRule/MissingThrowsRuleTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\MissingThrowsRule;
+
+use Haspadar\PHPStanRules\Rules\MissingThrowsRule;
+use Override;
+use PHPStan\Rules\Exceptions\MissingCheckedExceptionInThrowsCheck;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<MissingThrowsRule> */
+final class MissingThrowsRuleTest extends RuleTestCase
+{
+    #[Override]
+    protected function getRule(): Rule
+    {
+        return new MissingThrowsRule(
+            self::getContainer()->getByType(MissingCheckedExceptionInThrowsCheck::class),
+            ['skipOverridden' => true],
+        );
+    }
+
+    #[Test]
+    public function reportsThrowWithoutDeclaration(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/MissingThrowsRule/ThrowsExceptionWithoutDeclaration.php'],
+            [
+                [
+                    "Method Haspadar\\PHPStanRules\\Tests\\Fixtures\\Rules\\MissingThrowsRule\\ThrowsExceptionWithoutDeclaration::run() throws checked exception RuntimeException but it's missing from the PHPDoc @throws tag.",
+                    11,
+                ],
+            ],
+            'A method that throws a checked exception without @throws must be reported',
+        );
+    }
+
+    #[Test]
+    public function passesWhenThrowIsDeclared(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/MissingThrowsRule/ThrowsExceptionWithDeclaration.php'],
+            [],
+            'A method that declares @throws for the exception it throws must pass',
+        );
+    }
+
+    #[Test]
+    public function passesWhenMethodDoesNotThrow(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/MissingThrowsRule/NoThrowMethod.php'],
+            [],
+            'A method that throws nothing needs no @throws tag',
+        );
+    }
+
+    #[Test]
+    public function passesForOverriddenMethodOfParentClass(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/../../../Fixtures/Rules/MissingThrowsRule/ParentWithRunMethod.php',
+                __DIR__ . '/../../../Fixtures/Rules/MissingThrowsRule/OverriddenMethodWithoutDeclaration.php',
+            ],
+            [],
+            'An overridden method must inherit @throws from its parent by default',
+        );
+    }
+
+    #[Test]
+    public function passesForInterfaceImplementationMethod(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/../../../Fixtures/Rules/MissingThrowsRule/HasRunMethod.php',
+                __DIR__ . '/../../../Fixtures/Rules/MissingThrowsRule/InterfaceImplementationWithoutDeclaration.php',
+            ],
+            [],
+            'A method implementing an interface must inherit @throws from the interface by default',
+        );
+    }
+
+    #[Test]
+    public function passesWhenSuppressed(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/MissingThrowsRule/SuppressedMissingThrows.php'],
+            [],
+            'A @phpstan-ignore haspadar.missingThrows comment must silence the report',
+        );
+    }
+}

--- a/tests/Unit/RulesTest.php
+++ b/tests/Unit/RulesTest.php
@@ -67,6 +67,7 @@ use Haspadar\PHPStanRules\Rules\InstabilityRule;
 use Haspadar\PHPStanRules\Rules\PhpDocParamOrderRule;
 use Haspadar\PHPStanRules\Rules\LackOfCohesionRule;
 use Haspadar\PHPStanRules\Rules\NoActorSuffixRule;
+use Haspadar\PHPStanRules\Rules\MissingThrowsRule;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -139,6 +140,7 @@ final class RulesTest extends TestCase
                 LackOfCohesionRule::class,
                 InstabilityRule::class,
                 NoActorSuffixRule::class,
+                MissingThrowsRule::class,
             ],
             (new Rules())->all(),
             'Rules::all() must list every registered rule class',


### PR DESCRIPTION
- Added MissingThrowsRule reusing PHPStan's MissingCheckedExceptionInThrowsCheck helper
- Added skipOverridden option (default true) to inherit @throws from parent class or interface
- Updated rules.neon to disable the built-in exceptions.check.missingCheckedExceptionInThrows
- Updated README to warn against re-enabling the built-in flag alongside haspadar.missingThrows

Closes #164