### PR TITLE
Detect Local Variable Or Parameter Shadowing A Class Property

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@
 | `StringLiteralsConcatenationRule` | String literal concatenation via `.` or `.=` is forbidden                |
 | `TodoCommentRule`             | TODO, FIXME, and XXX comments are forbidden in method bodies                  |
 | `MissingThrowsRule`           | Methods must declare `@throws` for every checked exception they throw (overridden methods inherit by default) |
-| `HiddenFieldRule`             | Method parameter or local variable must not shadow a class property (promoted constructors excluded) |
+| `HiddenFieldRule`             | Method parameter or local variable must not shadow a class property (promoted constructors excluded, parameter takes precedence over local of the same name) |
 
 ### Naming
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@
 | `StringLiteralsConcatenationRule` | String literal concatenation via `.` or `.=` is forbidden                |
 | `TodoCommentRule`             | TODO, FIXME, and XXX comments are forbidden in method bodies                  |
 | `MissingThrowsRule`           | Methods must declare `@throws` for every checked exception they throw (overridden methods inherit by default) |
+| `HiddenFieldRule`             | Method parameter or local variable must not shadow a class property (promoted constructors excluded) |
 
 ### Naming
 
@@ -258,6 +259,11 @@ parameters:
                 - App\Legacy\UserManager
         missingThrows:
             skipOverridden: true
+        hiddenField:
+            ignoreConstructorParameter: true
+            ignoreAbstractMethods: false
+            ignoreSetter: false
+            ignoreNames: []
         afferentCoupling:
             maxAfferent: 10
             ignoreInterfaces: true

--- a/rules-ignore.neon
+++ b/rules-ignore.neon
@@ -20,6 +20,7 @@ parameters:
             identifier: haspadar.lackOfCohesion
             paths:
                 - src/Rules/CouplingBetweenObjectsRule.php
+                - src/Rules/HiddenFieldRule.php
                 - src/Rules/MethodLengthRule.php
         -
             identifier: haspadar.noActorSuffix
@@ -29,6 +30,8 @@ parameters:
                 - src/Rules/ConstantUsage/ExemptScalarCollector.php
                 - src/Rules/CouplingBetweenObjectsRule/MethodBodyTypeCollector.php
                 - src/Rules/CouplingBetweenObjectsRule/TypeNameExtractor.php
+                - src/Rules/HiddenFieldRule/LocalAssignmentCollector.php
+                - src/Rules/HiddenFieldRule/ParamShadowDetector.php
                 - src/Rules/Internal/BuiltinCallDetector.php
                 - src/Rules/LackOfCohesionRule/AdjacencyBuilder.php
                 - src/Rules/PhpDocDescriptionChecker.php

--- a/rules.neon
+++ b/rules.neon
@@ -166,6 +166,11 @@ parameters:
             excludedClasses: []
         missingThrows:
             skipOverridden: true
+        hiddenField:
+            ignoreConstructorParameter: true
+            ignoreAbstractMethods: false
+            ignoreSetter: false
+            ignoreNames: []
     exceptions:
         check:
             missingCheckedExceptionInThrows: false
@@ -310,6 +315,12 @@ parametersSchema:
         ]),
         missingThrows: structure([
             skipOverridden: bool(),
+        ]),
+        hiddenField: structure([
+            ignoreConstructorParameter: bool(),
+            ignoreAbstractMethods: bool(),
+            ignoreSetter: bool(),
+            ignoreNames: listOf(string()),
         ]),
     ])
 
@@ -695,5 +706,19 @@ services:
         arguments:
             options:
                 skipOverridden: %haspadar.missingThrows.skipOverridden%
+        tags:
+            - phpstan.rules.rule
+    -
+        class: Haspadar\PHPStanRules\Rules\HiddenFieldRule\LocalAssignmentCollector
+    -
+        class: Haspadar\PHPStanRules\Rules\HiddenFieldRule\ParamShadowDetector
+    -
+        class: Haspadar\PHPStanRules\Rules\HiddenFieldRule
+        arguments:
+            options:
+                ignoreConstructorParameter: %haspadar.hiddenField.ignoreConstructorParameter%
+                ignoreAbstractMethods: %haspadar.hiddenField.ignoreAbstractMethods%
+                ignoreSetter: %haspadar.hiddenField.ignoreSetter%
+                ignoreNames: %haspadar.hiddenField.ignoreNames%
         tags:
             - phpstan.rules.rule

--- a/src/Rules.php
+++ b/src/Rules.php
@@ -73,6 +73,7 @@ final class Rules
         Rules\InstabilityRule::class,
         Rules\NoActorSuffixRule::class,
         Rules\MissingThrowsRule::class,
+        Rules\HiddenFieldRule::class,
     ];
 
     /**

--- a/src/Rules/HiddenFieldRule.php
+++ b/src/Rules/HiddenFieldRule.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Rules;
+
+use Haspadar\PHPStanRules\Rules\HiddenFieldRule\LocalAssignmentCollector;
+use Haspadar\PHPStanRules\Rules\HiddenFieldRule\ParamShadowDetector;
+use Override;
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\ShouldNotHappenException;
+
+/**
+ * Detects parameters and local variables that shadow a class property.
+ *
+ * A parameter whose name matches a property of the enclosing class, or a
+ * local `$var = ...` assignment using such a name, is reported. Promoted
+ * constructor parameters are excluded since they are the property, not a
+ * shadow. Locals inside nested closures, arrow functions, other functions,
+ * and anonymous classes belong to a different scope and are not inspected.
+ *
+ * @implements Rule<ClassMethod>
+ */
+final readonly class HiddenFieldRule implements Rule
+{
+    private bool $ignoreConstructorParameter;
+
+    private bool $ignoreAbstractMethods;
+
+    private bool $ignoreSetter;
+
+    /** @var list<string> */
+    private array $ignoreNames;
+
+    /**
+     * Constructs the rule with collaborators and configuration options.
+     *
+     * @param LocalAssignmentCollector $collector Collects top-level $var=... assignments from a method body
+     * @param ParamShadowDetector $paramDetector Inspects method parameters for shadowing names
+     * @param array{
+     *     ignoreConstructorParameter?: bool,
+     *     ignoreAbstractMethods?: bool,
+     *     ignoreSetter?: bool,
+     *     ignoreNames?: list<string>
+     * } $options Flags that exempt constructor, abstract, setter, and named parameters or locals from the shadow check
+     */
+    public function __construct(
+        private LocalAssignmentCollector $collector,
+        private ParamShadowDetector $paramDetector,
+        array $options = [],
+    ) {
+        $this->ignoreConstructorParameter = $options['ignoreConstructorParameter'] ?? true;
+        $this->ignoreAbstractMethods = $options['ignoreAbstractMethods'] ?? false;
+        $this->ignoreSetter = $options['ignoreSetter'] ?? false;
+        $this->ignoreNames = $options['ignoreNames'] ?? [];
+    }
+
+    #[Override]
+    public function getNodeType(): string
+    {
+        return ClassMethod::class;
+    }
+
+    /**
+     * Analyses the node and returns a list of errors.
+     *
+     * @psalm-param ClassMethod $node
+     * @throws ShouldNotHappenException
+     * @return list<IdentifierRuleError>
+     */
+    #[Override]
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if ($this->shouldSkipMethod($node, $scope)) {
+            return [];
+        }
+
+        $classReflection = $scope->getClassReflection();
+        assert($classReflection !== null);
+        $propertyNames = $this->collectPropertyNames($classReflection);
+
+        if ($propertyNames === []) {
+            return [];
+        }
+
+        $context = [
+            'className' => $classReflection->getDisplayName(),
+            'methodName' => $node->name->toString(),
+            'propertyNames' => $propertyNames,
+        ];
+
+        return [
+            ...$this->paramErrors($node, $context),
+            ...$this->localErrors($node, $context),
+        ];
+    }
+
+    /**
+     * Returns true if the method should not be analysed at all.
+     */
+    private function shouldSkipMethod(ClassMethod $node, Scope $scope): bool
+    {
+        if ($scope->getClassReflection() === null) {
+            return true;
+        }
+
+        if ($this->ignoreAbstractMethods && $node->isAbstract()) {
+            return true;
+        }
+
+        return $this->ignoreSetter && $this->looksLikeSetter($node->name->toString());
+    }
+
+    /**
+     * Reports parameters that shadow a property.
+     *
+     * @param array{className: string, methodName: string, propertyNames: list<string>} $context
+     * @throws ShouldNotHappenException
+     * @return list<IdentifierRuleError>
+     */
+    private function paramErrors(ClassMethod $node, array $context): array
+    {
+        if ($context['methodName'] === '__construct' && $this->ignoreConstructorParameter) {
+            return [];
+        }
+
+        $errors = [];
+
+        foreach ($this->paramDetector->detect($node, $context['propertyNames'], $this->ignoreNames) as [$name, $line]) {
+            $errors[] = $this->buildError(
+                sprintf(
+                    'Parameter $%s in %s::%s() shadows property of the same name. Rename to avoid the name collision.',
+                    $name,
+                    $context['className'],
+                    $context['methodName'],
+                ),
+                $line,
+            );
+        }
+
+        return $errors;
+    }
+
+    /**
+     * Reports local variables that shadow a property.
+     *
+     * @param array{className: string, methodName: string, propertyNames: list<string>} $context
+     * @throws ShouldNotHappenException
+     * @return list<IdentifierRuleError>
+     */
+    private function localErrors(ClassMethod $node, array $context): array
+    {
+        $skip = array_merge($this->paramDetector->paramNames($node), $this->ignoreNames);
+        $errors = [];
+
+        foreach ($this->collector->collect($node) as [$varName, $line]) {
+            if (!in_array($varName, $context['propertyNames'], true) || in_array($varName, $skip, true)) {
+                continue;
+            }
+
+            $errors[] = $this->buildError(
+                sprintf(
+                    'Local variable $%s in %s::%s() shadows property of the same name. Rename to avoid the name collision.',
+                    $varName,
+                    $context['className'],
+                    $context['methodName'],
+                ),
+                $line,
+            );
+        }
+
+        return $errors;
+    }
+
+    /**
+     * Builds a PHPStan error with the rule identifier and line.
+     *
+     * @throws ShouldNotHappenException
+     */
+    private function buildError(string $message, int $line): IdentifierRuleError
+    {
+        return RuleErrorBuilder::message($message)
+            ->identifier('haspadar.hiddenField')
+            ->line($line)
+            ->build();
+    }
+
+    /**
+     * Returns native property names declared on the class (both non-static and static).
+     *
+     * @return list<string>
+     */
+    private function collectPropertyNames(ClassReflection $classReflection): array
+    {
+        $names = [];
+
+        foreach ($classReflection->getNativeReflection()->getProperties() as $property) {
+            if ($property->getDeclaringClass()->getName() !== $classReflection->getName()) {
+                continue;
+            }
+
+            $names[] = $property->getName();
+        }
+
+        return $names;
+    }
+
+    /**
+     * Returns true if the method name looks like a setter (setX convention).
+     */
+    private function looksLikeSetter(string $methodName): bool
+    {
+        return preg_match('/^set[A-Z]/', $methodName) === 1;
+    }
+}

--- a/src/Rules/HiddenFieldRule/LocalAssignmentCollector.php
+++ b/src/Rules/HiddenFieldRule/LocalAssignmentCollector.php
@@ -36,16 +36,14 @@ final readonly class LocalAssignmentCollector
         }
 
         $finder = new NodeFinder();
+
+        /** @var list<Assign> $assignments */
         $assignments = $finder->find($node->stmts, static fn(Node $inner): bool => $inner instanceof Assign);
 
         $seen = [];
         $result = [];
 
         foreach ($assignments as $assign) {
-            if (!$assign instanceof Assign) {
-                continue;
-            }
-
             if (!$assign->var instanceof Variable || !is_string($assign->var->name)) {
                 continue;
             }

--- a/src/Rules/HiddenFieldRule/LocalAssignmentCollector.php
+++ b/src/Rules/HiddenFieldRule/LocalAssignmentCollector.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Rules\HiddenFieldRule;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\ArrowFunction;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Function_;
+use PhpParser\NodeFinder;
+
+/**
+ * Collects `$var = ...` assignments from a method body, excluding nested scopes.
+ *
+ * Nested scopes here mean closures, arrow functions, nested function declarations,
+ * and anonymous classes — their locals belong to a different scope and must not
+ * count as shadows of the outer class properties.
+ */
+final readonly class LocalAssignmentCollector
+{
+    /**
+     * Returns distinct [varName, line] pairs for top-level assignments in the method body.
+     *
+     * @param ClassMethod $node Method AST node whose body is scanned for top-level `$var = ...` assignments
+     * @return list<array{0: string, 1: int}>
+     */
+    public function collect(ClassMethod $node): array
+    {
+        if ($node->stmts === null) {
+            return [];
+        }
+
+        $finder = new NodeFinder();
+        $assignments = $finder->find($node->stmts, static fn(Node $inner): bool => $inner instanceof Assign);
+
+        $seen = [];
+        $result = [];
+
+        foreach ($assignments as $assign) {
+            if (!$assign instanceof Assign) {
+                continue;
+            }
+
+            if (!$assign->var instanceof Variable || !is_string($assign->var->name)) {
+                continue;
+            }
+
+            if ($this->isInsideNestedScope($assign, $node)) {
+                continue;
+            }
+
+            $varName = $assign->var->name;
+
+            if (array_key_exists($varName, $seen)) {
+                continue;
+            }
+
+            $seen[$varName] = true;
+            $result[] = [$varName, $assign->getStartLine()];
+        }
+
+        return $result;
+    }
+
+    /**
+     * Returns true if the assignment is enclosed by a closure, arrow function, nested function, or anonymous class within the method.
+     */
+    private function isInsideNestedScope(Assign $assign, ClassMethod $method): bool
+    {
+        $finder = new NodeFinder();
+        $boundaries = $finder->find(
+            $method->stmts ?? [],
+            static fn(Node $outer): bool => ($outer instanceof Closure
+                || $outer instanceof ArrowFunction
+                || $outer instanceof Function_
+                || $outer instanceof Class_)
+                && (new NodeFinder())->findFirst([$outer], static fn(Node $inner): bool => $inner === $assign) !== null,
+        );
+
+        return $boundaries !== [];
+    }
+}

--- a/src/Rules/HiddenFieldRule/ParamShadowDetector.php
+++ b/src/Rules/HiddenFieldRule/ParamShadowDetector.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Rules\HiddenFieldRule;
+
+use PhpParser\Modifiers;
+use PhpParser\Node;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Stmt\ClassMethod;
+
+/**
+ * Inspects method parameters for names that shadow class properties.
+ */
+final readonly class ParamShadowDetector
+{
+    /**
+     * Returns [paramName, line] pairs for parameters that shadow a property.
+     *
+     * Promoted parameters are the property itself and never count as shadows.
+     *
+     * @param ClassMethod $node Method being scanned
+     * @param list<string> $propertyNames Names of properties declared on the class
+     * @param list<string> $ignoreNames Names to skip even if they match
+     * @return list<array{0: string, 1: int}>
+     */
+    public function detect(ClassMethod $node, array $propertyNames, array $ignoreNames): array
+    {
+        $result = [];
+
+        foreach ($node->params as $param) {
+            if ($this->isPromoted($param)) {
+                continue;
+            }
+
+            if (!$param->var instanceof Variable || !is_string($param->var->name)) {
+                continue;
+            }
+
+            $name = $param->var->name;
+
+            if (in_array($name, $ignoreNames, true) || !in_array($name, $propertyNames, true)) {
+                continue;
+            }
+
+            $result[] = [$name, $param->getStartLine()];
+        }
+
+        return $result;
+    }
+
+    /**
+     * Returns parameter names of the method.
+     *
+     * @param ClassMethod $node Method whose parameter names are returned
+     * @return list<string>
+     */
+    public function paramNames(ClassMethod $node): array
+    {
+        $names = [];
+
+        foreach ($node->params as $param) {
+            if ($param->var instanceof Variable && is_string($param->var->name)) {
+                $names[] = $param->var->name;
+            }
+        }
+
+        return $names;
+    }
+
+    /**
+     * Returns true if the parameter is a PHP 8 promoted property.
+     */
+    private function isPromoted(Node\Param $param): bool
+    {
+        $mask = Modifiers::PUBLIC | Modifiers::PROTECTED | Modifiers::PRIVATE;
+
+        return ($param->flags & $mask) !== 0;
+    }
+}

--- a/tests/Fixtures/Rules/HiddenFieldRule/AbstractMethodWithParamShadow.php
+++ b/tests/Fixtures/Rules/HiddenFieldRule/AbstractMethodWithParamShadow.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\HiddenFieldRule;
+
+abstract class AbstractMethodWithParamShadow
+{
+    protected string $name = '';
+
+    abstract public function rename(string $name): void;
+}

--- a/tests/Fixtures/Rules/HiddenFieldRule/ConstructorWithShadowOptOut.php
+++ b/tests/Fixtures/Rules/HiddenFieldRule/ConstructorWithShadowOptOut.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\HiddenFieldRule;
+
+final class ConstructorWithShadowOptOut
+{
+    private string $name = '';
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+}

--- a/tests/Fixtures/Rules/HiddenFieldRule/DifferentName.php
+++ b/tests/Fixtures/Rules/HiddenFieldRule/DifferentName.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\HiddenFieldRule;
+
+final class DifferentName
+{
+    private string $title = '';
+
+    public function update(string $newTitle): void
+    {
+        $this->title = $newTitle;
+    }
+}

--- a/tests/Fixtures/Rules/HiddenFieldRule/DuplicateLocalAssignments.php
+++ b/tests/Fixtures/Rules/HiddenFieldRule/DuplicateLocalAssignments.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\HiddenFieldRule;
+
+final class DuplicateLocalAssignments
+{
+    private int $total = 0;
+
+    public function recompute(): void
+    {
+        $total = 0;
+        $total = 10;
+        $this->total = $total;
+    }
+}

--- a/tests/Fixtures/Rules/HiddenFieldRule/IgnoreNamesRespected.php
+++ b/tests/Fixtures/Rules/HiddenFieldRule/IgnoreNamesRespected.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\HiddenFieldRule;
+
+final class IgnoreNamesRespected
+{
+    private mixed $value = null;
+
+    public function update(mixed $value): void
+    {
+        $this->value = $value;
+    }
+}

--- a/tests/Fixtures/Rules/HiddenFieldRule/LocalNotMatchingProperty.php
+++ b/tests/Fixtures/Rules/HiddenFieldRule/LocalNotMatchingProperty.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\HiddenFieldRule;
+
+final class LocalNotMatchingProperty
+{
+    private int $total = 0;
+
+    public function recompute(): void
+    {
+        $sum = 0;
+        $this->total = $sum;
+    }
+}

--- a/tests/Fixtures/Rules/HiddenFieldRule/LocalVariableShadowsProperty.php
+++ b/tests/Fixtures/Rules/HiddenFieldRule/LocalVariableShadowsProperty.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\HiddenFieldRule;
+
+final class LocalVariableShadowsProperty
+{
+    private int $total = 0;
+
+    public function recalculate(): void
+    {
+        $total = 0;
+        $this->total = $total;
+    }
+}

--- a/tests/Fixtures/Rules/HiddenFieldRule/NestedClosureShadow.php
+++ b/tests/Fixtures/Rules/HiddenFieldRule/NestedClosureShadow.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\HiddenFieldRule;
+
+final class NestedClosureShadow
+{
+    private int $total = 0;
+
+    public function build(): \Closure
+    {
+        return function (): int {
+            $total = 42;
+
+            return $total;
+        };
+    }
+}

--- a/tests/Fixtures/Rules/HiddenFieldRule/ParameterShadowsProperty.php
+++ b/tests/Fixtures/Rules/HiddenFieldRule/ParameterShadowsProperty.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\HiddenFieldRule;
+
+final class ParameterShadowsProperty
+{
+    private string $name = '';
+
+    public function rename(string $name): void
+    {
+        $this->name = $name;
+    }
+}

--- a/tests/Fixtures/Rules/HiddenFieldRule/ParentPropertyNotFlagged.php
+++ b/tests/Fixtures/Rules/HiddenFieldRule/ParentPropertyNotFlagged.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\HiddenFieldRule;
+
+final class ParentPropertyNotFlagged extends ParentWithName
+{
+    public function rename(string $name): void
+    {
+        $this->name = $name;
+    }
+}

--- a/tests/Fixtures/Rules/HiddenFieldRule/ParentWithName.php
+++ b/tests/Fixtures/Rules/HiddenFieldRule/ParentWithName.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\HiddenFieldRule;
+
+abstract class ParentWithName
+{
+    protected string $name = '';
+}

--- a/tests/Fixtures/Rules/HiddenFieldRule/PromotedConstructor.php
+++ b/tests/Fixtures/Rules/HiddenFieldRule/PromotedConstructor.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\HiddenFieldRule;
+
+final class PromotedConstructor
+{
+    public function __construct(private string $name) {}
+}

--- a/tests/Fixtures/Rules/HiddenFieldRule/SetterMethod.php
+++ b/tests/Fixtures/Rules/HiddenFieldRule/SetterMethod.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\HiddenFieldRule;
+
+final class SetterMethod
+{
+    private string $title = '';
+
+    public function setTitle(string $title): void
+    {
+        $this->title = $title;
+    }
+}

--- a/tests/Fixtures/Rules/HiddenFieldRule/StaticPropertyShadow.php
+++ b/tests/Fixtures/Rules/HiddenFieldRule/StaticPropertyShadow.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\HiddenFieldRule;
+
+final class StaticPropertyShadow
+{
+    private static int $counter = 0;
+
+    public function increment(int $counter): void
+    {
+        self::$counter += $counter;
+    }
+}

--- a/tests/Fixtures/Rules/HiddenFieldRule/SuppressedShadow.php
+++ b/tests/Fixtures/Rules/HiddenFieldRule/SuppressedShadow.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\HiddenFieldRule;
+
+final class SuppressedShadow
+{
+    private string $name = '';
+
+    /** @phpstan-ignore haspadar.hiddenField */
+    public function rename(string $name): void
+    {
+        $this->name = $name;
+    }
+}

--- a/tests/Unit/Rules/HiddenFieldRule/HiddenFieldRuleAbstractOptionTest.php
+++ b/tests/Unit/Rules/HiddenFieldRule/HiddenFieldRuleAbstractOptionTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\HiddenFieldRule;
+
+use Haspadar\PHPStanRules\Rules\HiddenFieldRule;
+use Override;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<HiddenFieldRule> */
+final class HiddenFieldRuleAbstractOptionTest extends RuleTestCase
+{
+    #[Override]
+    protected function getRule(): Rule
+    {
+        return new HiddenFieldRule(
+            new \Haspadar\PHPStanRules\Rules\HiddenFieldRule\LocalAssignmentCollector(),
+            new \Haspadar\PHPStanRules\Rules\HiddenFieldRule\ParamShadowDetector(),
+            ['ignoreAbstractMethods' => true],
+        );
+    }
+
+    #[Test]
+    public function passesWhenAbstractMethodsAreIgnored(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/HiddenFieldRule/AbstractMethodWithParamShadow.php'],
+            [],
+            'Enabling ignoreAbstractMethods must suppress reports on abstract declarations',
+        );
+    }
+}

--- a/tests/Unit/Rules/HiddenFieldRule/HiddenFieldRuleConstructorOptionTest.php
+++ b/tests/Unit/Rules/HiddenFieldRule/HiddenFieldRuleConstructorOptionTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\HiddenFieldRule;
+
+use Haspadar\PHPStanRules\Rules\HiddenFieldRule;
+use Override;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<HiddenFieldRule> */
+final class HiddenFieldRuleConstructorOptionTest extends RuleTestCase
+{
+    #[Override]
+    protected function getRule(): Rule
+    {
+        return new HiddenFieldRule(
+            new \Haspadar\PHPStanRules\Rules\HiddenFieldRule\LocalAssignmentCollector(),
+            new \Haspadar\PHPStanRules\Rules\HiddenFieldRule\ParamShadowDetector(),
+            ['ignoreConstructorParameter' => false],
+        );
+    }
+
+    #[Test]
+    public function reportsNonPromotedConstructorParameter(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/HiddenFieldRule/ConstructorWithShadowOptOut.php'],
+            [
+                [
+                    'Parameter $name in Haspadar\\PHPStanRules\\Tests\\Fixtures\\Rules\\HiddenFieldRule\\ConstructorWithShadowOptOut::__construct() shadows property of the same name. Rename to avoid the name collision.',
+                    11,
+                ],
+            ],
+            'Disabling ignoreConstructorParameter surfaces shadow on non-promoted constructor params',
+        );
+    }
+
+    #[Test]
+    public function passesForPromotedConstructorParameterEvenWithOptOut(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/HiddenFieldRule/PromotedConstructor.php'],
+            [],
+            'Promoted parameters are never shadows regardless of ignoreConstructorParameter',
+        );
+    }
+}

--- a/tests/Unit/Rules/HiddenFieldRule/HiddenFieldRuleIgnoreNamesTest.php
+++ b/tests/Unit/Rules/HiddenFieldRule/HiddenFieldRuleIgnoreNamesTest.php
@@ -32,4 +32,19 @@ final class HiddenFieldRuleIgnoreNamesTest extends RuleTestCase
             'Names listed in ignoreNames must be skipped even when shadowing a property',
         );
     }
+
+    #[Test]
+    public function reportsWhenNameIsNotInIgnoreList(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/HiddenFieldRule/ParameterShadowsProperty.php'],
+            [
+                [
+                    'Parameter $name in Haspadar\\PHPStanRules\\Tests\\Fixtures\\Rules\\HiddenFieldRule\\ParameterShadowsProperty::rename() shadows property of the same name. Rename to avoid the name collision.',
+                    11,
+                ],
+            ],
+            'ignoreNames limits to listed names only; other shadowing parameters still fail',
+        );
+    }
 }

--- a/tests/Unit/Rules/HiddenFieldRule/HiddenFieldRuleIgnoreNamesTest.php
+++ b/tests/Unit/Rules/HiddenFieldRule/HiddenFieldRuleIgnoreNamesTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\HiddenFieldRule;
+
+use Haspadar\PHPStanRules\Rules\HiddenFieldRule;
+use Override;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<HiddenFieldRule> */
+final class HiddenFieldRuleIgnoreNamesTest extends RuleTestCase
+{
+    #[Override]
+    protected function getRule(): Rule
+    {
+        return new HiddenFieldRule(
+            new \Haspadar\PHPStanRules\Rules\HiddenFieldRule\LocalAssignmentCollector(),
+            new \Haspadar\PHPStanRules\Rules\HiddenFieldRule\ParamShadowDetector(),
+            ['ignoreNames' => ['value']],
+        );
+    }
+
+    #[Test]
+    public function passesWhenNameIsInIgnoreList(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/HiddenFieldRule/IgnoreNamesRespected.php'],
+            [],
+            'Names listed in ignoreNames must be skipped even when shadowing a property',
+        );
+    }
+}

--- a/tests/Unit/Rules/HiddenFieldRule/HiddenFieldRuleSetterOptionTest.php
+++ b/tests/Unit/Rules/HiddenFieldRule/HiddenFieldRuleSetterOptionTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\HiddenFieldRule;
+
+use Haspadar\PHPStanRules\Rules\HiddenFieldRule;
+use Override;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<HiddenFieldRule> */
+final class HiddenFieldRuleSetterOptionTest extends RuleTestCase
+{
+    #[Override]
+    protected function getRule(): Rule
+    {
+        return new HiddenFieldRule(
+            new \Haspadar\PHPStanRules\Rules\HiddenFieldRule\LocalAssignmentCollector(),
+            new \Haspadar\PHPStanRules\Rules\HiddenFieldRule\ParamShadowDetector(),
+            ['ignoreSetter' => true],
+        );
+    }
+
+    #[Test]
+    public function passesWhenSetterMethodsAreIgnored(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/HiddenFieldRule/SetterMethod.php'],
+            [],
+            'Enabling ignoreSetter must suppress reports on setX methods',
+        );
+    }
+}

--- a/tests/Unit/Rules/HiddenFieldRule/HiddenFieldRuleTest.php
+++ b/tests/Unit/Rules/HiddenFieldRule/HiddenFieldRuleTest.php
@@ -119,4 +119,54 @@ final class HiddenFieldRuleTest extends RuleTestCase
             'A @phpstan-ignore haspadar.hiddenField comment must silence the report',
         );
     }
+
+    #[Test]
+    public function reportsLocalVariableOnceEvenWhenAssignedMultipleTimes(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/HiddenFieldRule/DuplicateLocalAssignments.php'],
+            [
+                [
+                    'Local variable $total in Haspadar\\PHPStanRules\\Tests\\Fixtures\\Rules\\HiddenFieldRule\\DuplicateLocalAssignments::recompute() shadows property of the same name. Rename to avoid the name collision.',
+                    13,
+                ],
+            ],
+            'Multiple assignments to the same local name must be reported only once',
+        );
+    }
+
+    #[Test]
+    public function passesWhenLocalIsDeclaredInsideNestedClosure(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/HiddenFieldRule/NestedClosureShadow.php'],
+            [],
+            'Locals declared inside a nested closure belong to its scope and must not be flagged',
+        );
+    }
+
+    #[Test]
+    public function passesWhenLocalNameDoesNotMatchAnyProperty(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/HiddenFieldRule/LocalNotMatchingProperty.php'],
+            [],
+            'Local variables with names different from any property must pass',
+        );
+    }
+
+    #[Test]
+    public function reportsAbstractMethodParameterUnderDefaults(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/HiddenFieldRule/AbstractMethodWithParamShadow.php'],
+            [
+                [
+                    'Parameter $name in Haspadar\\PHPStanRules\\Tests\\Fixtures\\Rules\\HiddenFieldRule\\AbstractMethodWithParamShadow::rename() shadows property of the same name. Rename to avoid the name collision.',
+                    11,
+                ],
+            ],
+            'Abstract method parameters are reported under default ignoreAbstractMethods=false',
+        );
+    }
 }

--- a/tests/Unit/Rules/HiddenFieldRule/HiddenFieldRuleTest.php
+++ b/tests/Unit/Rules/HiddenFieldRule/HiddenFieldRuleTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\HiddenFieldRule;
+
+use Haspadar\PHPStanRules\Rules\HiddenFieldRule;
+use Override;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<HiddenFieldRule> */
+final class HiddenFieldRuleTest extends RuleTestCase
+{
+    #[Override]
+    protected function getRule(): Rule
+    {
+        return new HiddenFieldRule(
+            new \Haspadar\PHPStanRules\Rules\HiddenFieldRule\LocalAssignmentCollector(),
+            new \Haspadar\PHPStanRules\Rules\HiddenFieldRule\ParamShadowDetector(),
+        );
+    }
+
+    #[Test]
+    public function reportsParameterShadowingProperty(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/HiddenFieldRule/ParameterShadowsProperty.php'],
+            [
+                [
+                    'Parameter $name in Haspadar\\PHPStanRules\\Tests\\Fixtures\\Rules\\HiddenFieldRule\\ParameterShadowsProperty::rename() shadows property of the same name. Rename to avoid the name collision.',
+                    11,
+                ],
+            ],
+            'A method parameter that shares a name with a property must be reported',
+        );
+    }
+
+    #[Test]
+    public function reportsLocalVariableShadowingProperty(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/HiddenFieldRule/LocalVariableShadowsProperty.php'],
+            [
+                [
+                    'Local variable $total in Haspadar\\PHPStanRules\\Tests\\Fixtures\\Rules\\HiddenFieldRule\\LocalVariableShadowsProperty::recalculate() shadows property of the same name. Rename to avoid the name collision.',
+                    13,
+                ],
+            ],
+            'A local variable that shares a name with a property must be reported',
+        );
+    }
+
+    #[Test]
+    public function passesForPromotedConstructorParameter(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/HiddenFieldRule/PromotedConstructor.php'],
+            [],
+            'A promoted constructor parameter is the property, not a shadow',
+        );
+    }
+
+    #[Test]
+    public function passesForNonPromotedConstructorWithDefaultOptions(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/HiddenFieldRule/ConstructorWithShadowOptOut.php'],
+            [],
+            'ignoreConstructorParameter defaults to true so constructor shadows are silent',
+        );
+    }
+
+    #[Test]
+    public function reportsStaticPropertyShadowedByParameter(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/HiddenFieldRule/StaticPropertyShadow.php'],
+            [
+                [
+                    'Parameter $counter in Haspadar\\PHPStanRules\\Tests\\Fixtures\\Rules\\HiddenFieldRule\\StaticPropertyShadow::increment() shadows property of the same name. Rename to avoid the name collision.',
+                    11,
+                ],
+            ],
+            'Static properties must count as shadowed names just like non-static ones',
+        );
+    }
+
+    #[Test]
+    public function passesWhenParameterMatchesInheritedPropertyOnly(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/../../../Fixtures/Rules/HiddenFieldRule/ParentWithName.php',
+                __DIR__ . '/../../../Fixtures/Rules/HiddenFieldRule/ParentPropertyNotFlagged.php',
+            ],
+            [],
+            'A property inherited from a parent class is not flagged by default',
+        );
+    }
+
+    #[Test]
+    public function passesWhenParameterAndPropertyHaveDifferentNames(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/HiddenFieldRule/DifferentName.php'],
+            [],
+            'Differently named parameters must not be reported',
+        );
+    }
+
+    #[Test]
+    public function passesWhenSuppressed(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/HiddenFieldRule/SuppressedShadow.php'],
+            [],
+            'A @phpstan-ignore haspadar.hiddenField comment must silence the report',
+        );
+    }
+}

--- a/tests/Unit/RulesTest.php
+++ b/tests/Unit/RulesTest.php
@@ -68,6 +68,7 @@ use Haspadar\PHPStanRules\Rules\PhpDocParamOrderRule;
 use Haspadar\PHPStanRules\Rules\LackOfCohesionRule;
 use Haspadar\PHPStanRules\Rules\NoActorSuffixRule;
 use Haspadar\PHPStanRules\Rules\MissingThrowsRule;
+use Haspadar\PHPStanRules\Rules\HiddenFieldRule;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -141,6 +142,7 @@ final class RulesTest extends TestCase
                 InstabilityRule::class,
                 NoActorSuffixRule::class,
                 MissingThrowsRule::class,
+                HiddenFieldRule::class,
             ],
             (new Rules())->all(),
             'Rules::all() must list every registered rule class',


### PR DESCRIPTION
- Added HiddenFieldRule reporting parameters or local assignments that reuse a class property name
- Added ignoreConstructorParameter, ignoreAbstractMethods, ignoreSetter, and ignoreNames options
- Added LocalAssignmentCollector and ParamShadowDetector helpers for scope-aware scanning
- Updated README to cover the new rule and its configuration flags

Closes #166