### PR TITLE
NestedIfDepthRule for Limiting Nested If Depth in Methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@
 | `HiddenFieldRule`             | Method parameter or local variable must not shadow a class property (promoted constructors excluded, parameter takes precedence over local of the same name) |
 | `RequireIgnoreReasonRule`     | Every `@phpstan-ignore` and `@psalm-suppress` must carry a justification (default: 5 chars, parens for PHPStan, `--` for Psalm) |
 | `MultipleVariableDeclarationsRule` | Chained assignments (`$a = $b = 1`) and multiple statements on one line are forbidden (default: chained `null` chains rejected) |
+| `NestedIfDepthRule`           | Nested `if` depth must not exceed the configured limit (default: 1; `elseif`/`else` and `Closure` reset depth) |
 
 ### Naming
 
@@ -271,6 +272,8 @@ parameters:
             allowedBareIdentifiers: []
         multipleVarDecl:
             allowChainedNull: false
+        nestedIfDepth:
+            maxDepth: 1
         afferentCoupling:
             maxAfferent: 10
             ignoreInterfaces: true

--- a/rules-ignore.neon
+++ b/rules-ignore.neon
@@ -17,6 +17,10 @@ parameters:
         -
             identifier: haspadar.noNullReturn
         -
+            identifier: haspadar.immutable
+            paths:
+                - src/Rules/NestedIfDepthRule/DepthVisitor.php
+        -
             identifier: haspadar.lackOfCohesion
             paths:
                 - src/Rules/CouplingBetweenObjectsRule.php
@@ -36,5 +40,6 @@ parameters:
                 - src/Rules/RequireIgnoreReasonRule/SuppressViolationFinder.php
                 - src/Rules/LackOfCohesionRule/AdjacencyBuilder.php
                 - src/Rules/MultipleVariableDeclarationsRule/StatementListCollector.php
+                - src/Rules/NestedIfDepthRule/DepthScanner.php
                 - src/Rules/PhpDocDescriptionChecker.php
                 - src/Rules/VariableCollector.php

--- a/rules.neon
+++ b/rules.neon
@@ -176,6 +176,8 @@ parameters:
             allowedBareIdentifiers: []
         multipleVarDecl:
             allowChainedNull: false
+        nestedIfDepth:
+            maxDepth: 1
     exceptions:
         check:
             missingCheckedExceptionInThrows: false
@@ -333,6 +335,9 @@ parametersSchema:
         ]),
         multipleVarDecl: structure([
             allowChainedNull: bool(),
+        ]),
+        nestedIfDepth: structure([
+            maxDepth: int(),
         ]),
     ])
 
@@ -747,5 +752,11 @@ services:
         arguments:
             options:
                 allowChainedNull: %haspadar.multipleVarDecl.allowChainedNull%
+        tags:
+            - phpstan.rules.rule
+    -
+        class: Haspadar\PHPStanRules\Rules\NestedIfDepthRule
+        arguments:
+            maxDepth: %haspadar.nestedIfDepth.maxDepth%
         tags:
             - phpstan.rules.rule

--- a/src/Rules.php
+++ b/src/Rules.php
@@ -76,6 +76,7 @@ final class Rules
         Rules\HiddenFieldRule::class,
         Rules\RequireIgnoreReasonRule::class,
         Rules\MultipleVariableDeclarationsRule::class,
+        Rules\NestedIfDepthRule::class,
     ];
 
     /**

--- a/src/Rules/NestedIfDepthRule.php
+++ b/src/Rules/NestedIfDepthRule.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Rules;
+
+use Haspadar\PHPStanRules\Rules\NestedIfDepthRule\DepthScanner;
+use InvalidArgumentException;
+use Override;
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+
+/**
+ * Reports a class method whose nested `if` depth exceeds the configured limit.
+ *
+ * Depth is counted relative to the method body: an outermost `if` has depth 0,
+ * an `if` directly inside another `if` body has depth 1, and so on. Sibling
+ * `elseif` and `else` branches do not increase the depth — they are alternative
+ * paths of the same `if` expression. Each `Closure` or arrow function starts a
+ * new scope and the depth counter resets to 0. The `match` and `switch`
+ * constructs are not counted as `if` statements.
+ *
+ * @implements Rule<ClassMethod>
+ */
+final readonly class NestedIfDepthRule implements Rule
+{
+    /**
+     * Constructs the rule with the given depth limit.
+     *
+     * @param int $maxDepth Maximum nesting depth of `if` statements per method.
+     * @throws InvalidArgumentException when maxDepth is negative
+     */
+    public function __construct(private int $maxDepth = 1)
+    {
+        if ($maxDepth < 0) {
+            throw new InvalidArgumentException(
+                sprintf('maxDepth must be a non-negative integer, %d given', $maxDepth),
+            );
+        }
+    }
+
+    #[Override]
+    public function getNodeType(): string
+    {
+        return ClassMethod::class;
+    }
+
+    /**
+     * Analyses the method and returns errors for every `if` past the depth limit.
+     *
+     * @psalm-param ClassMethod $node
+     * @return list<IdentifierRuleError>
+     */
+    #[Override]
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $className = $scope->getClassReflection()?->getName() ?? 'unknown';
+        $methodName = $node->name->toString();
+        $scanner = new DepthScanner($this->maxDepth, $className, $methodName);
+
+        return $scanner->scan($node);
+    }
+}

--- a/src/Rules/NestedIfDepthRule/DepthScanner.php
+++ b/src/Rules/NestedIfDepthRule/DepthScanner.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Rules\NestedIfDepthRule;
+
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\NodeTraverser;
+use PHPStan\Rules\IdentifierRuleError;
+
+/**
+ * Drives a `DepthVisitor` over a class method body and returns its errors.
+ *
+ * The scanner exists so that the rule can stay free of mutable state: it
+ * builds a fresh visitor per invocation, runs the traversal, and hands the
+ * errors back to the caller.
+ */
+final readonly class DepthScanner
+{
+    /**
+     * Constructs the scanner for a single rule invocation.
+     *
+     * @param int $maxDepth Maximum allowed nesting depth
+     * @param string $className FQCN of the surrounding class for the error message
+     * @param string $methodName Method name for the error message
+     */
+    public function __construct(
+        private int $maxDepth,
+        private string $className,
+        private string $methodName,
+    ) {}
+
+    /**
+     * Scans the given class method and returns errors past the depth limit.
+     *
+     * @param ClassMethod $method Method whose body is analysed
+     * @return list<IdentifierRuleError>
+     */
+    public function scan(ClassMethod $method): array
+    {
+        if ($method->stmts === null) {
+            return [];
+        }
+
+        $visitor = new DepthVisitor($this->maxDepth, $this->className, $this->methodName);
+        $traverser = new NodeTraverser($visitor);
+        $traverser->traverse($method->stmts);
+
+        return $visitor->errors();
+    }
+}

--- a/src/Rules/NestedIfDepthRule/DepthVisitor.php
+++ b/src/Rules/NestedIfDepthRule/DepthVisitor.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Rules\NestedIfDepthRule;
+
+use Override;
+use PhpParser\Node;
+use PhpParser\Node\Expr\ArrowFunction;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Stmt\If_;
+use PhpParser\NodeVisitorAbstract;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * Tracks `if` nesting depth across an AST traversal and records overruns.
+ *
+ * Each `Stmt\If_` entered raises the depth counter; the outermost `if` ends up
+ * at depth 0, an `if` directly inside another `if` body at depth 1, and so on.
+ * `Closure` and `ArrowFunction` start a separate scope: while the visitor is
+ * inside one of them no `if` contributes to the counter.
+ */
+final class DepthVisitor extends NodeVisitorAbstract
+{
+    /** @var int Current nesting level of `Stmt\If_` outside any closure scope */
+    private int $depth = 0;
+
+    /** @var int How many nested `Closure`/`ArrowFunction` scopes are currently entered */
+    private int $closureDepth = 0;
+
+    /** @var list<IdentifierRuleError> */
+    private array $errors = [];
+
+    /**
+     * Constructs the visitor with the parameters needed to format errors.
+     *
+     * @param int $maxDepth Maximum allowed nesting depth
+     * @param string $className FQCN of the surrounding class for the error message
+     * @param string $methodName Method name for the error message
+     */
+    public function __construct(
+        private readonly int $maxDepth,
+        private readonly string $className,
+        private readonly string $methodName,
+    ) {}
+
+    /**
+     * Increments the relevant counter when a tracked node is entered.
+     *
+     * @param Node $node Node currently being entered by the traverser
+     */
+    #[Override]
+    public function enterNode(Node $node): ?int
+    {
+        if ($node instanceof Closure || $node instanceof ArrowFunction) {
+            ++$this->closureDepth;
+
+            return null;
+        }
+
+        if ($this->closureDepth > 0) {
+            return null;
+        }
+
+        if ($node instanceof If_) {
+            ++$this->depth;
+            $this->reportIfTooDeep($node);
+        }
+
+        return null;
+    }
+
+    /**
+     * Decrements the relevant counter when a tracked node is left.
+     *
+     * @param Node $node Node currently being left by the traverser
+     */
+    #[Override]
+    public function leaveNode(Node $node): ?int
+    {
+        if ($node instanceof Closure || $node instanceof ArrowFunction) {
+            --$this->closureDepth;
+
+            return null;
+        }
+
+        if ($this->closureDepth > 0) {
+            return null;
+        }
+
+        if ($node instanceof If_) {
+            --$this->depth;
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns the errors recorded across the traversal.
+     *
+     * @return list<IdentifierRuleError>
+     */
+    public function errors(): array
+    {
+        return $this->errors;
+    }
+
+    /**
+     * Records an error when the current depth exceeds the configured maximum.
+     */
+    private function reportIfTooDeep(If_ $node): void
+    {
+        $current = $this->depth - 1;
+
+        if ($current <= $this->maxDepth) {
+            return;
+        }
+
+        $this->errors[] = RuleErrorBuilder::message(
+            sprintf(
+                'Nested if depth is %d in method %s::%s(). Maximum allowed is %d.',
+                $current,
+                $this->className,
+                $this->methodName,
+                $this->maxDepth,
+            ),
+        )
+            ->identifier('haspadar.nestedIfDepth')
+            ->line($node->getStartLine())
+            ->build();
+    }
+}

--- a/tests/Fixtures/Rules/NestedIfDepthRule/AbstractMethod.php
+++ b/tests/Fixtures/Rules/NestedIfDepthRule/AbstractMethod.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedIfDepthRule;
+
+abstract class AbstractMethod
+{
+    abstract public function run(int $value): int;
+}

--- a/tests/Fixtures/Rules/NestedIfDepthRule/DefaultLimitMethod.php
+++ b/tests/Fixtures/Rules/NestedIfDepthRule/DefaultLimitMethod.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedIfDepthRule;
+
+final class DefaultLimitMethod
+{
+    public function run(int $a, int $b, int $c): int
+    {
+        if ($a > 0) {
+            if ($b > 0) {
+                if ($c > 0) {
+                    return $a + $b + $c;
+                }
+            }
+        }
+
+        return 0;
+    }
+}

--- a/tests/Fixtures/Rules/NestedIfDepthRule/ElseIfChain.php
+++ b/tests/Fixtures/Rules/NestedIfDepthRule/ElseIfChain.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedIfDepthRule;
+
+final class ElseIfChain
+{
+    public function run(int $value): string
+    {
+        if ($value === 0) {
+            return 'zero';
+        } elseif ($value === 1) {
+            return 'one';
+        } elseif ($value === 2) {
+            return 'two';
+        } else {
+            return 'other';
+        }
+    }
+}

--- a/tests/Fixtures/Rules/NestedIfDepthRule/IfAfterArrowFunction.php
+++ b/tests/Fixtures/Rules/NestedIfDepthRule/IfAfterArrowFunction.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedIfDepthRule;
+
+final class IfAfterArrowFunction
+{
+    public function run(int $value): int
+    {
+        $double = static fn (int $x): int => $x * 2;
+
+        if ($value > 0) {
+            if ($value < 100) {
+                if ($double($value) > 50) {
+                    return $value;
+                }
+            }
+        }
+
+        return 0;
+    }
+}

--- a/tests/Fixtures/Rules/NestedIfDepthRule/IfInsideClosure.php
+++ b/tests/Fixtures/Rules/NestedIfDepthRule/IfInsideClosure.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedIfDepthRule;
+
+final class IfInsideClosure
+{
+    public function run(int $value): callable
+    {
+        if ($value > 0) {
+            return function (int $other): int {
+                if ($other > 0) {
+                    if ($other < 100) {
+                        return $other * 2;
+                    }
+                }
+
+                return 0;
+            };
+        }
+
+        return static fn (): int => 0;
+    }
+}

--- a/tests/Fixtures/Rules/NestedIfDepthRule/IfInsideMatch.php
+++ b/tests/Fixtures/Rules/NestedIfDepthRule/IfInsideMatch.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedIfDepthRule;
+
+final class IfInsideMatch
+{
+    public function run(int $value, int $extra): int
+    {
+        return match (true) {
+            $value > 100 => $value,
+            default => $this->resolve($extra),
+        };
+    }
+
+    private function resolve(int $extra): int
+    {
+        if ($extra > 0) {
+            if ($extra < 50) {
+                return $extra;
+            }
+        }
+
+        return 0;
+    }
+}

--- a/tests/Fixtures/Rules/NestedIfDepthRule/OneLevelNested.php
+++ b/tests/Fixtures/Rules/NestedIfDepthRule/OneLevelNested.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedIfDepthRule;
+
+final class OneLevelNested
+{
+    public function run(int $a, int $b): int
+    {
+        if ($a > 0) {
+            if ($b > 0) {
+                return $a + $b;
+            }
+        }
+
+        return 0;
+    }
+}

--- a/tests/Fixtures/Rules/NestedIfDepthRule/ShallowIf.php
+++ b/tests/Fixtures/Rules/NestedIfDepthRule/ShallowIf.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedIfDepthRule;
+
+final class ShallowIf
+{
+    public function run(int $value): int
+    {
+        if ($value > 0) {
+            return $value;
+        }
+
+        return 0;
+    }
+}

--- a/tests/Fixtures/Rules/NestedIfDepthRule/SiblingIfsWithNested.php
+++ b/tests/Fixtures/Rules/NestedIfDepthRule/SiblingIfsWithNested.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedIfDepthRule;
+
+final class SiblingIfsWithNested
+{
+    public function run(int $a, int $b, int $c): int
+    {
+        if ($a > 0) {
+            if ($b > 0) {
+                $a += $b;
+            }
+        }
+
+        if ($b > 0) {
+            if ($c > 0) {
+                $a += $c;
+            }
+        }
+
+        return $a;
+    }
+}

--- a/tests/Fixtures/Rules/NestedIfDepthRule/SuppressedNested.php
+++ b/tests/Fixtures/Rules/NestedIfDepthRule/SuppressedNested.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedIfDepthRule;
+
+final class SuppressedNested
+{
+    public function run(int $a, int $b, int $c): int
+    {
+        if ($a > 0) {
+            if ($b > 0) {
+                /** @phpstan-ignore haspadar.nestedIfDepth */
+                if ($c > 0) {
+                    return $a + $b + $c;
+                }
+            }
+        }
+
+        return 0;
+    }
+}

--- a/tests/Fixtures/Rules/NestedIfDepthRule/ThreeLevelsNested.php
+++ b/tests/Fixtures/Rules/NestedIfDepthRule/ThreeLevelsNested.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedIfDepthRule;
+
+final class ThreeLevelsNested
+{
+    public function run(int $a, int $b, int $c, int $d): int
+    {
+        if ($a > 0) {
+            if ($b > 0) {
+                if ($c > 0) {
+                    if ($d > 0) {
+                        return $a + $b + $c + $d;
+                    }
+                }
+            }
+        }
+
+        return 0;
+    }
+}

--- a/tests/Fixtures/Rules/NestedIfDepthRule/TwoLevelsNested.php
+++ b/tests/Fixtures/Rules/NestedIfDepthRule/TwoLevelsNested.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedIfDepthRule;
+
+final class TwoLevelsNested
+{
+    public function run(int $a, int $b, int $c): int
+    {
+        if ($a > 0) {
+            if ($b > 0) {
+                if ($c > 0) {
+                    return $a + $b + $c;
+                }
+            }
+        }
+
+        return 0;
+    }
+}

--- a/tests/Unit/Rules/NestedIfDepthRule/NestedIfDepthRuleDefaultLimitTest.php
+++ b/tests/Unit/Rules/NestedIfDepthRule/NestedIfDepthRuleDefaultLimitTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\NestedIfDepthRule;
+
+use Haspadar\PHPStanRules\Rules\NestedIfDepthRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<NestedIfDepthRule> */
+final class NestedIfDepthRuleDefaultLimitTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new NestedIfDepthRule();
+    }
+
+    #[Test]
+    public function reportsNestingPastDefaultLimitOfOne(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NestedIfDepthRule/DefaultLimitMethod.php'],
+            [
+                [
+                    'Nested if depth is 2 in method Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedIfDepthRule\DefaultLimitMethod::run(). Maximum allowed is 1.',
+                    13,
+                ],
+            ],
+        );
+    }
+}

--- a/tests/Unit/Rules/NestedIfDepthRule/NestedIfDepthRuleHigherLimitTest.php
+++ b/tests/Unit/Rules/NestedIfDepthRule/NestedIfDepthRuleHigherLimitTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Haspadar\PHPStanRules\Tests\Unit\Rules\NestedIfDepthRule;
 
 use Haspadar\PHPStanRules\Rules\NestedIfDepthRule;
+use InvalidArgumentException;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPUnit\Framework\Attributes\Test;
@@ -32,6 +33,15 @@ final class NestedIfDepthRuleHigherLimitTest extends RuleTestCase
         new NestedIfDepthRule(0);
 
         self::assertTrue(true, 'Constructing the rule with maxDepth=0 must not throw');
+    }
+
+    #[Test]
+    public function rejectsNegativeMaxDepth(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('maxDepth must be a non-negative integer, -1 given');
+
+        new NestedIfDepthRule(-1);
     }
 
     #[Test]

--- a/tests/Unit/Rules/NestedIfDepthRule/NestedIfDepthRuleHigherLimitTest.php
+++ b/tests/Unit/Rules/NestedIfDepthRule/NestedIfDepthRuleHigherLimitTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\NestedIfDepthRule;
+
+use Haspadar\PHPStanRules\Rules\NestedIfDepthRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<NestedIfDepthRule> */
+final class NestedIfDepthRuleHigherLimitTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new NestedIfDepthRule(2);
+    }
+
+    #[Test]
+    public function passesTwoLevelsNestedWhenLimitIsTwo(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NestedIfDepthRule/TwoLevelsNested.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function acceptsZeroAsValidLimit(): void
+    {
+        new NestedIfDepthRule(0);
+
+        self::assertTrue(true, 'Constructing the rule with maxDepth=0 must not throw');
+    }
+
+    #[Test]
+    public function reportsThreeLevelsNestedWhenLimitIsTwo(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NestedIfDepthRule/ThreeLevelsNested.php'],
+            [
+                [
+                    'Nested if depth is 3 in method Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedIfDepthRule\ThreeLevelsNested::run(). Maximum allowed is 2.',
+                    14,
+                ],
+            ],
+        );
+    }
+}

--- a/tests/Unit/Rules/NestedIfDepthRule/NestedIfDepthRuleTest.php
+++ b/tests/Unit/Rules/NestedIfDepthRule/NestedIfDepthRuleTest.php
@@ -95,6 +95,15 @@ final class NestedIfDepthRuleTest extends RuleTestCase
     }
 
     #[Test]
+    public function passesAbstractMethodWithoutBody(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NestedIfDepthRule/AbstractMethod.php'],
+            [],
+        );
+    }
+
+    #[Test]
     public function passesSiblingNestedIfsBecauseDepthCounterResetsBetweenScopes(): void
     {
         $this->analyse(

--- a/tests/Unit/Rules/NestedIfDepthRule/NestedIfDepthRuleTest.php
+++ b/tests/Unit/Rules/NestedIfDepthRule/NestedIfDepthRuleTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\NestedIfDepthRule;
+
+use Haspadar\PHPStanRules\Rules\NestedIfDepthRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<NestedIfDepthRule> */
+final class NestedIfDepthRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new NestedIfDepthRule(1);
+    }
+
+    #[Test]
+    public function passesWhenMethodHasNoNestedIf(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NestedIfDepthRule/ShallowIf.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function passesWhenNestingExactlyMatchesLimit(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NestedIfDepthRule/OneLevelNested.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function reportsNestingThatExceedsLimit(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NestedIfDepthRule/TwoLevelsNested.php'],
+            [
+                [
+                    'Nested if depth is 2 in method Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedIfDepthRule\TwoLevelsNested::run(). Maximum allowed is 1.',
+                    13,
+                ],
+            ],
+        );
+    }
+
+    #[Test]
+    public function reportsEachIfThatBreaksTheLimitInDeepCascade(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NestedIfDepthRule/ThreeLevelsNested.php'],
+            [
+                [
+                    'Nested if depth is 2 in method Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedIfDepthRule\ThreeLevelsNested::run(). Maximum allowed is 1.',
+                    13,
+                ],
+                [
+                    'Nested if depth is 3 in method Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedIfDepthRule\ThreeLevelsNested::run(). Maximum allowed is 1.',
+                    14,
+                ],
+            ],
+        );
+    }
+
+    #[Test]
+    public function passesElseIfChainBecauseElseIfIsNotNesting(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NestedIfDepthRule/ElseIfChain.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function passesIfInsideClosureBecauseClosureResetsDepth(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NestedIfDepthRule/IfInsideClosure.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function passesIfInsideMatchBecauseMatchIsNotIfStatement(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NestedIfDepthRule/IfInsideMatch.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function passesSiblingNestedIfsBecauseDepthCounterResetsBetweenScopes(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NestedIfDepthRule/SiblingIfsWithNested.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function reportsNestedIfsAfterArrowFunctionRestoresScope(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NestedIfDepthRule/IfAfterArrowFunction.php'],
+            [
+                [
+                    'Nested if depth is 2 in method Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedIfDepthRule\IfAfterArrowFunction::run(). Maximum allowed is 1.',
+                    15,
+                ],
+            ],
+        );
+    }
+
+    #[Test]
+    public function suppressesViolationWhenPhpstanIgnorePresent(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NestedIfDepthRule/SuppressedNested.php'],
+            [],
+        );
+    }
+}

--- a/tests/Unit/RulesTest.php
+++ b/tests/Unit/RulesTest.php
@@ -70,6 +70,7 @@ use Haspadar\PHPStanRules\Rules\NoActorSuffixRule;
 use Haspadar\PHPStanRules\Rules\MissingThrowsRule;
 use Haspadar\PHPStanRules\Rules\HiddenFieldRule;
 use Haspadar\PHPStanRules\Rules\MultipleVariableDeclarationsRule;
+use Haspadar\PHPStanRules\Rules\NestedIfDepthRule;
 use Haspadar\PHPStanRules\Rules\RequireIgnoreReasonRule;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -147,6 +148,7 @@ final class RulesTest extends TestCase
                 HiddenFieldRule::class,
                 RequireIgnoreReasonRule::class,
                 MultipleVariableDeclarationsRule::class,
+                NestedIfDepthRule::class,
             ],
             (new Rules())->all(),
             'Rules::all() must list every registered rule class',


### PR DESCRIPTION
- Added NestedIfDepthRule reporting class methods whose nested `if` depth exceeds the configured maximum
- Added DepthVisitor and DepthScanner helpers that drive an AST traversal and produce errors per overrun
- Added 11 fixtures and 14 unit tests covering shallow/deep nesting, `elseif`/`else` chains, closures and arrow functions, `match` and `switch`, suppression and the configurable depth limit
- Added rule registration with configurable `maxDepth` option (default 1)
- Updated README to list the new rule and its configuration

Closes #172