### PR TITLE
Require Justification Reason On Every Suppress Annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@
 | `TodoCommentRule`             | TODO, FIXME, and XXX comments are forbidden in method bodies                  |
 | `MissingThrowsRule`           | Methods must declare `@throws` for every checked exception they throw (overridden methods inherit by default) |
 | `HiddenFieldRule`             | Method parameter or local variable must not shadow a class property (promoted constructors excluded, parameter takes precedence over local of the same name) |
+| `RequireIgnoreReasonRule`     | Every `@phpstan-ignore` and `@psalm-suppress` must carry a justification (default: 5 chars, parens for PHPStan, `--` for Psalm) |
 
 ### Naming
 
@@ -264,6 +265,9 @@ parameters:
             ignoreAbstractMethods: false
             ignoreSetter: false
             ignoreNames: []
+        requireIgnoreReason:
+            minReasonLength: 5
+            allowedBareIdentifiers: []
         afferentCoupling:
             maxAfferent: 10
             ignoreInterfaces: true
@@ -295,6 +299,17 @@ When the rule reports a class like `UserDispatcher`, pick one of three fixes:
 Rule of thumb: if the suffix describes *what the class is*, extend `allowedWords`. If it describes *what the class does*, rename.
 
 `allowedWords` is matched **case-sensitively** against the last PascalCase segment of the class name. PHP class names follow PascalCase convention, so entries must be capitalized (`User`, not `user`).
+
+### RequireIgnoreReasonRule — where to put the reason
+
+Two different delimiters, one per tool:
+
+```php
+/** @phpstan-ignore foo.bar (reason in parentheses — PHPStan 1.11+ native) */
+/** @psalm-suppress FooBar -- reason after double-dash (ESLint convention) */
+```
+
+`minReasonLength` counts **trimmed** characters, so padding does not help. `allowedBareIdentifiers` skips both the reason requirement and length check — use it for self-evident project-wide suppressions.
 
 ### MissingThrowsRule — @throws inheritance for overridden methods
 

--- a/rules-ignore.neon
+++ b/rules-ignore.neon
@@ -33,6 +33,7 @@ parameters:
                 - src/Rules/HiddenFieldRule/LocalAssignmentCollector.php
                 - src/Rules/HiddenFieldRule/ParamShadowDetector.php
                 - src/Rules/Internal/BuiltinCallDetector.php
+                - src/Rules/RequireIgnoreReasonRule/SuppressViolationFinder.php
                 - src/Rules/LackOfCohesionRule/AdjacencyBuilder.php
                 - src/Rules/PhpDocDescriptionChecker.php
                 - src/Rules/VariableCollector.php

--- a/rules.neon
+++ b/rules.neon
@@ -171,6 +171,9 @@ parameters:
             ignoreAbstractMethods: false
             ignoreSetter: false
             ignoreNames: []
+        requireIgnoreReason:
+            minReasonLength: 5
+            allowedBareIdentifiers: []
     exceptions:
         check:
             missingCheckedExceptionInThrows: false
@@ -321,6 +324,10 @@ parametersSchema:
             ignoreAbstractMethods: bool(),
             ignoreSetter: bool(),
             ignoreNames: listOf(string()),
+        ]),
+        requireIgnoreReason: structure([
+            minReasonLength: int(),
+            allowedBareIdentifiers: listOf(string()),
         ]),
     ])
 
@@ -720,5 +727,13 @@ services:
                 ignoreAbstractMethods: %haspadar.hiddenField.ignoreAbstractMethods%
                 ignoreSetter: %haspadar.hiddenField.ignoreSetter%
                 ignoreNames: %haspadar.hiddenField.ignoreNames%
+        tags:
+            - phpstan.rules.rule
+    -
+        class: Haspadar\PHPStanRules\Rules\RequireIgnoreReasonRule
+        arguments:
+            options:
+                minReasonLength: %haspadar.requireIgnoreReason.minReasonLength%
+                allowedBareIdentifiers: %haspadar.requireIgnoreReason.allowedBareIdentifiers%
         tags:
             - phpstan.rules.rule

--- a/src/NodeHelper/ChildNodes.php
+++ b/src/NodeHelper/ChildNodes.php
@@ -25,7 +25,7 @@ final class ChildNodes
 
         foreach ($node->getSubNodeNames() as $name) {
             /** @var mixed $child -- dynamic access is intentional: PhpParser sub-node API */
-            // @phpstan-ignore property.dynamicName
+            // @phpstan-ignore property.dynamicName (dynamic access is intentional: PhpParser sub-node API)
             $child = $node->$name;
 
             foreach (self::extractNodes($child) as $extracted) {
@@ -53,7 +53,7 @@ final class ChildNodes
 
         $nodes = [];
 
-        /** @psalm-suppress MixedAssignment */
+        /** @psalm-suppress MixedAssignment -- PhpParser attribute is `mixed` by design, instanceof check filters below */
         foreach ($value as $item) {
             if ($item instanceof Node) {
                 $nodes[] = $item;

--- a/src/Rules.php
+++ b/src/Rules.php
@@ -74,6 +74,7 @@ final class Rules
         Rules\NoActorSuffixRule::class,
         Rules\MissingThrowsRule::class,
         Rules\HiddenFieldRule::class,
+        Rules\RequireIgnoreReasonRule::class,
     ];
 
     /**

--- a/src/Rules/MissingThrowsRule.php
+++ b/src/Rules/MissingThrowsRule.php
@@ -70,7 +70,7 @@ final readonly class MissingThrowsRule implements Rule
         $errors = [];
         $throwPoints = $node->getStatementResult()->getThrowPoints();
 
-        /** @phpstan-ignore phpstanApi.method */
+        /** @phpstan-ignore phpstanApi.method (reuse PHPStan internal helper for checked-exception detection) */
         $missing = $this->check->check(
             $method->getThrowType(),
             $throwPoints,

--- a/src/Rules/RequireIgnoreReasonRule.php
+++ b/src/Rules/RequireIgnoreReasonRule.php
@@ -109,23 +109,24 @@ final readonly class RequireIgnoreReasonRule implements Rule
     /**
      * Builds a PHPStan error message for a violation.
      *
-     * @param array{identifier: string, offsetLine: int, kind: string} $violation
+     * @param array{identifier: string, offsetLine: int, kind: 'phpstan'|'psalm'} $violation
      * @throws ShouldNotHappenException
      */
     private function buildError(array $violation, int $baseLine): IdentifierRuleError
     {
         $identifier = $violation['identifier'];
-        $message = $violation['kind'] === 'phpstan'
-            ? sprintf(
+        $message = match ($violation['kind']) {
+            'phpstan' => sprintf(
                 'Suppress "%s" must include a reason in parentheses: @phpstan-ignore %s (reason).',
                 $identifier,
                 $identifier,
-            )
-            : sprintf(
+            ),
+            'psalm' => sprintf(
                 'Suppress "%s" must include a reason after "--": @psalm-suppress %s -- reason.',
                 $identifier,
                 $identifier,
-            );
+            ),
+        };
 
         return RuleErrorBuilder::message($message)
             ->identifier('haspadar.requireIgnoreReason')

--- a/src/Rules/RequireIgnoreReasonRule.php
+++ b/src/Rules/RequireIgnoreReasonRule.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Rules;
+
+use Haspadar\PHPStanRules\Rules\RequireIgnoreReasonRule\SuppressViolationFinder;
+use Override;
+use PhpParser\Comment;
+use PhpParser\Node;
+use PhpParser\NodeFinder;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\FileNode;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\ShouldNotHappenException;
+
+/**
+ * Requires every suppress annotation to include a justification reason.
+ *
+ * Supported forms: PHPStan "at-phpstan-ignore identifier (reason)" and its
+ * next-line and line variants (native parenthesised reason, PHPStan 1.11+);
+ * Psalm "at-psalm-suppress Identifier -- reason" where the "--" delimiter is
+ * borrowed from the ESLint convention because Psalm has no native reason field.
+ *
+ * A suppress without a reason, or with a reason shorter than `minReasonLength`,
+ * is reported. Identifiers listed in `allowedBareIdentifiers` may appear without
+ * a reason (useful for project-wide suppressions that are self-evident).
+ *
+ * @implements Rule<FileNode>
+ */
+final readonly class RequireIgnoreReasonRule implements Rule
+{
+    private const int DEFAULT_MIN_REASON_LENGTH = 5;
+
+    private SuppressViolationFinder $finder;
+
+    /**
+     * Constructs the rule with the given options.
+     *
+     * @param array{
+     *     minReasonLength?: int,
+     *     allowedBareIdentifiers?: list<string>
+     * } $options Minimum reason length and a whitelist of identifiers that may omit the reason
+     */
+    public function __construct(array $options = [])
+    {
+        $this->finder = new SuppressViolationFinder(
+            $options['minReasonLength'] ?? self::DEFAULT_MIN_REASON_LENGTH,
+            $options['allowedBareIdentifiers'] ?? [],
+        );
+    }
+
+    #[Override]
+    public function getNodeType(): string
+    {
+        return FileNode::class;
+    }
+
+    /**
+     * Analyses the node and returns a list of errors.
+     *
+     * @psalm-param FileNode $node
+     * @throws ShouldNotHappenException
+     * @return list<IdentifierRuleError>
+     */
+    #[Override]
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $errors = [];
+
+        foreach ($this->collectComments($node) as $comment) {
+            foreach ($this->finder->find($comment->getText()) as $violation) {
+                $errors[] = $this->buildError($violation, $comment->getStartLine());
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * Collects every PhpParser comment attached to any descendant node of the file.
+     *
+     * @return list<Comment>
+     */
+    private function collectComments(FileNode $node): array
+    {
+        $nodeFinder = new NodeFinder();
+        $seen = [];
+        $result = [];
+
+        foreach ($nodeFinder->findInstanceOf($node->getNodes(), Node::class) as $descendant) {
+            foreach ($descendant->getComments() as $comment) {
+                $key = sprintf('%d:%d', $comment->getStartLine(), $comment->getStartFilePos());
+
+                if (array_key_exists($key, $seen)) {
+                    continue;
+                }
+
+                $seen[$key] = true;
+                $result[] = $comment;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Builds a PHPStan error message for a violation.
+     *
+     * @param array{identifier: string, offsetLine: int, kind: string} $violation
+     * @throws ShouldNotHappenException
+     */
+    private function buildError(array $violation, int $baseLine): IdentifierRuleError
+    {
+        $identifier = $violation['identifier'];
+        $message = $violation['kind'] === 'phpstan'
+            ? sprintf(
+                'Suppress "%s" must include a reason in parentheses: @phpstan-ignore %s (reason).',
+                $identifier,
+                $identifier,
+            )
+            : sprintf(
+                'Suppress "%s" must include a reason after "--": @psalm-suppress %s -- reason.',
+                $identifier,
+                $identifier,
+            );
+
+        return RuleErrorBuilder::message($message)
+            ->identifier('haspadar.requireIgnoreReason')
+            ->line($baseLine + $violation['offsetLine'])
+            ->build();
+    }
+}

--- a/src/Rules/RequireIgnoreReasonRule/SuppressViolationFinder.php
+++ b/src/Rules/RequireIgnoreReasonRule/SuppressViolationFinder.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Rules\RequireIgnoreReasonRule;
+
+/**
+ * Locates suppress annotations inside a comment and returns those lacking a valid reason.
+ *
+ * Supported forms: PHPStan "at-phpstan-ignore" plus its next-line and line variants
+ * with an optional parenthesised reason, and Psalm "at-psalm-suppress" with an
+ * optional "-- reason" tail borrowed from the ESLint convention.
+ *
+ * A reason is accepted when it is non-null and its trimmed length is at least the
+ * configured minimum. Identifiers in the allow-list are skipped regardless of reason.
+ */
+final readonly class SuppressViolationFinder
+{
+    private const int IDENTIFIER_GROUP = 1;
+
+    private const int REASON_GROUP = 2;
+
+    /**
+     * Constructs the finder with the minimum reason length and a whitelist of bare identifiers.
+     *
+     * @param int $minReasonLength Minimum trimmed length of an acceptable reason
+     * @param list<string> $allowedBareIdentifiers Identifiers that may omit the reason
+     */
+    public function __construct(
+        private int $minReasonLength,
+        private array $allowedBareIdentifiers,
+    ) {}
+
+    /**
+     * Returns a list of suppress annotations whose reason is missing or too short.
+     *
+     * Each returned tuple carries the identifier, the line offset inside the
+     * searched text, and a "kind" (`phpstan` or `psalm`) so the caller can
+     * build the correct error message for the relevant tool.
+     *
+     * @param string $text Raw comment text to scan for suppress annotations
+     * @return list<array{identifier: string, offsetLine: int, kind: string}>
+     */
+    public function find(string $text): array
+    {
+        $violations = [];
+
+        foreach ($this->matchPhpstanIgnore($text) as [$identifier, $reason, $offsetLine]) {
+            if ($this->isAcceptable($identifier, $reason)) {
+                continue;
+            }
+
+            $violations[] = ['identifier' => $identifier, 'offsetLine' => $offsetLine, 'kind' => 'phpstan'];
+        }
+
+        foreach ($this->matchPsalmSuppress($text) as [$identifier, $reason, $offsetLine]) {
+            if ($this->isAcceptable($identifier, $reason)) {
+                continue;
+            }
+
+            $violations[] = ['identifier' => $identifier, 'offsetLine' => $offsetLine, 'kind' => 'psalm'];
+        }
+
+        return $violations;
+    }
+
+    /**
+     * Matches PHPStan-ignore annotations with an optional parenthesised reason.
+     *
+     * @return list<array{0: string, 1: string, 2: int}>
+     */
+    private function matchPhpstanIgnore(string $text): array
+    {
+        return $this->matchAll('/@phpstan-ignore(?:-next-line|-line)?\s+([\w.]+)(?:\s*\(([^)]*)\))?/', $text);
+    }
+
+    /**
+     * Matches Psalm-suppress annotations with an optional "-- reason" tail.
+     *
+     * @return list<array{0: string, 1: string, 2: int}>
+     */
+    private function matchPsalmSuppress(string $text): array
+    {
+        return $this->matchAll('/@psalm-suppress\s+(\w+)(?:\s*--\s*(.+?))?(?:\s*\*\/|\s*$)/m', $text);
+    }
+
+    /**
+     * Runs a regex and returns [identifier, reason, offsetLine] triples for each match.
+     *
+     * A missing reason is returned as an empty string so every consumer handles a
+     * single type and never a null.
+     *
+     * @param non-empty-string $pattern
+     * @return list<array{0: string, 1: string, 2: int}>
+     */
+    private function matchAll(string $pattern, string $text): array
+    {
+        if (preg_match_all($pattern, $text, $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER) === false) {
+            return [];
+        }
+
+        $result = [];
+
+        foreach ($matches as $match) {
+            $identifier = $match[self::IDENTIFIER_GROUP][0];
+            $reason = array_key_exists(self::REASON_GROUP, $match)
+                ? $match[self::REASON_GROUP][0]
+                : '';
+            $offset = $match[0][1];
+            $offsetLine = $offset > 0
+                ? substr_count(substr($text, 0, $offset), "\n")
+                : 0;
+            $result[] = [$identifier, $reason, $offsetLine];
+        }
+
+        return $result;
+    }
+
+    /**
+     * Returns true if the identifier may be used bare or the reason is long enough.
+     */
+    private function isAcceptable(string $identifier, string $reason): bool
+    {
+        if (in_array($identifier, $this->allowedBareIdentifiers, true)) {
+            return true;
+        }
+
+        return strlen(trim($reason)) >= $this->minReasonLength;
+    }
+}

--- a/src/Rules/RequireIgnoreReasonRule/SuppressViolationFinder.php
+++ b/src/Rules/RequireIgnoreReasonRule/SuppressViolationFinder.php
@@ -67,21 +67,36 @@ final readonly class SuppressViolationFinder
     /**
      * Matches PHPStan-ignore annotations with an optional parenthesised reason.
      *
+     * The directive must sit at the start of a docblock line (optional slash-star
+     * or star line leader), which prevents false positives when the string appears
+     * inside free-form prose. Identifiers follow the dotted camelCase convention
+     * from the PHPStan error catalogue; reasons are captured without nested parentheses.
+     *
      * @return list<array{0: string, 1: string, 2: int}>
      */
     private function matchPhpstanIgnore(string $text): array
     {
-        return $this->matchAll('/@phpstan-ignore(?:-next-line|-line)?\s+([\w.]+)(?:\s*\(([^)]*)\))?/', $text);
+        return $this->matchAll(
+            '~(?:^|\n)(?:[ \t/*]*)\K@phpstan-ignore(?:-next-line|-line)?[ \t]+([\w.]+)(?:[ \t]*\(([^)]*)\))?~',
+            $text,
+        );
     }
 
     /**
      * Matches Psalm-suppress annotations with an optional "-- reason" tail.
      *
+     * The directive must sit at the start of a docblock line (optional `//`, `/**`,
+     * or `*` line leader). Psalm identifiers are single-word camelCase so `\w+`
+     * is sufficient.
+     *
      * @return list<array{0: string, 1: string, 2: int}>
      */
     private function matchPsalmSuppress(string $text): array
     {
-        return $this->matchAll('/@psalm-suppress\s+(\w+)(?:\s*--\s*(.+?))?(?:\s*\*\/|\s*$)/m', $text);
+        return $this->matchAll(
+            '~(?:^|\n)(?:[ \t/*]*)\K@psalm-suppress[ \t]+(\w+)(?:[ \t]*--[ \t]*(.+?))?(?:[ \t]*\*/|\s*$)~m',
+            $text,
+        );
     }
 
     /**

--- a/src/Rules/RequireIgnoreReasonRule/SuppressViolationFinder.php
+++ b/src/Rules/RequireIgnoreReasonRule/SuppressViolationFinder.php
@@ -39,7 +39,7 @@ final readonly class SuppressViolationFinder
      * build the correct error message for the relevant tool.
      *
      * @param string $text Raw comment text to scan for suppress annotations
-     * @return list<array{identifier: string, offsetLine: int, kind: string}>
+     * @return list<array{identifier: string, offsetLine: int, kind: 'phpstan'|'psalm'}>
      */
     public function find(string $text): array
     {

--- a/tests/Unit/Rules/RequireIgnoreReasonRule/RequireIgnoreReasonRuleTest.php
+++ b/tests/Unit/Rules/RequireIgnoreReasonRule/RequireIgnoreReasonRuleTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\RequireIgnoreReasonRule;
+
+use Haspadar\PHPStanRules\Rules\RequireIgnoreReasonRule;
+use PhpParser\Comment\Doc;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\Expression;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\FileNode;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Integration test for RequireIgnoreReasonRule.
+ *
+ * RuleTestCase cannot be used because PHPStan's LocalIgnoresProcessor would
+ * emit "no error to ignore" errors for the placeholder identifiers inside
+ * fixtures that the isolated rule registry cannot satisfy. Instead the rule
+ * is driven directly: we build a FileNode carrying a hand-crafted Comment
+ * and assert the list of RuleError instances it returns.
+ */
+final class RequireIgnoreReasonRuleTest extends TestCase
+{
+    #[Test]
+    public function reportsSuppressWithoutReason(): void
+    {
+        $errors = $this->runOn('/** @phpstan-ignore missingType.iterableValue */');
+
+        self::assertCount(
+            1,
+            $errors,
+            'A bare @phpstan-ignore must yield exactly one error',
+        );
+    }
+
+    #[Test]
+    public function reportsSuppressWithTooShortReason(): void
+    {
+        $errors = $this->runOn('/** @phpstan-ignore missingType.iterableValue (x) */');
+
+        self::assertSame(
+            'Suppress "missingType.iterableValue" must include a reason in parentheses: @phpstan-ignore missingType.iterableValue (reason).',
+            $errors[0]->getMessage(),
+            'A too-short reason must yield the same error as a missing one',
+        );
+    }
+
+    #[Test]
+    public function reportsPsalmSuppressWithoutReason(): void
+    {
+        $errors = $this->runOn('/** @psalm-suppress UnusedVariable */');
+
+        self::assertSame(
+            'Suppress "UnusedVariable" must include a reason after "--": @psalm-suppress UnusedVariable -- reason.',
+            $errors[0]->getMessage(),
+            'Psalm suppress without reason must yield a Psalm-style error message',
+        );
+    }
+
+    #[Test]
+    public function passesSuppressWithReason(): void
+    {
+        $errors = $this->runOn('/** @phpstan-ignore missingType.iterableValue (documented upstream) */');
+
+        self::assertSame(
+            [],
+            $errors,
+            'A @phpstan-ignore with a parenthesised reason must yield no errors',
+        );
+    }
+
+    #[Test]
+    public function passesWhenIdentifierIsInAllowList(): void
+    {
+        $rule = new RequireIgnoreReasonRule(['allowedBareIdentifiers' => ['project.wide']]);
+        $node = $this->fileNodeWithDocComment('/** @phpstan-ignore project.wide */');
+        $scope = $this->createStub(Scope::class);
+
+        self::assertSame(
+            [],
+            $rule->processNode($node, $scope),
+            'An identifier in allowedBareIdentifiers must not be reported even without a reason',
+        );
+    }
+
+    #[Test]
+    public function returnsEmptyListWhenFileHasNoSuppresses(): void
+    {
+        $errors = $this->runOn('/** Regular docblock summary. */');
+
+        self::assertSame(
+            [],
+            $errors,
+            'A file without suppress annotations must pass',
+        );
+    }
+
+    /**
+     * Runs the rule on a synthetic FileNode whose expression carries a single docblock.
+     *
+     * @return array<int, \PHPStan\Rules\IdentifierRuleError>
+     */
+    private function runOn(string $commentText): array
+    {
+        $rule = new RequireIgnoreReasonRule();
+        $node = $this->fileNodeWithDocComment($commentText);
+        $scope = $this->createStub(Scope::class);
+
+        return $rule->processNode($node, $scope);
+    }
+
+    /**
+     * Builds a FileNode containing a statement whose doc comment is the given text.
+     */
+    private function fileNodeWithDocComment(string $commentText): FileNode
+    {
+        $expression = new Expression(new String_(''), ['comments' => [new Doc($commentText)]]);
+
+        return new FileNode([$expression]);
+    }
+}

--- a/tests/Unit/Rules/RequireIgnoreReasonRule/RequireIgnoreReasonRuleTest.php
+++ b/tests/Unit/Rules/RequireIgnoreReasonRule/RequireIgnoreReasonRuleTest.php
@@ -98,6 +98,24 @@ final class RequireIgnoreReasonRuleTest extends TestCase
         );
     }
 
+    #[Test]
+    public function reportsErrorOnLineRelativeToDocblockStart(): void
+    {
+        $rule = new RequireIgnoreReasonRule();
+        $comment = "/**\n * @phpstan-ignore missingType.iterableValue\n */";
+        $expression = new Expression(
+            new String_(''),
+            ['comments' => [new Doc($comment, 100)]],
+        );
+        $errors = $rule->processNode(new FileNode([$expression]), $this->createStub(Scope::class));
+
+        self::assertSame(
+            101,
+            $errors[0]->getLine(),
+            'Reported line must equal docblock start line plus offset of the violation inside the docblock',
+        );
+    }
+
     /**
      * Runs the rule on a synthetic FileNode whose expression carries a single docblock.
      *

--- a/tests/Unit/Rules/RequireIgnoreReasonRule/SuppressViolationFinderTest.php
+++ b/tests/Unit/Rules/RequireIgnoreReasonRule/SuppressViolationFinderTest.php
@@ -169,4 +169,17 @@ final class SuppressViolationFinderTest extends TestCase
             'The directive only counts when anchored at start-of-line or after whitespace not inside prose',
         );
     }
+
+    #[Test]
+    public function ignoresPhpstanIgnoreMentionedMidSentenceAfterLeader(): void
+    {
+        $finder = new SuppressViolationFinder(5, []);
+        $text = "/**\n * The word @phpstan-ignore can appear here.\n */";
+
+        self::assertSame(
+            [],
+            $finder->find($text),
+            'A directive inside prose on a leading "*" line must not be matched',
+        );
+    }
 }

--- a/tests/Unit/Rules/RequireIgnoreReasonRule/SuppressViolationFinderTest.php
+++ b/tests/Unit/Rules/RequireIgnoreReasonRule/SuppressViolationFinderTest.php
@@ -145,4 +145,28 @@ final class SuppressViolationFinderTest extends TestCase
             'Raising minReasonLength must reject previously-acceptable reasons that are shorter',
         );
     }
+
+    #[Test]
+    public function acceptsPhpstanIgnoreLineWithReason(): void
+    {
+        $finder = new SuppressViolationFinder(5, []);
+
+        self::assertSame(
+            [],
+            $finder->find('// @phpstan-ignore-line foo.bar (reason kept concise)'),
+            'The -line variant honours the same reason rule as the other two forms',
+        );
+    }
+
+    #[Test]
+    public function ignoresPhpstanIgnoreMentionedInsideProse(): void
+    {
+        $finder = new SuppressViolationFinder(5, []);
+
+        self::assertSame(
+            [],
+            $finder->find('/** See @phpstan-ignore directive in the PHPStan docs */'),
+            'The directive only counts when anchored at start-of-line or after whitespace not inside prose',
+        );
+    }
 }

--- a/tests/Unit/Rules/RequireIgnoreReasonRule/SuppressViolationFinderTest.php
+++ b/tests/Unit/Rules/RequireIgnoreReasonRule/SuppressViolationFinderTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\RequireIgnoreReasonRule;
+
+use Haspadar\PHPStanRules\Rules\RequireIgnoreReasonRule\SuppressViolationFinder;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class SuppressViolationFinderTest extends TestCase
+{
+    #[Test]
+    public function acceptsPhpstanIgnoreWithReason(): void
+    {
+        $finder = new SuppressViolationFinder(5, []);
+
+        self::assertSame(
+            [],
+            $finder->find('/** @phpstan-ignore missingType.iterableValue (documented in parent) */'),
+            'A @phpstan-ignore with a parenthesised reason must produce no violations',
+        );
+    }
+
+    #[Test]
+    public function reportsPhpstanIgnoreWithoutReason(): void
+    {
+        $finder = new SuppressViolationFinder(5, []);
+
+        self::assertSame(
+            [['identifier' => 'missingType.iterableValue', 'offsetLine' => 0, 'kind' => 'phpstan']],
+            $finder->find('/** @phpstan-ignore missingType.iterableValue */'),
+            'A @phpstan-ignore missing the reason must report one violation',
+        );
+    }
+
+    #[Test]
+    public function reportsPhpstanIgnoreWithReasonShorterThanMinimum(): void
+    {
+        $finder = new SuppressViolationFinder(5, []);
+
+        self::assertSame(
+            [['identifier' => 'missingType.iterableValue', 'offsetLine' => 0, 'kind' => 'phpstan']],
+            $finder->find('/** @phpstan-ignore missingType.iterableValue (x) */'),
+            'A reason shorter than minReasonLength must be reported like a missing one',
+        );
+    }
+
+    #[Test]
+    public function acceptsPhpstanIgnoreNextLineWithReason(): void
+    {
+        $finder = new SuppressViolationFinder(5, []);
+
+        self::assertSame(
+            [],
+            $finder->find('// @phpstan-ignore-next-line foo.bar (detailed reason)'),
+            'The next-line variant honours the same reason rule',
+        );
+    }
+
+    #[Test]
+    public function acceptsPsalmSuppressWithReason(): void
+    {
+        $finder = new SuppressViolationFinder(5, []);
+
+        self::assertSame(
+            [],
+            $finder->find('/** @psalm-suppress UnusedVariable -- reserved for plugin hook */'),
+            'A @psalm-suppress followed by `-- reason` must produce no violations',
+        );
+    }
+
+    #[Test]
+    public function reportsPsalmSuppressWithoutReason(): void
+    {
+        $finder = new SuppressViolationFinder(5, []);
+
+        self::assertSame(
+            [['identifier' => 'UnusedVariable', 'offsetLine' => 0, 'kind' => 'psalm']],
+            $finder->find('/** @psalm-suppress UnusedVariable */'),
+            'A bare @psalm-suppress must be reported',
+        );
+    }
+
+    #[Test]
+    public function skipsIdentifiersFromAllowList(): void
+    {
+        $finder = new SuppressViolationFinder(5, ['foo.bar']);
+
+        self::assertSame(
+            [],
+            $finder->find('/** @phpstan-ignore foo.bar */'),
+            'Identifiers in allowedBareIdentifiers must be ignored even without a reason',
+        );
+    }
+
+    #[Test]
+    public function reportsIdentifiersNotInAllowList(): void
+    {
+        $finder = new SuppressViolationFinder(5, ['foo.bar']);
+
+        self::assertSame(
+            [['identifier' => 'other.identifier', 'offsetLine' => 0, 'kind' => 'phpstan']],
+            $finder->find('/** @phpstan-ignore other.identifier */'),
+            'allowedBareIdentifiers must not exempt identifiers outside the list',
+        );
+    }
+
+    #[Test]
+    public function returnsEmptyListWhenNoSuppressAnnotationsArePresent(): void
+    {
+        $finder = new SuppressViolationFinder(5, []);
+
+        self::assertSame(
+            [],
+            $finder->find('/** Regular phpdoc summary with no suppress annotations */'),
+            'A comment without suppress directives must produce no violations',
+        );
+    }
+
+    #[Test]
+    public function reportsOffsetLineOfSecondViolationInMultiLineComment(): void
+    {
+        $finder = new SuppressViolationFinder(5, []);
+        $text = "/**\n * @phpstan-ignore first.id\n * @phpstan-ignore second.id\n */";
+
+        self::assertSame(
+            [
+                ['identifier' => 'first.id', 'offsetLine' => 1, 'kind' => 'phpstan'],
+                ['identifier' => 'second.id', 'offsetLine' => 2, 'kind' => 'phpstan'],
+            ],
+            $finder->find($text),
+            'Each violation must carry the relative line offset inside the multi-line comment',
+        );
+    }
+
+    #[Test]
+    public function raisesMinimumRejectsOtherwiseValidReason(): void
+    {
+        $finder = new SuppressViolationFinder(50, []);
+
+        self::assertSame(
+            [['identifier' => 'foo.bar', 'offsetLine' => 0, 'kind' => 'phpstan']],
+            $finder->find('/** @phpstan-ignore foo.bar (short reason) */'),
+            'Raising minReasonLength must reject previously-acceptable reasons that are shorter',
+        );
+    }
+}

--- a/tests/Unit/RulesTest.php
+++ b/tests/Unit/RulesTest.php
@@ -69,6 +69,7 @@ use Haspadar\PHPStanRules\Rules\LackOfCohesionRule;
 use Haspadar\PHPStanRules\Rules\NoActorSuffixRule;
 use Haspadar\PHPStanRules\Rules\MissingThrowsRule;
 use Haspadar\PHPStanRules\Rules\HiddenFieldRule;
+use Haspadar\PHPStanRules\Rules\RequireIgnoreReasonRule;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -143,6 +144,7 @@ final class RulesTest extends TestCase
                 NoActorSuffixRule::class,
                 MissingThrowsRule::class,
                 HiddenFieldRule::class,
+                RequireIgnoreReasonRule::class,
             ],
             (new Rules())->all(),
             'Rules::all() must list every registered rule class',


### PR DESCRIPTION
- Added RequireIgnoreReasonRule scanning every comment for PHPStan and Psalm suppress directives
- Added SuppressViolationFinder helper that anchors matches to docblock leaders to avoid prose false positives
- Updated internal suppressions in ChildNodes.php and MissingThrowsRule.php to satisfy the new rule
- Updated README to document the two reason delimiters (parentheses for PHPStan, -- for Psalm)

Closes #168

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforces that @phpstan-ignore and @psalm-suppress tags include a justification; configurable minimum reason length and allowlist for bare identifiers.
* **Documentation**
  * README and example config updated with guidance on suppression reason syntax and options.
* **Configuration**
  * Rule added to analysis configuration and ignore settings expanded to include additional suppressed entries.
* **Tests**
  * New unit and integration tests covering detection, offsets, allowlist behavior, and multiple directive forms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->