### PR TITLE
MultipleVariableDeclarationsRule for Chained Assigns and Multi-Statement Lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@
 | `MissingThrowsRule`           | Methods must declare `@throws` for every checked exception they throw (overridden methods inherit by default) |
 | `HiddenFieldRule`             | Method parameter or local variable must not shadow a class property (promoted constructors excluded, parameter takes precedence over local of the same name) |
 | `RequireIgnoreReasonRule`     | Every `@phpstan-ignore` and `@psalm-suppress` must carry a justification (default: 5 chars, parens for PHPStan, `--` for Psalm) |
+| `MultipleVariableDeclarationsRule` | Chained assignments (`$a = $b = 1`) and multiple statements on one line are forbidden (default: chained `null` chains rejected) |
 
 ### Naming
 
@@ -268,6 +269,8 @@ parameters:
         requireIgnoreReason:
             minReasonLength: 5
             allowedBareIdentifiers: []
+        multipleVarDecl:
+            allowChainedNull: false
         afferentCoupling:
             maxAfferent: 10
             ignoreInterfaces: true

--- a/rules-ignore.neon
+++ b/rules-ignore.neon
@@ -35,5 +35,6 @@ parameters:
                 - src/Rules/Internal/BuiltinCallDetector.php
                 - src/Rules/RequireIgnoreReasonRule/SuppressViolationFinder.php
                 - src/Rules/LackOfCohesionRule/AdjacencyBuilder.php
+                - src/Rules/MultipleVariableDeclarationsRule/StatementListCollector.php
                 - src/Rules/PhpDocDescriptionChecker.php
                 - src/Rules/VariableCollector.php

--- a/rules.neon
+++ b/rules.neon
@@ -174,6 +174,8 @@ parameters:
         requireIgnoreReason:
             minReasonLength: 5
             allowedBareIdentifiers: []
+        multipleVarDecl:
+            allowChainedNull: false
     exceptions:
         check:
             missingCheckedExceptionInThrows: false
@@ -328,6 +330,9 @@ parametersSchema:
         requireIgnoreReason: structure([
             minReasonLength: int(),
             allowedBareIdentifiers: listOf(string()),
+        ]),
+        multipleVarDecl: structure([
+            allowChainedNull: bool(),
         ]),
     ])
 
@@ -735,5 +740,12 @@ services:
             options:
                 minReasonLength: %haspadar.requireIgnoreReason.minReasonLength%
                 allowedBareIdentifiers: %haspadar.requireIgnoreReason.allowedBareIdentifiers%
+        tags:
+            - phpstan.rules.rule
+    -
+        class: Haspadar\PHPStanRules\Rules\MultipleVariableDeclarationsRule
+        arguments:
+            options:
+                allowChainedNull: %haspadar.multipleVarDecl.allowChainedNull%
         tags:
             - phpstan.rules.rule

--- a/src/Rules.php
+++ b/src/Rules.php
@@ -75,6 +75,7 @@ final class Rules
         Rules\MissingThrowsRule::class,
         Rules\HiddenFieldRule::class,
         Rules\RequireIgnoreReasonRule::class,
+        Rules\MultipleVariableDeclarationsRule::class,
     ];
 
     /**

--- a/src/Rules/MultipleVariableDeclarationsRule.php
+++ b/src/Rules/MultipleVariableDeclarationsRule.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Rules;
+
+use Haspadar\PHPStanRules\Rules\MultipleVariableDeclarationsRule\StatementListCollector;
+use Override;
+use PhpParser\Node;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\ConstFetch;
+use PhpParser\Node\Stmt\Expression;
+use PhpParser\NodeFinder;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\FileNode;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * Forbids two forms that pack several declarations into one source unit.
+ *
+ * The rule reports a chained assignment such as `$a = $b = 1;` because the
+ * right-hand side carries another `Assign` node, and it reports two adjacent
+ * statements that share a single source line because each statement deserves
+ * its own line. A `for` initialiser may carry several expressions and is not
+ * affected by the per-line check; destructuring assignments and assignments
+ * used as conditions are not chained and remain untouched.
+ *
+ * @implements Rule<FileNode>
+ */
+final readonly class MultipleVariableDeclarationsRule implements Rule
+{
+    private bool $allowChainedNull;
+
+    private StatementListCollector $statementLists;
+
+    /**
+     * Constructs the rule with the optional opt-in for `null` chains.
+     *
+     * @param array{allowChainedNull?: bool} $options Switch that allows `$a = $b = null;` when enabled.
+     */
+    public function __construct(array $options = [])
+    {
+        $this->allowChainedNull = $options['allowChainedNull'] ?? false;
+        $this->statementLists = new StatementListCollector();
+    }
+
+    #[Override]
+    public function getNodeType(): string
+    {
+        return FileNode::class;
+    }
+
+    /**
+     * Analyses the file and returns errors for chained assignments and multi-statement lines.
+     *
+     * @psalm-param FileNode $node
+     * @return list<IdentifierRuleError>
+     */
+    #[Override]
+    public function processNode(Node $node, Scope $scope): array
+    {
+        return array_merge(
+            $this->findChainedAssignments($node),
+            $this->findMultipleStatementsPerLine($node),
+        );
+    }
+
+    /**
+     * Reports each statement whose top-level assignment chains into another assignment.
+     *
+     * Only the outermost link of a chain is reported so a single chained
+     * statement produces one error regardless of nesting depth.
+     *
+     * @return list<IdentifierRuleError>
+     */
+    private function findChainedAssignments(FileNode $node): array
+    {
+        /** @var list<Expression> $expressions */
+        $expressions = (new NodeFinder())->findInstanceOf($node->getNodes(), Expression::class);
+        $errors = [];
+
+        foreach ($expressions as $expression) {
+            if (!$expression->expr instanceof Assign) {
+                continue;
+            }
+
+            if (!$expression->expr->expr instanceof Assign) {
+                continue;
+            }
+
+            if ($this->allowChainedNull && $this->isAllNullChain($expression->expr)) {
+                continue;
+            }
+
+            $errors[] = RuleErrorBuilder::message(
+                'Chained assignment is forbidden: split into separate statements.',
+            )
+                ->identifier('haspadar.multipleVarDecl')
+                ->line($expression->getStartLine())
+                ->build();
+        }
+
+        return $errors;
+    }
+
+    /**
+     * Reports adjacent statements that share a line within any statement collection.
+     *
+     * Each statement list — file-level, function/method/closure bodies, branches
+     * of `if`/`else`, loop bodies, `switch` cases and `try`/`catch`/`finally` —
+     * is scanned and every pair of neighbours with an identical start line
+     * yields one error pinned to the second statement.
+     *
+     * @return list<IdentifierRuleError>
+     */
+    private function findMultipleStatementsPerLine(FileNode $node): array
+    {
+        $errors = [];
+
+        foreach ($this->statementLists->collect($node) as $stmts) {
+            $previousLine = 0;
+
+            foreach ($stmts as $stmt) {
+                if ($stmt->getStartLine() === $previousLine) {
+                    $errors[] = RuleErrorBuilder::message(
+                        'Only one statement is allowed per line.',
+                    )
+                        ->identifier('haspadar.multipleVarDecl')
+                        ->line($stmt->getStartLine())
+                        ->build();
+                }
+
+                $previousLine = $stmt->getStartLine();
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * Returns true when every assignment in the chain has `null` on its rightmost side.
+     */
+    private function isAllNullChain(Assign $assign): bool
+    {
+        $current = $assign;
+
+        while ($current->expr instanceof Assign) {
+            $current = $current->expr;
+        }
+
+        return $current->expr instanceof ConstFetch
+            && $current->expr->name->toLowerString() === 'null';
+    }
+}

--- a/src/Rules/MultipleVariableDeclarationsRule/StatementListCollector.php
+++ b/src/Rules/MultipleVariableDeclarationsRule/StatementListCollector.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Rules\MultipleVariableDeclarationsRule;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Stmt;
+use PhpParser\Node\Stmt\Catch_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Do_;
+use PhpParser\Node\Stmt\Else_;
+use PhpParser\Node\Stmt\ElseIf_;
+use PhpParser\Node\Stmt\For_;
+use PhpParser\Node\Stmt\Foreach_;
+use PhpParser\Node\Stmt\Function_;
+use PhpParser\Node\Stmt\If_;
+use PhpParser\Node\Stmt\Namespace_;
+use PhpParser\Node\Stmt\Switch_;
+use PhpParser\Node\Stmt\TryCatch;
+use PhpParser\Node\Stmt\While_;
+use PhpParser\NodeFinder;
+use PHPStan\Node\FileNode;
+
+/**
+ * Collects every list of statements that an AST file exposes as a child collection.
+ *
+ * The file-level node list is returned alongside the body of every node type
+ * whose `stmts` property carries a statement collection: namespaces,
+ * function-likes, branches of `if`/`else`/`elseif`, loop bodies, `switch`
+ * cases and `try`/`catch`/`finally` blocks.
+ */
+final readonly class StatementListCollector
+{
+    /**
+     * Returns every list of statements found inside the file.
+     *
+     * @param FileNode $node File-level AST node provided by PHPStan.
+     * @return list<array<array-key, Stmt>>
+     */
+    public function collect(FileNode $node): array
+    {
+        $lists = [array_filter(
+            $node->getNodes(),
+            static fn(Node $n): bool => $n instanceof Stmt,
+        )];
+
+        $simpleHolders = [
+            Function_::class,
+            Closure::class,
+            Namespace_::class,
+            If_::class,
+            ElseIf_::class,
+            Else_::class,
+            For_::class,
+            Foreach_::class,
+            While_::class,
+            Do_::class,
+            TryCatch::class,
+            Catch_::class,
+        ];
+
+        foreach ($simpleHolders as $type) {
+            foreach ($this->bodiesOf($node, $type) as $body) {
+                $lists[] = $body;
+            }
+        }
+
+        foreach ($this->classMethodBodies($node) as $body) {
+            $lists[] = $body;
+        }
+
+        foreach ($this->finallyBodies($node) as $body) {
+            $lists[] = $body;
+        }
+
+        foreach ($this->switchCaseBodies($node) as $body) {
+            $lists[] = $body;
+        }
+
+        return $lists;
+    }
+
+    /**
+     * Returns the `stmts` arrays of all nodes of the given type inside the file.
+     *
+     * @template T of Function_|Closure|Namespace_|If_|ElseIf_|Else_|For_|Foreach_|While_|Do_|TryCatch|Catch_
+     * @param class-string<T> $type
+     * @return list<array<array-key, Stmt>>
+     */
+    private function bodiesOf(FileNode $node, string $type): array
+    {
+        /** @var list<T> $matches */
+        $matches = (new NodeFinder())->findInstanceOf($node->getNodes(), $type);
+        $lists = [];
+
+        foreach ($matches as $match) {
+            $lists[] = $match->stmts;
+        }
+
+        return $lists;
+    }
+
+    /**
+     * Returns the bodies of every concrete `ClassMethod`, skipping abstract methods.
+     *
+     * @return list<array<array-key, Stmt>>
+     */
+    private function classMethodBodies(FileNode $node): array
+    {
+        /** @var list<ClassMethod> $methods */
+        $methods = (new NodeFinder())->findInstanceOf($node->getNodes(), ClassMethod::class);
+        $lists = [];
+
+        foreach ($methods as $method) {
+            if ($method->stmts !== null) {
+                $lists[] = $method->stmts;
+            }
+        }
+
+        return $lists;
+    }
+
+    /**
+     * Returns the bodies of every `finally` block attached to a `try` statement.
+     *
+     * @return list<array<array-key, Stmt>>
+     */
+    private function finallyBodies(FileNode $node): array
+    {
+        /** @var list<TryCatch> $tries */
+        $tries = (new NodeFinder())->findInstanceOf($node->getNodes(), TryCatch::class);
+        $lists = [];
+
+        foreach ($tries as $try) {
+            if ($try->finally !== null) {
+                $lists[] = $try->finally->stmts;
+            }
+        }
+
+        return $lists;
+    }
+
+    /**
+     * Returns the bodies of every `case` inside every `switch` statement.
+     *
+     * @return list<array<array-key, Stmt>>
+     */
+    private function switchCaseBodies(FileNode $node): array
+    {
+        /** @var list<Switch_> $switches */
+        $switches = (new NodeFinder())->findInstanceOf($node->getNodes(), Switch_::class);
+        $lists = [];
+
+        foreach ($switches as $switch) {
+            foreach ($switch->cases as $case) {
+                $lists[] = $case->stmts;
+            }
+        }
+
+        return $lists;
+    }
+}

--- a/tests/Fixtures/Rules/MultipleVariableDeclarationsRule/AssignInsideCondition.php
+++ b/tests/Fixtures/Rules/MultipleVariableDeclarationsRule/AssignInsideCondition.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\MultipleVariableDeclarationsRule;
+
+final class AssignInsideCondition
+{
+    public function run(): int
+    {
+        $source = 5;
+
+        if (($value = $source) > 0) {
+            return $value;
+        }
+
+        return 0;
+    }
+}

--- a/tests/Fixtures/Rules/MultipleVariableDeclarationsRule/ChainedAssignment.php
+++ b/tests/Fixtures/Rules/MultipleVariableDeclarationsRule/ChainedAssignment.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\MultipleVariableDeclarationsRule;
+
+final class ChainedAssignment
+{
+    public function run(): int
+    {
+        print 'header';
+        $a = $b = 1;
+        $second = 2;
+        $c = $d = 2;
+
+        return $a + $b + $c + $d + $second;
+    }
+}

--- a/tests/Fixtures/Rules/MultipleVariableDeclarationsRule/ChainedNullAssignment.php
+++ b/tests/Fixtures/Rules/MultipleVariableDeclarationsRule/ChainedNullAssignment.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\MultipleVariableDeclarationsRule;
+
+final class ChainedNullAssignment
+{
+    public function run(): bool
+    {
+        $a = $b = null;
+        $c = $d = null;
+
+        return $a === null && $b === null && $c === null && $d === null;
+    }
+}

--- a/tests/Fixtures/Rules/MultipleVariableDeclarationsRule/DeepChainedAssignment.php
+++ b/tests/Fixtures/Rules/MultipleVariableDeclarationsRule/DeepChainedAssignment.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\MultipleVariableDeclarationsRule;
+
+final class DeepChainedAssignment
+{
+    public function run(): int
+    {
+        $a = $b = $c = $d = 1;
+
+        return $a + $b + $c + $d;
+    }
+}

--- a/tests/Fixtures/Rules/MultipleVariableDeclarationsRule/Destructuring.php
+++ b/tests/Fixtures/Rules/MultipleVariableDeclarationsRule/Destructuring.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\MultipleVariableDeclarationsRule;
+
+final class Destructuring
+{
+    /**
+     * @return array{0: int, 1: int}
+     */
+    public function pair(): array
+    {
+        $tuple = [1, 2];
+        [$a, $b] = $tuple;
+
+        return [$a, $b];
+    }
+}

--- a/tests/Fixtures/Rules/MultipleVariableDeclarationsRule/FileLevelMultipleStatements.php
+++ b/tests/Fixtures/Rules/MultipleVariableDeclarationsRule/FileLevelMultipleStatements.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+$fileLevelA = 1; $fileLevelB = 2;

--- a/tests/Fixtures/Rules/MultipleVariableDeclarationsRule/ForLoopMultipleInits.php
+++ b/tests/Fixtures/Rules/MultipleVariableDeclarationsRule/ForLoopMultipleInits.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\MultipleVariableDeclarationsRule;
+
+final class ForLoopMultipleInits
+{
+    public function run(int $n): int
+    {
+        $sum = 0;
+
+        for ($i = 0, $j = $n; $i < $j; ++$i, --$j) {
+            $sum += $i;
+        }
+
+        return $sum;
+    }
+}

--- a/tests/Fixtures/Rules/MultipleVariableDeclarationsRule/MixedChains.php
+++ b/tests/Fixtures/Rules/MultipleVariableDeclarationsRule/MixedChains.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\MultipleVariableDeclarationsRule;
+
+final class MixedChains
+{
+    public function run(): bool
+    {
+        $a = $b = null;
+        $c = $d = 1;
+        $e = $f = null;
+
+        return $a === null && $b === null && $c === 1 && $d === 1 && $e === null && $f === null;
+    }
+}

--- a/tests/Fixtures/Rules/MultipleVariableDeclarationsRule/MultipleStatementsInLoops.php
+++ b/tests/Fixtures/Rules/MultipleVariableDeclarationsRule/MultipleStatementsInLoops.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\MultipleVariableDeclarationsRule;
+
+use RuntimeException;
+
+final class MultipleStatementsInLoops
+{
+    public function run(int $limit, array $items): int
+    {
+        $sum = 0;
+
+        for ($i = 0; $i < $limit; ++$i) {
+            $a = 1; $b = 2;
+            $sum += $a + $b;
+        }
+
+        foreach ($items as $item) {
+            $c = 1; $d = 2;
+            $sum += $c + $d;
+        }
+
+        while ($sum < 100) {
+            $e = 1; $f = 2;
+            $sum += $e + $f;
+        }
+
+        do {
+            $g = 1; $h = 2;
+            $sum += $g + $h;
+        } while ($sum < 200);
+
+        try {
+            $i = 1; $j = 2;
+            $sum += $i + $j;
+        } catch (RuntimeException $exception) {
+            $k = 1; $m = 2;
+            $sum += $k + $m;
+        } finally {
+            $n = 1; $o = 2;
+            $sum += $n + $o;
+        }
+
+        try {
+            $r = 1; $s = 2;
+            $sum += $r + $s;
+        } finally {
+            $t = 1; $u = 2;
+            $sum += $t + $u;
+        }
+
+        $closure = function (): int {
+            $p = 1; $q = 2;
+
+            return $p + $q;
+        };
+
+        return $sum + $closure();
+    }
+}

--- a/tests/Fixtures/Rules/MultipleVariableDeclarationsRule/MultipleStatementsPerLine.php
+++ b/tests/Fixtures/Rules/MultipleVariableDeclarationsRule/MultipleStatementsPerLine.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\MultipleVariableDeclarationsRule;
+
+final class MultipleStatementsPerLine
+{
+    public function run(int $value): int
+    {
+        $a = 1; $b = 2;
+
+        if ($value > 0) {
+            $c = 1; $d = 2;
+
+            return $a + $b + $c + $d;
+        }
+
+        switch ($value) {
+            case 0:
+                $e = 1; $f = 2;
+
+                return $a + $b + $e + $f;
+            case 1:
+                $g = 1; $h = 2;
+
+                return $a + $b + $g + $h;
+        }
+
+        return $a + $b;
+    }
+
+    public function tally(int $count): int
+    {
+        $sum = 0; $delta = 1;
+
+        return $sum + $count + $delta;
+    }
+}

--- a/tests/Fixtures/Rules/MultipleVariableDeclarationsRule/SingleAssignment.php
+++ b/tests/Fixtures/Rules/MultipleVariableDeclarationsRule/SingleAssignment.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\MultipleVariableDeclarationsRule;
+
+final class SingleAssignment
+{
+    public function run(): int
+    {
+        $a = 1;
+        $b = 2;
+
+        return $a + $b;
+    }
+}

--- a/tests/Fixtures/Rules/MultipleVariableDeclarationsRule/SuppressedChained.php
+++ b/tests/Fixtures/Rules/MultipleVariableDeclarationsRule/SuppressedChained.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\MultipleVariableDeclarationsRule;
+
+final class SuppressedChained
+{
+    public function run(): int
+    {
+        /** @phpstan-ignore haspadar.multipleVarDecl */
+        $a = $b = 1;
+
+        return $a + $b;
+    }
+}

--- a/tests/Unit/Rules/MultipleVariableDeclarationsRule/MultipleVariableDeclarationsRuleAllowChainedNullTest.php
+++ b/tests/Unit/Rules/MultipleVariableDeclarationsRule/MultipleVariableDeclarationsRuleAllowChainedNullTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\MultipleVariableDeclarationsRule;
+
+use Haspadar\PHPStanRules\Rules\MultipleVariableDeclarationsRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<MultipleVariableDeclarationsRule> */
+final class MultipleVariableDeclarationsRuleAllowChainedNullTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new MultipleVariableDeclarationsRule(['allowChainedNull' => true]);
+    }
+
+    #[Test]
+    public function passesChainedNullAssignmentWhenOptionIsEnabled(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/MultipleVariableDeclarationsRule/ChainedNullAssignment.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function reportsChainedNonNullAssignmentEvenWhenOptionIsEnabled(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/MultipleVariableDeclarationsRule/ChainedAssignment.php'],
+            [
+                ['Chained assignment is forbidden: split into separate statements.', 12],
+                ['Chained assignment is forbidden: split into separate statements.', 14],
+            ],
+        );
+    }
+
+    #[Test]
+    public function continuesAfterAcceptedNullChainToInspectLaterChains(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/MultipleVariableDeclarationsRule/MixedChains.php'],
+            [
+                ['Chained assignment is forbidden: split into separate statements.', 12],
+            ],
+        );
+    }
+}

--- a/tests/Unit/Rules/MultipleVariableDeclarationsRule/MultipleVariableDeclarationsRuleTest.php
+++ b/tests/Unit/Rules/MultipleVariableDeclarationsRule/MultipleVariableDeclarationsRuleTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\MultipleVariableDeclarationsRule;
+
+use Haspadar\PHPStanRules\Rules\MultipleVariableDeclarationsRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<MultipleVariableDeclarationsRule> */
+final class MultipleVariableDeclarationsRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new MultipleVariableDeclarationsRule();
+    }
+
+    #[Test]
+    public function passesWhenEachAssignmentIsOnItsOwnLine(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/MultipleVariableDeclarationsRule/SingleAssignment.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function reportsEveryChainedAssignmentIndependently(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/MultipleVariableDeclarationsRule/ChainedAssignment.php'],
+            [
+                ['Chained assignment is forbidden: split into separate statements.', 12],
+                ['Chained assignment is forbidden: split into separate statements.', 14],
+            ],
+        );
+    }
+
+    #[Test]
+    public function reportsDeepChainedAssignmentOnceAtTheOutermostLink(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/MultipleVariableDeclarationsRule/DeepChainedAssignment.php'],
+            [
+                ['Chained assignment is forbidden: split into separate statements.', 11],
+            ],
+        );
+    }
+
+    #[Test]
+    public function reportsChainedNullAssignmentByDefault(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/MultipleVariableDeclarationsRule/ChainedNullAssignment.php'],
+            [
+                ['Chained assignment is forbidden: split into separate statements.', 11],
+                ['Chained assignment is forbidden: split into separate statements.', 12],
+            ],
+        );
+    }
+
+    #[Test]
+    public function reportsTwoStatementsOnTheSameLineAcrossEveryStatementCollection(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/MultipleVariableDeclarationsRule/MultipleStatementsPerLine.php'],
+            [
+                ['Only one statement is allowed per line.', 11],
+                ['Only one statement is allowed per line.', 14],
+                ['Only one statement is allowed per line.', 21],
+                ['Only one statement is allowed per line.', 25],
+                ['Only one statement is allowed per line.', 35],
+            ],
+        );
+    }
+
+    #[Test]
+    public function reportsMultipleStatementsAtFileLevelOutsideAnyNamespace(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/MultipleVariableDeclarationsRule/FileLevelMultipleStatements.php'],
+            [
+                ['Only one statement is allowed per line.', 5],
+            ],
+        );
+    }
+
+    #[Test]
+    public function reportsMultipleStatementsInsideLoopsTryCatchAndClosureBodies(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/MultipleVariableDeclarationsRule/MultipleStatementsInLoops.php'],
+            [
+                ['Only one statement is allowed per line.', 16],
+                ['Only one statement is allowed per line.', 21],
+                ['Only one statement is allowed per line.', 26],
+                ['Only one statement is allowed per line.', 31],
+                ['Only one statement is allowed per line.', 36],
+                ['Only one statement is allowed per line.', 39],
+                ['Only one statement is allowed per line.', 42],
+                ['Only one statement is allowed per line.', 47],
+                ['Only one statement is allowed per line.', 50],
+                ['Only one statement is allowed per line.', 55],
+            ],
+        );
+    }
+
+    #[Test]
+    public function passesForLoopWithSeveralInitExpressions(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/MultipleVariableDeclarationsRule/ForLoopMultipleInits.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function passesAssignmentNestedInsideCondition(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/MultipleVariableDeclarationsRule/AssignInsideCondition.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function passesDestructuringAssignment(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/MultipleVariableDeclarationsRule/Destructuring.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function suppressesChainedAssignmentWhenPhpstanIgnorePresent(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/MultipleVariableDeclarationsRule/SuppressedChained.php'],
+            [],
+        );
+    }
+}

--- a/tests/Unit/RulesTest.php
+++ b/tests/Unit/RulesTest.php
@@ -69,6 +69,7 @@ use Haspadar\PHPStanRules\Rules\LackOfCohesionRule;
 use Haspadar\PHPStanRules\Rules\NoActorSuffixRule;
 use Haspadar\PHPStanRules\Rules\MissingThrowsRule;
 use Haspadar\PHPStanRules\Rules\HiddenFieldRule;
+use Haspadar\PHPStanRules\Rules\MultipleVariableDeclarationsRule;
 use Haspadar\PHPStanRules\Rules\RequireIgnoreReasonRule;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -145,6 +146,7 @@ final class RulesTest extends TestCase
                 MissingThrowsRule::class,
                 HiddenFieldRule::class,
                 RequireIgnoreReasonRule::class,
+                MultipleVariableDeclarationsRule::class,
             ],
             (new Rules())->all(),
             'Rules::all() must list every registered rule class',


### PR DESCRIPTION
- Added MultipleVariableDeclarationsRule reporting chained assignments and statements that share a source line
- Added StatementListCollector to expose every statement collection an AST file holds
- Added 9 fixtures and 14 unit tests covering chained chains, per-line cases inside loops, switch cases, try/catch/finally and closures, suppression and the allowChainedNull option
- Added rule registration with configurable allowChainedNull option (default false)
- Updated README to list the new rule and its configuration

Closes #170