### PR TITLE
Limit Nested Try Depth Per Method With NestedTryDepthRule

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@
 | `MultipleVariableDeclarationsRule` | Chained assignments (`$a = $b = 1`) and multiple statements on one line are forbidden (default: chained `null` chains rejected) |
 | `NestedIfDepthRule`           | Nested `if` depth must not exceed the configured limit (default: 1; `elseif`/`else` and `Closure` reset depth) |
 | `NestedForDepthRule`          | Nested loop depth (`for`/`foreach`/`while`/`do-while`) must not exceed the configured limit (default: 1; `Closure` and arrow functions reset depth) |
+| `NestedTryDepthRule`          | Nested `try` depth must not exceed the configured limit (default: 1; `catch`/`finally` and `Closure` and arrow functions reset depth) |
 
 ### Naming
 
@@ -276,6 +277,8 @@ parameters:
         nestedIfDepth:
             maxDepth: 1
         nestedForDepth:
+            maxDepth: 1
+        nestedTryDepth:
             maxDepth: 1
         afferentCoupling:
             maxAfferent: 10

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@
 | `MultipleVariableDeclarationsRule` | Chained assignments (`$a = $b = 1`) and multiple statements on one line are forbidden (default: chained `null` chains rejected) |
 | `NestedIfDepthRule`           | Nested `if` depth must not exceed the configured limit (default: 1; `elseif`/`else` and `Closure` reset depth) |
 | `NestedForDepthRule`          | Nested loop depth (`for`/`foreach`/`while`/`do-while`) must not exceed the configured limit (default: 1; `Closure` and arrow functions reset depth) |
-| `NestedTryDepthRule`          | Nested `try` depth must not exceed the configured limit (default: 1; `catch`/`finally` and `Closure` and arrow functions reset depth) |
+| `NestedTryDepthRule`          | Nested `try` depth must not exceed the configured limit (default: 1; `catch`/`finally`, `Closure`, and arrow functions reset depth) |
 
 ### Naming
 

--- a/rules-ignore.neon
+++ b/rules-ignore.neon
@@ -21,6 +21,7 @@ parameters:
             paths:
                 - src/Rules/NestedIfDepthRule/DepthVisitor.php
                 - src/Rules/NestedForDepthRule/DepthVisitor.php
+                - src/Rules/NestedTryDepthRule/DepthVisitor.php
         -
             identifier: haspadar.nestedForDepth
             paths:
@@ -48,5 +49,6 @@ parameters:
                 - src/Rules/MultipleVariableDeclarationsRule/StatementListCollector.php
                 - src/Rules/NestedForDepthRule/DepthScanner.php
                 - src/Rules/NestedIfDepthRule/DepthScanner.php
+                - src/Rules/NestedTryDepthRule/DepthScanner.php
                 - src/Rules/PhpDocDescriptionChecker.php
                 - src/Rules/VariableCollector.php

--- a/rules.neon
+++ b/rules.neon
@@ -180,6 +180,8 @@ parameters:
             maxDepth: 1
         nestedForDepth:
             maxDepth: 1
+        nestedTryDepth:
+            maxDepth: 1
     exceptions:
         check:
             missingCheckedExceptionInThrows: false
@@ -342,6 +344,9 @@ parametersSchema:
             maxDepth: int(),
         ]),
         nestedForDepth: structure([
+            maxDepth: int(),
+        ]),
+        nestedTryDepth: structure([
             maxDepth: int(),
         ]),
     ])
@@ -769,5 +774,11 @@ services:
         class: Haspadar\PHPStanRules\Rules\NestedForDepthRule
         arguments:
             maxDepth: %haspadar.nestedForDepth.maxDepth%
+        tags:
+            - phpstan.rules.rule
+    -
+        class: Haspadar\PHPStanRules\Rules\NestedTryDepthRule
+        arguments:
+            maxDepth: %haspadar.nestedTryDepth.maxDepth%
         tags:
             - phpstan.rules.rule

--- a/src/Rules.php
+++ b/src/Rules.php
@@ -78,6 +78,7 @@ final class Rules
         Rules\MultipleVariableDeclarationsRule::class,
         Rules\NestedIfDepthRule::class,
         Rules\NestedForDepthRule::class,
+        Rules\NestedTryDepthRule::class,
     ];
 
     /**

--- a/src/Rules/NestedTryDepthRule.php
+++ b/src/Rules/NestedTryDepthRule.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Rules;
+
+use Haspadar\PHPStanRules\Rules\NestedTryDepthRule\DepthScanner;
+use InvalidArgumentException;
+use Override;
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+
+/**
+ * Reports a class method whose nested `try` depth exceeds the configured limit.
+ *
+ * Depth is counted relative to the method body: an outermost `try` has depth 0,
+ * a `try` directly inside another `try` (or its `catch`/`finally` branches) has
+ * depth 1, and so on. Sibling `catch` and `finally` clauses do not increase the
+ * depth — they are branches of the same `try` expression. Loops and conditional
+ * statements (`if`, `for`, `foreach`, `while`, `match`, `switch`) between `try`
+ * blocks belong to other rules and do not contribute to the counter. Loops or
+ * `try` blocks inside a `Closure` or arrow function are excluded from the count;
+ * the rule tracks nesting only at the surrounding method level.
+ *
+ * @implements Rule<ClassMethod>
+ */
+final readonly class NestedTryDepthRule implements Rule
+{
+    /**
+     * Constructs the rule with the given depth limit.
+     *
+     * @param int $maxDepth Maximum nesting depth of `try` statements per method
+     * @throws InvalidArgumentException when maxDepth is negative
+     */
+    public function __construct(private int $maxDepth = 1)
+    {
+        if ($maxDepth < 0) {
+            throw new InvalidArgumentException(
+                sprintf('maxDepth must be a non-negative integer, %d given', $maxDepth),
+            );
+        }
+    }
+
+    #[Override]
+    public function getNodeType(): string
+    {
+        return ClassMethod::class;
+    }
+
+    /**
+     * Analyses the method and returns errors for every `try` past the depth limit.
+     *
+     * @psalm-param ClassMethod $node
+     * @return list<IdentifierRuleError>
+     */
+    #[Override]
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $className = $scope->getClassReflection()?->getName() ?? 'unknown';
+        $methodName = $node->name->toString();
+        $scanner = new DepthScanner($this->maxDepth, $className, $methodName);
+
+        return $scanner->scan($node);
+    }
+}

--- a/src/Rules/NestedTryDepthRule.php
+++ b/src/Rules/NestedTryDepthRule.php
@@ -53,7 +53,7 @@ final readonly class NestedTryDepthRule implements Rule
     /**
      * Analyses the method and returns errors for every `try` past the depth limit.
      *
-     * @psalm-param ClassMethod $node
+     * @param ClassMethod $node
      * @return list<IdentifierRuleError>
      */
     #[Override]

--- a/src/Rules/NestedTryDepthRule/DepthScanner.php
+++ b/src/Rules/NestedTryDepthRule/DepthScanner.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Rules\NestedTryDepthRule;
+
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\NodeTraverser;
+use PHPStan\Rules\IdentifierRuleError;
+
+/**
+ * Drives a `DepthVisitor` over a class method body and returns its errors.
+ *
+ * The scanner exists so that the rule can stay free of mutable state: it
+ * builds a fresh visitor per invocation, runs the traversal, and hands the
+ * errors back to the caller.
+ */
+final readonly class DepthScanner
+{
+    /**
+     * Constructs the scanner for a single rule invocation.
+     *
+     * @param int $maxDepth Maximum allowed nesting depth
+     * @param string $className FQCN of the surrounding class for the error message
+     * @param string $methodName Method name for the error message
+     */
+    public function __construct(
+        private int $maxDepth,
+        private string $className,
+        private string $methodName,
+    ) {}
+
+    /**
+     * Scans the given class method and returns errors past the depth limit.
+     *
+     * @param ClassMethod $method Method whose body is analysed
+     * @return list<IdentifierRuleError>
+     */
+    public function scan(ClassMethod $method): array
+    {
+        if ($method->stmts === null) {
+            return [];
+        }
+
+        $visitor = new DepthVisitor($this->maxDepth, $this->className, $this->methodName);
+        $traverser = new NodeTraverser($visitor);
+        $traverser->traverse($method->stmts);
+
+        return $visitor->errors();
+    }
+}

--- a/src/Rules/NestedTryDepthRule/DepthVisitor.php
+++ b/src/Rules/NestedTryDepthRule/DepthVisitor.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Rules\NestedTryDepthRule;
+
+use Override;
+use PhpParser\Node;
+use PhpParser\Node\Expr\ArrowFunction;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Stmt\TryCatch;
+use PhpParser\NodeVisitorAbstract;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * Tracks `try` nesting depth across an AST traversal and records overruns.
+ *
+ * Each `Stmt\TryCatch` entered raises the depth counter; the outermost
+ * `try` ends up at depth 0, a `try` directly inside another `try` at
+ * depth 1, and so on. `Closure` and `ArrowFunction` start a separate
+ * scope: while the visitor is inside one of them no `try` contributes
+ * to the counter.
+ */
+final class DepthVisitor extends NodeVisitorAbstract
+{
+    /** @var int Current nesting level of `Stmt\TryCatch` outside any closure scope */
+    private int $depth = 0;
+
+    /** @var int How many nested `Closure`/`ArrowFunction` scopes are currently entered */
+    private int $closureDepth = 0;
+
+    /** @var list<IdentifierRuleError> */
+    private array $errors = [];
+
+    /**
+     * Constructs the visitor with the parameters needed to format errors.
+     *
+     * @param int $maxDepth Maximum allowed nesting depth
+     * @param string $className FQCN of the surrounding class for the error message
+     * @param string $methodName Method name for the error message
+     */
+    public function __construct(
+        private readonly int $maxDepth,
+        private readonly string $className,
+        private readonly string $methodName,
+    ) {}
+
+    /**
+     * Increments the relevant counter when a tracked node is entered.
+     *
+     * @param Node $node Node currently being entered by the traverser
+     */
+    #[Override]
+    public function enterNode(Node $node): ?int
+    {
+        if ($node instanceof Closure || $node instanceof ArrowFunction) {
+            ++$this->closureDepth;
+
+            return null;
+        }
+
+        if ($this->closureDepth > 0) {
+            return null;
+        }
+
+        if ($node instanceof TryCatch) {
+            ++$this->depth;
+            $this->reportIfTooDeep($node);
+        }
+
+        return null;
+    }
+
+    /**
+     * Decrements the relevant counter when a tracked node is left.
+     *
+     * @param Node $node Node currently being left by the traverser
+     */
+    #[Override]
+    public function leaveNode(Node $node): ?int
+    {
+        if ($node instanceof Closure || $node instanceof ArrowFunction) {
+            --$this->closureDepth;
+
+            return null;
+        }
+
+        if ($this->closureDepth > 0) {
+            return null;
+        }
+
+        if ($node instanceof TryCatch) {
+            --$this->depth;
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns the errors recorded across the traversal.
+     *
+     * @return list<IdentifierRuleError>
+     */
+    public function errors(): array
+    {
+        return $this->errors;
+    }
+
+    /**
+     * Records an error when the current depth exceeds the configured maximum.
+     */
+    private function reportIfTooDeep(TryCatch $node): void
+    {
+        $current = $this->depth - 1;
+
+        if ($current <= $this->maxDepth) {
+            return;
+        }
+
+        $this->errors[] = RuleErrorBuilder::message(
+            sprintf(
+                'Nested try depth is %d in method %s::%s(). Maximum allowed is %d.',
+                $current,
+                $this->className,
+                $this->methodName,
+                $this->maxDepth,
+            ),
+        )
+            ->identifier('haspadar.nestedTryDepth')
+            ->line($node->getStartLine())
+            ->build();
+    }
+}

--- a/tests/Fixtures/Rules/NestedTryDepthRule/AbstractMethod.php
+++ b/tests/Fixtures/Rules/NestedTryDepthRule/AbstractMethod.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedTryDepthRule;
+
+abstract class AbstractMethod
+{
+    abstract public function run(): void;
+}

--- a/tests/Fixtures/Rules/NestedTryDepthRule/DefaultLimitMethod.php
+++ b/tests/Fixtures/Rules/NestedTryDepthRule/DefaultLimitMethod.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedTryDepthRule;
+
+final class DefaultLimitMethod
+{
+    public function run(): void
+    {
+        try {
+            try {
+                try {
+                    $this->doRisky();
+                } catch (\RuntimeException $e) {
+                    throw new \DomainException('inner', 0, $e);
+                }
+            } catch (\DomainException $e) {
+                throw new \LogicException('mid', 0, $e);
+            }
+        } catch (\LogicException $e) {
+            $this->log($e->getMessage());
+        }
+    }
+
+    private function doRisky(): void {}
+
+    private function log(string $message): void {}
+}

--- a/tests/Fixtures/Rules/NestedTryDepthRule/OneLevelNested.php
+++ b/tests/Fixtures/Rules/NestedTryDepthRule/OneLevelNested.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedTryDepthRule;
+
+final class OneLevelNested
+{
+    public function run(): void
+    {
+        try {
+            try {
+                $this->doRisky();
+            } catch (\RuntimeException $e) {
+                throw new \DomainException('inner', 0, $e);
+            }
+        } catch (\DomainException $e) {
+            $this->log($e->getMessage());
+        }
+    }
+
+    private function doRisky(): void {}
+
+    private function log(string $message): void {}
+}

--- a/tests/Fixtures/Rules/NestedTryDepthRule/ShallowTry.php
+++ b/tests/Fixtures/Rules/NestedTryDepthRule/ShallowTry.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedTryDepthRule;
+
+final class ShallowTry
+{
+    public function run(): void
+    {
+        try {
+            $this->doRisky();
+        } catch (\RuntimeException $e) {
+            $this->log($e->getMessage());
+        }
+    }
+
+    private function doRisky(): void {}
+
+    private function log(string $message): void {}
+}

--- a/tests/Fixtures/Rules/NestedTryDepthRule/SiblingTriesWithNested.php
+++ b/tests/Fixtures/Rules/NestedTryDepthRule/SiblingTriesWithNested.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedTryDepthRule;
+
+final class SiblingTriesWithNested
+{
+    public function run(): void
+    {
+        try {
+            try {
+                $this->first();
+            } catch (\RuntimeException $e) {
+                $this->log($e->getMessage());
+            }
+        } catch (\Throwable $e) {
+            $this->log($e->getMessage());
+        }
+        try {
+            try {
+                $this->second();
+            } catch (\RuntimeException $e) {
+                $this->log($e->getMessage());
+            }
+        } catch (\Throwable $e) {
+            $this->log($e->getMessage());
+        }
+    }
+
+    private function first(): void {}
+
+    private function second(): void {}
+
+    private function log(string $message): void {}
+}

--- a/tests/Fixtures/Rules/NestedTryDepthRule/SuppressedNested.php
+++ b/tests/Fixtures/Rules/NestedTryDepthRule/SuppressedNested.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedTryDepthRule;
+
+final class SuppressedNested
+{
+    public function run(): void
+    {
+        try {
+            try {
+                /** @phpstan-ignore haspadar.nestedTryDepth */
+                try {
+                    $this->doRisky();
+                } catch (\RuntimeException $e) {
+                    throw new \DomainException('inner', 0, $e);
+                }
+            } catch (\DomainException $e) {
+                throw new \LogicException('mid', 0, $e);
+            }
+        } catch (\LogicException $e) {
+            $this->log($e->getMessage());
+        }
+    }
+
+    private function doRisky(): void {}
+
+    private function log(string $message): void {}
+}

--- a/tests/Fixtures/Rules/NestedTryDepthRule/ThreeLevelsNested.php
+++ b/tests/Fixtures/Rules/NestedTryDepthRule/ThreeLevelsNested.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedTryDepthRule;
+
+final class ThreeLevelsNested
+{
+    public function run(): void
+    {
+        try {
+            try {
+                try {
+                    try {
+                        $this->doRisky();
+                    } catch (\RuntimeException $e) {
+                        throw new \DomainException('inner', 0, $e);
+                    }
+                } catch (\DomainException $e) {
+                    throw new \LogicException('mid', 0, $e);
+                }
+            } catch (\LogicException $e) {
+                throw new \UnexpectedValueException('outer', 0, $e);
+            }
+        } catch (\UnexpectedValueException $e) {
+            $this->log($e->getMessage());
+        }
+    }
+
+    private function doRisky(): void {}
+
+    private function log(string $message): void {}
+}

--- a/tests/Fixtures/Rules/NestedTryDepthRule/TryInsideCatch.php
+++ b/tests/Fixtures/Rules/NestedTryDepthRule/TryInsideCatch.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedTryDepthRule;
+
+final class TryInsideCatch
+{
+    public function run(): void
+    {
+        try {
+            $this->doRisky();
+        } catch (\RuntimeException $e) {
+            try {
+                $this->fallback();
+            } catch (\LogicException $inner) {
+                $this->log($inner->getMessage());
+            }
+        }
+    }
+
+    private function doRisky(): void {}
+
+    private function fallback(): void {}
+
+    private function log(string $message): void {}
+}

--- a/tests/Fixtures/Rules/NestedTryDepthRule/TryInsideClosure.php
+++ b/tests/Fixtures/Rules/NestedTryDepthRule/TryInsideClosure.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedTryDepthRule;
+
+final class TryInsideClosure
+{
+    public function build(): callable
+    {
+        try {
+            return function (): void {
+                try {
+                    try {
+                        $this->doRisky();
+                    } catch (\RuntimeException $e) {
+                        throw new \DomainException('inner', 0, $e);
+                    }
+                } catch (\DomainException $e) {
+                    $this->log($e->getMessage());
+                }
+            };
+        } catch (\Throwable $e) {
+            return static fn (): null => null;
+        }
+    }
+
+    private function doRisky(): void {}
+
+    private function log(string $message): void {}
+}

--- a/tests/Fixtures/Rules/NestedTryDepthRule/TryInsideClosure.php
+++ b/tests/Fixtures/Rules/NestedTryDepthRule/TryInsideClosure.php
@@ -12,11 +12,15 @@ final class TryInsideClosure
             return function (): void {
                 try {
                     try {
-                        $this->doRisky();
-                    } catch (\RuntimeException $e) {
-                        throw new \DomainException('inner', 0, $e);
+                        try {
+                            $this->doRisky();
+                        } catch (\RuntimeException $e) {
+                            throw new \DomainException('inner', 0, $e);
+                        }
+                    } catch (\DomainException $e) {
+                        throw new \LogicException('mid', 0, $e);
                     }
-                } catch (\DomainException $e) {
+                } catch (\LogicException $e) {
                     $this->log($e->getMessage());
                 }
             };

--- a/tests/Fixtures/Rules/NestedTryDepthRule/TryInsideFinally.php
+++ b/tests/Fixtures/Rules/NestedTryDepthRule/TryInsideFinally.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedTryDepthRule;
+
+final class TryInsideFinally
+{
+    public function run(): void
+    {
+        try {
+            $this->doRisky();
+        } finally {
+            try {
+                $this->release();
+            } catch (\RuntimeException $e) {
+                $this->log($e->getMessage());
+            }
+        }
+    }
+
+    private function doRisky(): void {}
+
+    private function release(): void {}
+
+    private function log(string $message): void {}
+}

--- a/tests/Fixtures/Rules/NestedTryDepthRule/TwoLevelsNested.php
+++ b/tests/Fixtures/Rules/NestedTryDepthRule/TwoLevelsNested.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedTryDepthRule;
+
+final class TwoLevelsNested
+{
+    public function run(): void
+    {
+        try {
+            try {
+                try {
+                    $this->doRisky();
+                } catch (\RuntimeException $e) {
+                    throw new \DomainException('inner', 0, $e);
+                }
+            } catch (\DomainException $e) {
+                throw new \LogicException('mid', 0, $e);
+            }
+        } catch (\LogicException $e) {
+            $this->log($e->getMessage());
+        }
+    }
+
+    private function doRisky(): void {}
+
+    private function log(string $message): void {}
+}

--- a/tests/Unit/Rules/NestedForDepthRule/NestedForDepthRuleHigherLimitTest.php
+++ b/tests/Unit/Rules/NestedForDepthRule/NestedForDepthRuleHigherLimitTest.php
@@ -30,9 +30,9 @@ final class NestedForDepthRuleHigherLimitTest extends RuleTestCase
     #[Test]
     public function acceptsZeroAsValidLimit(): void
     {
-        new NestedForDepthRule(0);
+        $this->expectNotToPerformAssertions();
 
-        self::assertTrue(true, 'Constructing the rule with maxDepth=0 must not throw');
+        new NestedForDepthRule(0);
     }
 
     #[Test]

--- a/tests/Unit/Rules/NestedIfDepthRule/NestedIfDepthRuleHigherLimitTest.php
+++ b/tests/Unit/Rules/NestedIfDepthRule/NestedIfDepthRuleHigherLimitTest.php
@@ -30,9 +30,9 @@ final class NestedIfDepthRuleHigherLimitTest extends RuleTestCase
     #[Test]
     public function acceptsZeroAsValidLimit(): void
     {
-        new NestedIfDepthRule(0);
+        $this->expectNotToPerformAssertions();
 
-        self::assertTrue(true, 'Constructing the rule with maxDepth=0 must not throw');
+        new NestedIfDepthRule(0);
     }
 
     #[Test]

--- a/tests/Unit/Rules/NestedTryDepthRule/NestedTryDepthRuleDefaultLimitTest.php
+++ b/tests/Unit/Rules/NestedTryDepthRule/NestedTryDepthRuleDefaultLimitTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\NestedTryDepthRule;
+
+use Haspadar\PHPStanRules\Rules\NestedTryDepthRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<NestedTryDepthRule> */
+final class NestedTryDepthRuleDefaultLimitTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new NestedTryDepthRule();
+    }
+
+    #[Test]
+    public function reportsNestingPastDefaultLimitOfOne(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NestedTryDepthRule/DefaultLimitMethod.php'],
+            [
+                [
+                    'Nested try depth is 2 in method Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedTryDepthRule\DefaultLimitMethod::run(). Maximum allowed is 1.',
+                    13,
+                ],
+            ],
+        );
+    }
+}

--- a/tests/Unit/Rules/NestedTryDepthRule/NestedTryDepthRuleHigherLimitTest.php
+++ b/tests/Unit/Rules/NestedTryDepthRule/NestedTryDepthRuleHigherLimitTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\NestedTryDepthRule;
+
+use Haspadar\PHPStanRules\Rules\NestedTryDepthRule;
+use InvalidArgumentException;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<NestedTryDepthRule> */
+final class NestedTryDepthRuleHigherLimitTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new NestedTryDepthRule(2);
+    }
+
+    #[Test]
+    public function passesTwoLevelsNestedWhenLimitIsTwo(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NestedTryDepthRule/TwoLevelsNested.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function acceptsZeroAsValidLimit(): void
+    {
+        new NestedTryDepthRule(0);
+
+        self::assertTrue(true, 'Constructing the rule with maxDepth=0 must not throw');
+    }
+
+    #[Test]
+    public function rejectsNegativeMaxDepth(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('maxDepth must be a non-negative integer, -1 given');
+
+        new NestedTryDepthRule(-1);
+    }
+
+    #[Test]
+    public function reportsThreeLevelsNestedWhenLimitIsTwo(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NestedTryDepthRule/ThreeLevelsNested.php'],
+            [
+                [
+                    'Nested try depth is 3 in method Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedTryDepthRule\ThreeLevelsNested::run(). Maximum allowed is 2.',
+                    14,
+                ],
+            ],
+        );
+    }
+}

--- a/tests/Unit/Rules/NestedTryDepthRule/NestedTryDepthRuleHigherLimitTest.php
+++ b/tests/Unit/Rules/NestedTryDepthRule/NestedTryDepthRuleHigherLimitTest.php
@@ -30,9 +30,9 @@ final class NestedTryDepthRuleHigherLimitTest extends RuleTestCase
     #[Test]
     public function acceptsZeroAsValidLimit(): void
     {
-        new NestedTryDepthRule(0);
+        $this->expectNotToPerformAssertions();
 
-        self::assertTrue(true, 'Constructing the rule with maxDepth=0 must not throw');
+        new NestedTryDepthRule(0);
     }
 
     #[Test]

--- a/tests/Unit/Rules/NestedTryDepthRule/NestedTryDepthRuleTest.php
+++ b/tests/Unit/Rules/NestedTryDepthRule/NestedTryDepthRuleTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\NestedTryDepthRule;
+
+use Haspadar\PHPStanRules\Rules\NestedTryDepthRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<NestedTryDepthRule> */
+final class NestedTryDepthRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new NestedTryDepthRule(1);
+    }
+
+    #[Test]
+    public function passesWhenMethodHasNoNestedTry(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NestedTryDepthRule/ShallowTry.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function passesWhenNestingExactlyMatchesLimit(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NestedTryDepthRule/OneLevelNested.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function reportsNestingThatExceedsLimit(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NestedTryDepthRule/TwoLevelsNested.php'],
+            [
+                [
+                    'Nested try depth is 2 in method Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedTryDepthRule\TwoLevelsNested::run(). Maximum allowed is 1.',
+                    13,
+                ],
+            ],
+        );
+    }
+
+    #[Test]
+    public function reportsEachTryThatBreaksLimitInDeepCascade(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NestedTryDepthRule/ThreeLevelsNested.php'],
+            [
+                [
+                    'Nested try depth is 2 in method Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedTryDepthRule\ThreeLevelsNested::run(). Maximum allowed is 1.',
+                    13,
+                ],
+                [
+                    'Nested try depth is 3 in method Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedTryDepthRule\ThreeLevelsNested::run(). Maximum allowed is 1.',
+                    14,
+                ],
+            ],
+        );
+    }
+
+    #[Test]
+    public function passesTryInsideCatchWhenWithinLimit(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NestedTryDepthRule/TryInsideCatch.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function passesTryInsideFinallyWhenWithinLimit(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NestedTryDepthRule/TryInsideFinally.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function passesTryInsideClosureBecauseClosureResetsDepth(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NestedTryDepthRule/TryInsideClosure.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function passesAbstractMethodWithoutBody(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NestedTryDepthRule/AbstractMethod.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function passesSiblingNestedTriesBecauseDepthCounterResetsBetweenScopes(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NestedTryDepthRule/SiblingTriesWithNested.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function suppressesViolationWhenPhpstanIgnorePresent(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NestedTryDepthRule/SuppressedNested.php'],
+            [],
+        );
+    }
+}

--- a/tests/Unit/RulesTest.php
+++ b/tests/Unit/RulesTest.php
@@ -72,6 +72,7 @@ use Haspadar\PHPStanRules\Rules\HiddenFieldRule;
 use Haspadar\PHPStanRules\Rules\MultipleVariableDeclarationsRule;
 use Haspadar\PHPStanRules\Rules\NestedForDepthRule;
 use Haspadar\PHPStanRules\Rules\NestedIfDepthRule;
+use Haspadar\PHPStanRules\Rules\NestedTryDepthRule;
 use Haspadar\PHPStanRules\Rules\RequireIgnoreReasonRule;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -151,6 +152,7 @@ final class RulesTest extends TestCase
                 MultipleVariableDeclarationsRule::class,
                 NestedIfDepthRule::class,
                 NestedForDepthRule::class,
+                NestedTryDepthRule::class,
             ],
             (new Rules())->all(),
             'Rules::all() must list every registered rule class',


### PR DESCRIPTION
- Added NestedTryDepthRule reporting class methods whose try-catch nesting exceeds the configured depth
- Added DepthVisitor and DepthScanner driving the AST traversal with closure-scope reset
- Registered the rule in rules.neon with maxDepth schema (default 1) and in Rules::all()
- Updated README with the rule entry and configuration example

Closes #176

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable rule to detect excessive try/catch nesting in methods (default max depth: 1), with correct handling of catch/finally and closures.

* **Documentation**
  * README and configuration examples updated to document the new rule and its maxDepth option.

* **Tests**
  * Added comprehensive unit tests and fixture cases covering limits, suppression annotations, closures, finally/catch behaviors and boundary values.

* **Chores**
  * Updated ignore configuration to suppress the new rule for specific components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->