### PR TITLE
Limit Nested Loop Depth Per Method With NestedForDepthRule

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@
 | `RequireIgnoreReasonRule`     | Every `@phpstan-ignore` and `@psalm-suppress` must carry a justification (default: 5 chars, parens for PHPStan, `--` for Psalm) |
 | `MultipleVariableDeclarationsRule` | Chained assignments (`$a = $b = 1`) and multiple statements on one line are forbidden (default: chained `null` chains rejected) |
 | `NestedIfDepthRule`           | Nested `if` depth must not exceed the configured limit (default: 1; `elseif`/`else` and `Closure` reset depth) |
+| `NestedForDepthRule`          | Nested loop depth (`for`/`foreach`/`while`/`do-while`) must not exceed the configured limit (default: 1; `Closure` resets depth) |
 
 ### Naming
 
@@ -273,6 +274,8 @@ parameters:
         multipleVarDecl:
             allowChainedNull: false
         nestedIfDepth:
+            maxDepth: 1
+        nestedForDepth:
             maxDepth: 1
         afferentCoupling:
             maxAfferent: 10

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@
 | `RequireIgnoreReasonRule`     | Every `@phpstan-ignore` and `@psalm-suppress` must carry a justification (default: 5 chars, parens for PHPStan, `--` for Psalm) |
 | `MultipleVariableDeclarationsRule` | Chained assignments (`$a = $b = 1`) and multiple statements on one line are forbidden (default: chained `null` chains rejected) |
 | `NestedIfDepthRule`           | Nested `if` depth must not exceed the configured limit (default: 1; `elseif`/`else` and `Closure` reset depth) |
-| `NestedForDepthRule`          | Nested loop depth (`for`/`foreach`/`while`/`do-while`) must not exceed the configured limit (default: 1; `Closure` resets depth) |
+| `NestedForDepthRule`          | Nested loop depth (`for`/`foreach`/`while`/`do-while`) must not exceed the configured limit (default: 1; `Closure` and arrow functions reset depth) |
 
 ### Naming
 

--- a/rules-ignore.neon
+++ b/rules-ignore.neon
@@ -20,6 +20,12 @@ parameters:
             identifier: haspadar.immutable
             paths:
                 - src/Rules/NestedIfDepthRule/DepthVisitor.php
+                - src/Rules/NestedForDepthRule/DepthVisitor.php
+        -
+            identifier: haspadar.nestedForDepth
+            paths:
+                - src/Rules/AfferentCouplingRule.php
+                - src/Rules/InstabilityRule/DependencyGraph.php
         -
             identifier: haspadar.lackOfCohesion
             paths:
@@ -40,6 +46,7 @@ parameters:
                 - src/Rules/RequireIgnoreReasonRule/SuppressViolationFinder.php
                 - src/Rules/LackOfCohesionRule/AdjacencyBuilder.php
                 - src/Rules/MultipleVariableDeclarationsRule/StatementListCollector.php
+                - src/Rules/NestedForDepthRule/DepthScanner.php
                 - src/Rules/NestedIfDepthRule/DepthScanner.php
                 - src/Rules/PhpDocDescriptionChecker.php
                 - src/Rules/VariableCollector.php

--- a/rules.neon
+++ b/rules.neon
@@ -178,6 +178,8 @@ parameters:
             allowChainedNull: false
         nestedIfDepth:
             maxDepth: 1
+        nestedForDepth:
+            maxDepth: 1
     exceptions:
         check:
             missingCheckedExceptionInThrows: false
@@ -337,6 +339,9 @@ parametersSchema:
             allowChainedNull: bool(),
         ]),
         nestedIfDepth: structure([
+            maxDepth: int(),
+        ]),
+        nestedForDepth: structure([
             maxDepth: int(),
         ]),
     ])
@@ -758,5 +763,11 @@ services:
         class: Haspadar\PHPStanRules\Rules\NestedIfDepthRule
         arguments:
             maxDepth: %haspadar.nestedIfDepth.maxDepth%
+        tags:
+            - phpstan.rules.rule
+    -
+        class: Haspadar\PHPStanRules\Rules\NestedForDepthRule
+        arguments:
+            maxDepth: %haspadar.nestedForDepth.maxDepth%
         tags:
             - phpstan.rules.rule

--- a/src/Rules.php
+++ b/src/Rules.php
@@ -77,6 +77,7 @@ final class Rules
         Rules\RequireIgnoreReasonRule::class,
         Rules\MultipleVariableDeclarationsRule::class,
         Rules\NestedIfDepthRule::class,
+        Rules\NestedForDepthRule::class,
     ];
 
     /**

--- a/src/Rules/NestedForDepthRule.php
+++ b/src/Rules/NestedForDepthRule.php
@@ -20,8 +20,9 @@ use PHPStan\Rules\Rule;
  * `while`, and `do-while`: an outermost loop has depth 0, a loop directly
  * inside another loop body has depth 1, and so on. Conditional statements
  * (`if`, `else`, `match`, `switch`) between loops do not increase the
- * depth — they belong to other rules. Each `Closure` or arrow function
- * starts a new scope and the depth counter resets to 0.
+ * depth — they belong to other rules. Loops inside a `Closure` or arrow
+ * function are excluded from depth counting; the rule tracks nesting only
+ * at the surrounding method level.
  *
  * @implements Rule<ClassMethod>
  */

--- a/src/Rules/NestedForDepthRule.php
+++ b/src/Rules/NestedForDepthRule.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Rules;
+
+use Haspadar\PHPStanRules\Rules\NestedForDepthRule\DepthScanner;
+use InvalidArgumentException;
+use Override;
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+
+/**
+ * Reports a class method whose nested loop depth exceeds the configured limit.
+ *
+ * Depth is counted relative to the method body across `for`, `foreach`,
+ * `while`, and `do-while`: an outermost loop has depth 0, a loop directly
+ * inside another loop body has depth 1, and so on. Conditional statements
+ * (`if`, `else`, `match`, `switch`) between loops do not increase the
+ * depth — they belong to other rules. Each `Closure` or arrow function
+ * starts a new scope and the depth counter resets to 0.
+ *
+ * @implements Rule<ClassMethod>
+ */
+final readonly class NestedForDepthRule implements Rule
+{
+    /**
+     * Constructs the rule with the given depth limit.
+     *
+     * @param int $maxDepth Maximum nesting depth of loop statements per method
+     * @throws InvalidArgumentException when maxDepth is negative
+     */
+    public function __construct(private int $maxDepth = 1)
+    {
+        if ($maxDepth < 0) {
+            throw new InvalidArgumentException(
+                sprintf('maxDepth must be a non-negative integer, %d given', $maxDepth),
+            );
+        }
+    }
+
+    #[Override]
+    public function getNodeType(): string
+    {
+        return ClassMethod::class;
+    }
+
+    /**
+     * Analyses the method and returns errors for every loop past the depth limit.
+     *
+     * @psalm-param ClassMethod $node
+     * @return list<IdentifierRuleError>
+     */
+    #[Override]
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $className = $scope->getClassReflection()?->getName() ?? 'unknown';
+        $methodName = $node->name->toString();
+        $scanner = new DepthScanner($this->maxDepth, $className, $methodName);
+
+        return $scanner->scan($node);
+    }
+}

--- a/src/Rules/NestedForDepthRule/DepthScanner.php
+++ b/src/Rules/NestedForDepthRule/DepthScanner.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Rules\NestedForDepthRule;
+
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\NodeTraverser;
+use PHPStan\Rules\IdentifierRuleError;
+
+/**
+ * Drives a `DepthVisitor` over a class method body and returns its errors.
+ *
+ * The scanner exists so that the rule can stay free of mutable state: it
+ * builds a fresh visitor per invocation, runs the traversal, and hands the
+ * errors back to the caller.
+ */
+final readonly class DepthScanner
+{
+    /**
+     * Constructs the scanner for a single rule invocation.
+     *
+     * @param int $maxDepth Maximum allowed nesting depth
+     * @param string $className FQCN of the surrounding class for the error message
+     * @param string $methodName Method name for the error message
+     */
+    public function __construct(
+        private int $maxDepth,
+        private string $className,
+        private string $methodName,
+    ) {}
+
+    /**
+     * Scans the given class method and returns errors past the depth limit.
+     *
+     * @param ClassMethod $method Method whose body is analysed
+     * @return list<IdentifierRuleError>
+     */
+    public function scan(ClassMethod $method): array
+    {
+        if ($method->stmts === null) {
+            return [];
+        }
+
+        $visitor = new DepthVisitor($this->maxDepth, $this->className, $this->methodName);
+        $traverser = new NodeTraverser($visitor);
+        $traverser->traverse($method->stmts);
+
+        return $visitor->errors();
+    }
+}

--- a/src/Rules/NestedForDepthRule/DepthVisitor.php
+++ b/src/Rules/NestedForDepthRule/DepthVisitor.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Rules\NestedForDepthRule;
+
+use Override;
+use PhpParser\Node;
+use PhpParser\Node\Expr\ArrowFunction;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Stmt\Do_;
+use PhpParser\Node\Stmt\For_;
+use PhpParser\Node\Stmt\Foreach_;
+use PhpParser\Node\Stmt\While_;
+use PhpParser\NodeVisitorAbstract;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * Tracks loop nesting depth across an AST traversal and records overruns.
+ *
+ * Each `for`, `foreach`, `while`, and `do-while` entered raises the depth
+ * counter; the outermost loop ends up at depth 0, a loop directly inside
+ * another loop body at depth 1, and so on. `Closure` and `ArrowFunction`
+ * start a separate scope: while the visitor is inside one of them no loop
+ * contributes to the counter.
+ */
+final class DepthVisitor extends NodeVisitorAbstract
+{
+    /** @var int Current nesting level of loop statements outside any closure scope */
+    private int $depth = 0;
+
+    /** @var int How many nested `Closure`/`ArrowFunction` scopes are currently entered */
+    private int $closureDepth = 0;
+
+    /** @var list<IdentifierRuleError> */
+    private array $errors = [];
+
+    /**
+     * Constructs the visitor with the parameters needed to format errors.
+     *
+     * @param int $maxDepth Maximum allowed nesting depth
+     * @param string $className FQCN of the surrounding class for the error message
+     * @param string $methodName Method name for the error message
+     */
+    public function __construct(
+        private readonly int $maxDepth,
+        private readonly string $className,
+        private readonly string $methodName,
+    ) {}
+
+    /**
+     * Increments the relevant counter when a tracked node is entered.
+     *
+     * @param Node $node Node currently being entered by the traverser
+     */
+    #[Override]
+    public function enterNode(Node $node): ?int
+    {
+        if ($node instanceof Closure || $node instanceof ArrowFunction) {
+            ++$this->closureDepth;
+
+            return null;
+        }
+
+        if ($this->closureDepth > 0) {
+            return null;
+        }
+
+        if ($this->isLoop($node)) {
+            ++$this->depth;
+            $this->reportIfTooDeep($node);
+        }
+
+        return null;
+    }
+
+    /**
+     * Decrements the relevant counter when a tracked node is left.
+     *
+     * @param Node $node Node currently being left by the traverser
+     */
+    #[Override]
+    public function leaveNode(Node $node): ?int
+    {
+        if ($node instanceof Closure || $node instanceof ArrowFunction) {
+            --$this->closureDepth;
+
+            return null;
+        }
+
+        if ($this->closureDepth > 0) {
+            return null;
+        }
+
+        if ($this->isLoop($node)) {
+            --$this->depth;
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns the errors recorded across the traversal.
+     *
+     * @return list<IdentifierRuleError>
+     */
+    public function errors(): array
+    {
+        return $this->errors;
+    }
+
+    /**
+     * Tells whether the given node is a loop statement tracked by this visitor.
+     *
+     * @param Node $node Node to classify
+     */
+    private function isLoop(Node $node): bool
+    {
+        return $node instanceof For_
+            || $node instanceof Foreach_
+            || $node instanceof While_
+            || $node instanceof Do_;
+    }
+
+    /**
+     * Records an error when the current depth exceeds the configured maximum.
+     */
+    private function reportIfTooDeep(Node $node): void
+    {
+        $current = $this->depth - 1;
+
+        if ($current <= $this->maxDepth) {
+            return;
+        }
+
+        $this->errors[] = RuleErrorBuilder::message(
+            sprintf(
+                'Nested loop depth is %d in method %s::%s(). Maximum allowed is %d.',
+                $current,
+                $this->className,
+                $this->methodName,
+                $this->maxDepth,
+            ),
+        )
+            ->identifier('haspadar.nestedForDepth')
+            ->line($node->getStartLine())
+            ->build();
+    }
+}

--- a/tests/Fixtures/Rules/NestedForDepthRule/AbstractMethod.php
+++ b/tests/Fixtures/Rules/NestedForDepthRule/AbstractMethod.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedForDepthRule;
+
+abstract class AbstractMethod
+{
+    abstract public function run(array $items): array;
+}

--- a/tests/Fixtures/Rules/NestedForDepthRule/DefaultLimitMethod.php
+++ b/tests/Fixtures/Rules/NestedForDepthRule/DefaultLimitMethod.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedForDepthRule;
+
+final class DefaultLimitMethod
+{
+    public function flatten(array $rows): array
+    {
+        $result = [];
+        foreach ($rows as $row) {
+            foreach ($row as $cell) {
+                foreach ($cell as $value) {
+                    $result[] = $value;
+                }
+            }
+        }
+
+        return $result;
+    }
+}

--- a/tests/Fixtures/Rules/NestedForDepthRule/IfBetweenLoops.php
+++ b/tests/Fixtures/Rules/NestedForDepthRule/IfBetweenLoops.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedForDepthRule;
+
+final class IfBetweenLoops
+{
+    public function gather(array $rows): array
+    {
+        $result = [];
+        foreach ($rows as $row) {
+            if (is_array($row)) {
+                foreach ($row as $cell) {
+                    $result[] = $cell;
+                }
+            }
+        }
+
+        return $result;
+    }
+}

--- a/tests/Fixtures/Rules/NestedForDepthRule/LoopAfterArrowFunction.php
+++ b/tests/Fixtures/Rules/NestedForDepthRule/LoopAfterArrowFunction.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedForDepthRule;
+
+final class LoopAfterArrowFunction
+{
+    public function run(array $rows): array
+    {
+        $double = static fn (int $value): int => $value * 2;
+
+        $result = [];
+        foreach ($rows as $row) {
+            foreach ($row as $cell) {
+                foreach ($cell as $value) {
+                    $result[] = $double($value);
+                }
+            }
+        }
+
+        return $result;
+    }
+}

--- a/tests/Fixtures/Rules/NestedForDepthRule/LoopInsideClosure.php
+++ b/tests/Fixtures/Rules/NestedForDepthRule/LoopInsideClosure.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedForDepthRule;
+
+final class LoopInsideClosure
+{
+    public function build(array $rows): callable
+    {
+        foreach ($rows as $row) {
+            return function (array $items) use ($row): array {
+                $result = [];
+                foreach ($items as $item) {
+                    foreach ($row as $cell) {
+                        $result[] = [$item, $cell];
+                    }
+                }
+
+                return $result;
+            };
+        }
+
+        return static fn (): array => [];
+    }
+}

--- a/tests/Fixtures/Rules/NestedForDepthRule/MatchBetweenLoops.php
+++ b/tests/Fixtures/Rules/NestedForDepthRule/MatchBetweenLoops.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedForDepthRule;
+
+final class MatchBetweenLoops
+{
+    public function process(array $rows): array
+    {
+        $result = [];
+        foreach ($rows as $row) {
+            $kind = match (true) {
+                is_array($row) => 'list',
+                default => 'scalar',
+            };
+            foreach ((array) $row as $cell) {
+                $result[] = [$kind, $cell];
+            }
+        }
+
+        return $result;
+    }
+}

--- a/tests/Fixtures/Rules/NestedForDepthRule/MixedLoopTypes.php
+++ b/tests/Fixtures/Rules/NestedForDepthRule/MixedLoopTypes.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedForDepthRule;
+
+final class MixedLoopTypes
+{
+    public function chew(array $rows): int
+    {
+        $sum = 0;
+        for ($i = 0; $i < count($rows); ++$i) {
+            $j = 0;
+            while ($j < count($rows[$i])) {
+                foreach ($rows[$i][$j] as $cell) {
+                    $k = 0;
+                    do {
+                        $sum += $cell + $k;
+                        ++$k;
+                    } while ($k < 1);
+                }
+                ++$j;
+            }
+        }
+
+        return $sum;
+    }
+}

--- a/tests/Fixtures/Rules/NestedForDepthRule/OneLevelNested.php
+++ b/tests/Fixtures/Rules/NestedForDepthRule/OneLevelNested.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedForDepthRule;
+
+final class OneLevelNested
+{
+    public function pairs(array $xs, array $ys): array
+    {
+        $pairs = [];
+        foreach ($xs as $x) {
+            foreach ($ys as $y) {
+                $pairs[] = [$x, $y];
+            }
+        }
+
+        return $pairs;
+    }
+}

--- a/tests/Fixtures/Rules/NestedForDepthRule/ShallowFor.php
+++ b/tests/Fixtures/Rules/NestedForDepthRule/ShallowFor.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedForDepthRule;
+
+final class ShallowFor
+{
+    public function run(array $items): int
+    {
+        $sum = 0;
+        foreach ($items as $value) {
+            $sum += $value;
+        }
+
+        return $sum;
+    }
+}

--- a/tests/Fixtures/Rules/NestedForDepthRule/SiblingLoopsWithNested.php
+++ b/tests/Fixtures/Rules/NestedForDepthRule/SiblingLoopsWithNested.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedForDepthRule;
+
+final class SiblingLoopsWithNested
+{
+    public function combine(array $left, array $right): array
+    {
+        $result = [];
+        foreach ($left as $row) {
+            foreach ($row as $cell) {
+                $result[] = $cell;
+            }
+        }
+        foreach ($right as $row) {
+            foreach ($row as $cell) {
+                $result[] = $cell;
+            }
+        }
+
+        return $result;
+    }
+}

--- a/tests/Fixtures/Rules/NestedForDepthRule/SuppressedNested.php
+++ b/tests/Fixtures/Rules/NestedForDepthRule/SuppressedNested.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedForDepthRule;
+
+final class SuppressedNested
+{
+    public function flatten(array $rows): array
+    {
+        $result = [];
+        foreach ($rows as $row) {
+            foreach ($row as $cell) {
+                /** @phpstan-ignore haspadar.nestedForDepth */
+                foreach ($cell as $value) {
+                    $result[] = $value;
+                }
+            }
+        }
+
+        return $result;
+    }
+}

--- a/tests/Fixtures/Rules/NestedForDepthRule/SwitchBetweenLoops.php
+++ b/tests/Fixtures/Rules/NestedForDepthRule/SwitchBetweenLoops.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedForDepthRule;
+
+final class SwitchBetweenLoops
+{
+    public function process(array $rows): array
+    {
+        $result = [];
+        foreach ($rows as $row) {
+            switch (true) {
+                case is_array($row):
+                    foreach ($row as $cell) {
+                        $result[] = $cell;
+                    }
+                    break;
+                default:
+                    $result[] = $row;
+            }
+        }
+
+        return $result;
+    }
+}

--- a/tests/Fixtures/Rules/NestedForDepthRule/ThreeLevelsNested.php
+++ b/tests/Fixtures/Rules/NestedForDepthRule/ThreeLevelsNested.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedForDepthRule;
+
+final class ThreeLevelsNested
+{
+    public function dive(array $cube): array
+    {
+        $result = [];
+        foreach ($cube as $matrix) {
+            foreach ($matrix as $row) {
+                foreach ($row as $cell) {
+                    foreach ($cell as $value) {
+                        $result[] = $value;
+                    }
+                }
+            }
+        }
+
+        return $result;
+    }
+}

--- a/tests/Fixtures/Rules/NestedForDepthRule/TwoLevelsNested.php
+++ b/tests/Fixtures/Rules/NestedForDepthRule/TwoLevelsNested.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedForDepthRule;
+
+final class TwoLevelsNested
+{
+    public function flatten(array $rows): array
+    {
+        $result = [];
+        foreach ($rows as $row) {
+            foreach ($row as $cell) {
+                foreach ($cell as $value) {
+                    $result[] = $value;
+                }
+            }
+        }
+
+        return $result;
+    }
+}

--- a/tests/Unit/Rules/NestedForDepthRule/NestedForDepthRuleDefaultLimitTest.php
+++ b/tests/Unit/Rules/NestedForDepthRule/NestedForDepthRuleDefaultLimitTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\NestedForDepthRule;
+
+use Haspadar\PHPStanRules\Rules\NestedForDepthRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<NestedForDepthRule> */
+final class NestedForDepthRuleDefaultLimitTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new NestedForDepthRule();
+    }
+
+    #[Test]
+    public function reportsNestingPastDefaultLimitOfOne(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NestedForDepthRule/DefaultLimitMethod.php'],
+            [
+                [
+                    'Nested loop depth is 2 in method Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedForDepthRule\DefaultLimitMethod::flatten(). Maximum allowed is 1.',
+                    14,
+                ],
+            ],
+        );
+    }
+}

--- a/tests/Unit/Rules/NestedForDepthRule/NestedForDepthRuleHigherLimitTest.php
+++ b/tests/Unit/Rules/NestedForDepthRule/NestedForDepthRuleHigherLimitTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\NestedForDepthRule;
+
+use Haspadar\PHPStanRules\Rules\NestedForDepthRule;
+use InvalidArgumentException;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<NestedForDepthRule> */
+final class NestedForDepthRuleHigherLimitTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new NestedForDepthRule(2);
+    }
+
+    #[Test]
+    public function passesTwoLevelsNestedWhenLimitIsTwo(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NestedForDepthRule/TwoLevelsNested.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function acceptsZeroAsValidLimit(): void
+    {
+        new NestedForDepthRule(0);
+
+        self::assertTrue(true, 'Constructing the rule with maxDepth=0 must not throw');
+    }
+
+    #[Test]
+    public function rejectsNegativeMaxDepth(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('maxDepth must be a non-negative integer, -1 given');
+
+        new NestedForDepthRule(-1);
+    }
+
+    #[Test]
+    public function reportsThreeLevelsNestedWhenLimitIsTwo(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NestedForDepthRule/ThreeLevelsNested.php'],
+            [
+                [
+                    'Nested loop depth is 3 in method Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedForDepthRule\ThreeLevelsNested::dive(). Maximum allowed is 2.',
+                    15,
+                ],
+            ],
+        );
+    }
+}

--- a/tests/Unit/Rules/NestedForDepthRule/NestedForDepthRuleTest.php
+++ b/tests/Unit/Rules/NestedForDepthRule/NestedForDepthRuleTest.php
@@ -95,6 +95,24 @@ final class NestedForDepthRuleTest extends RuleTestCase
     }
 
     #[Test]
+    public function passesMatchBetweenLoopsBecauseMatchIsNotLoop(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NestedForDepthRule/MatchBetweenLoops.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function passesSwitchBetweenLoopsBecauseSwitchIsNotLoop(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NestedForDepthRule/SwitchBetweenLoops.php'],
+            [],
+        );
+    }
+
+    #[Test]
     public function passesLoopInsideClosureBecauseClosureResetsDepth(): void
     {
         $this->analyse(

--- a/tests/Unit/Rules/NestedForDepthRule/NestedForDepthRuleTest.php
+++ b/tests/Unit/Rules/NestedForDepthRule/NestedForDepthRuleTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\NestedForDepthRule;
+
+use Haspadar\PHPStanRules\Rules\NestedForDepthRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<NestedForDepthRule> */
+final class NestedForDepthRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new NestedForDepthRule(1);
+    }
+
+    #[Test]
+    public function passesWhenMethodHasNoNestedLoop(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NestedForDepthRule/ShallowFor.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function passesWhenNestingExactlyMatchesLimit(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NestedForDepthRule/OneLevelNested.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function reportsNestingThatExceedsLimit(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NestedForDepthRule/TwoLevelsNested.php'],
+            [
+                [
+                    'Nested loop depth is 2 in method Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedForDepthRule\TwoLevelsNested::flatten(). Maximum allowed is 1.',
+                    14,
+                ],
+            ],
+        );
+    }
+
+    #[Test]
+    public function reportsEachLoopThatBreaksLimitInDeepCascade(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NestedForDepthRule/ThreeLevelsNested.php'],
+            [
+                [
+                    'Nested loop depth is 2 in method Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedForDepthRule\ThreeLevelsNested::dive(). Maximum allowed is 1.',
+                    14,
+                ],
+                [
+                    'Nested loop depth is 3 in method Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedForDepthRule\ThreeLevelsNested::dive(). Maximum allowed is 1.',
+                    15,
+                ],
+            ],
+        );
+    }
+
+    #[Test]
+    public function reportsMixedLoopTypesAsNested(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NestedForDepthRule/MixedLoopTypes.php'],
+            [
+                [
+                    'Nested loop depth is 2 in method Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedForDepthRule\MixedLoopTypes::chew(). Maximum allowed is 1.',
+                    15,
+                ],
+                [
+                    'Nested loop depth is 3 in method Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedForDepthRule\MixedLoopTypes::chew(). Maximum allowed is 1.',
+                    17,
+                ],
+            ],
+        );
+    }
+
+    #[Test]
+    public function passesIfBetweenLoopsBecauseIfIsNotLoop(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NestedForDepthRule/IfBetweenLoops.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function passesLoopInsideClosureBecauseClosureResetsDepth(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NestedForDepthRule/LoopInsideClosure.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function passesAbstractMethodWithoutBody(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NestedForDepthRule/AbstractMethod.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function passesSiblingNestedLoopsBecauseDepthCounterResetsBetweenScopes(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NestedForDepthRule/SiblingLoopsWithNested.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function reportsNestedLoopsAfterArrowFunctionRestoresScope(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NestedForDepthRule/LoopAfterArrowFunction.php'],
+            [
+                [
+                    'Nested loop depth is 2 in method Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedForDepthRule\LoopAfterArrowFunction::run(). Maximum allowed is 1.',
+                    16,
+                ],
+            ],
+        );
+    }
+
+    #[Test]
+    public function suppressesViolationWhenPhpstanIgnorePresent(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NestedForDepthRule/SuppressedNested.php'],
+            [],
+        );
+    }
+}

--- a/tests/Unit/RulesTest.php
+++ b/tests/Unit/RulesTest.php
@@ -70,6 +70,7 @@ use Haspadar\PHPStanRules\Rules\NoActorSuffixRule;
 use Haspadar\PHPStanRules\Rules\MissingThrowsRule;
 use Haspadar\PHPStanRules\Rules\HiddenFieldRule;
 use Haspadar\PHPStanRules\Rules\MultipleVariableDeclarationsRule;
+use Haspadar\PHPStanRules\Rules\NestedForDepthRule;
 use Haspadar\PHPStanRules\Rules\NestedIfDepthRule;
 use Haspadar\PHPStanRules\Rules\RequireIgnoreReasonRule;
 use PHPUnit\Framework\Attributes\Test;
@@ -149,6 +150,7 @@ final class RulesTest extends TestCase
                 RequireIgnoreReasonRule::class,
                 MultipleVariableDeclarationsRule::class,
                 NestedIfDepthRule::class,
+                NestedForDepthRule::class,
             ],
             (new Rules())->all(),
             'Rules::all() must list every registered rule class',


### PR DESCRIPTION
- Added NestedForDepthRule reporting class methods whose loop nesting exceeds the configured depth
- Added DepthVisitor and DepthScanner driving the AST traversal with closure-scope reset
- Registered the rule in rules.neon with maxDepth schema (default 1) and in Rules::all()
- Updated README with the rule entry and configuration example
- Suppressed the new rule for two existing files where deeply nested foreach traverses dependency graphs

Closes #174

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new code quality rule that enforces limits on nested loop depth across `for`/`foreach`/`while`/`do-while` loops. The default maximum nesting depth is set to 1 level, with nested closures resetting the depth counter. This parameter is configurable via the `haspadar.nestedForDepth.maxDepth` configuration option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->