### PR TITLE
Enforce Default Case in Switch Statements With SwitchDefaultRule

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@
 | `NestedIfDepthRule`           | Nested `if` depth must not exceed the configured limit (default: 1; `elseif`/`else` and `Closure` reset depth) |
 | `NestedForDepthRule`          | Nested loop depth (`for`/`foreach`/`while`/`do-while`) must not exceed the configured limit (default: 1; `Closure` and arrow functions reset depth) |
 | `NestedTryDepthRule`          | Nested `try` depth must not exceed the configured limit (default: 1; `catch`/`finally`, `Closure`, and arrow functions reset depth) |
+| `SwitchDefaultRule`           | Every `switch` must have a `default` case and it must be last |
 
 ### Naming
 

--- a/rules.neon
+++ b/rules.neon
@@ -782,3 +782,7 @@ services:
             maxDepth: %haspadar.nestedTryDepth.maxDepth%
         tags:
             - phpstan.rules.rule
+    -
+        class: Haspadar\PHPStanRules\Rules\SwitchDefaultRule
+        tags:
+            - phpstan.rules.rule

--- a/src/Rules.php
+++ b/src/Rules.php
@@ -79,6 +79,7 @@ final class Rules
         Rules\NestedIfDepthRule::class,
         Rules\NestedForDepthRule::class,
         Rules\NestedTryDepthRule::class,
+        Rules\SwitchDefaultRule::class,
     ];
 
     /**

--- a/src/Rules/SwitchDefaultRule.php
+++ b/src/Rules/SwitchDefaultRule.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Rules;
+
+use Override;
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Case_;
+use PhpParser\Node\Stmt\Switch_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\ShouldNotHappenException;
+
+/**
+ * Checks every `switch` statement in the analysed code.
+ *
+ * Two invariants are enforced:
+ * - every `switch` must contain at least one `default` case; a `switch` without
+ *   `default` silently ignores unexpected values, which violates the principle of
+ *   explicit control flow;
+ * - the `default` case must appear last in the case list; placing `default` earlier
+ *   misleads readers and differs from every major style guide (Checkstyle, PMD).
+ *
+ * `match` expressions are not covered: PHP guarantees exhaustiveness via
+ * `UnhandledMatchError` at runtime and the compiler can enforce it for enums.
+ *
+ * @implements Rule<Switch_>
+ */
+final readonly class SwitchDefaultRule implements Rule
+{
+    #[Override]
+    public function getNodeType(): string
+    {
+        return Switch_::class;
+    }
+
+    /**
+     * Analyses the switch node and returns errors for missing or misplaced default.
+     *
+     * @param Switch_ $node
+     * @throws ShouldNotHappenException
+     * @return list<IdentifierRuleError>
+     */
+    #[Override]
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $cases = $node->cases;
+
+        if ($cases === []) {
+            return [];
+        }
+
+        $defaultCase = $this->findDefaultCase(array_values($cases));
+
+        if ($defaultCase === []) {
+            return [
+                RuleErrorBuilder::message('Switch statement must have a default case.')
+                    ->identifier('haspadar.switchDefault')
+                    ->line($node->getStartLine())
+                    ->build(),
+            ];
+        }
+
+        $lastCase = end($cases);
+
+        if ($defaultCase[0] !== $lastCase) {
+            return [
+                RuleErrorBuilder::message('Default case must be the last case in a switch statement.')
+                    ->identifier('haspadar.switchDefault')
+                    ->line($defaultCase[0]->getStartLine())
+                    ->build(),
+            ];
+        }
+
+        return [];
+    }
+
+    /**
+     * Returns an array containing the default case node, or an empty array if not found.
+     *
+     * @param list<Case_> $cases
+     * @return list<Case_>
+     */
+    private function findDefaultCase(array $cases): array
+    {
+        foreach ($cases as $case) {
+            if ($case->cond === null) {
+                return [$case];
+            }
+        }
+
+        return [];
+    }
+}

--- a/tests/Fixtures/Rules/SwitchDefaultRule/DefaultNotLast.php
+++ b/tests/Fixtures/Rules/SwitchDefaultRule/DefaultNotLast.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\SwitchDefaultRule;
+
+final class DefaultNotLast
+{
+    public function run(string $status): void
+    {
+        switch ($status) {
+            case 'active':
+                $this->enable();
+                break;
+            default:
+                throw new \RuntimeException('Unknown status');
+            case 'inactive':
+                $this->disable();
+                break;
+        }
+    }
+
+    private function enable(): void {}
+
+    private function disable(): void {}
+}

--- a/tests/Fixtures/Rules/SwitchDefaultRule/DefaultOnly.php
+++ b/tests/Fixtures/Rules/SwitchDefaultRule/DefaultOnly.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\SwitchDefaultRule;
+
+final class DefaultOnly
+{
+    public function run(string $status): void
+    {
+        switch ($status) {
+            default:
+                throw new \RuntimeException('Unknown status');
+        }
+    }
+}

--- a/tests/Fixtures/Rules/SwitchDefaultRule/EmptySwitch.php
+++ b/tests/Fixtures/Rules/SwitchDefaultRule/EmptySwitch.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\SwitchDefaultRule;
+
+final class EmptySwitch
+{
+    public function run(string $status): void
+    {
+        switch ($status) {
+        }
+    }
+}

--- a/tests/Fixtures/Rules/SwitchDefaultRule/NoDefault.php
+++ b/tests/Fixtures/Rules/SwitchDefaultRule/NoDefault.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\SwitchDefaultRule;
+
+final class NoDefault
+{
+    public function run(string $status): void
+    {
+        switch ($status) {
+            case 'active':
+                $this->enable();
+                break;
+            case 'inactive':
+                $this->disable();
+                break;
+        }
+    }
+
+    private function enable(): void {}
+
+    private function disable(): void {}
+}

--- a/tests/Fixtures/Rules/SwitchDefaultRule/SuppressedClass.php
+++ b/tests/Fixtures/Rules/SwitchDefaultRule/SuppressedClass.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\SwitchDefaultRule;
+
+final class SuppressedClass
+{
+    public function run(string $status): void
+    {
+        /** @phpstan-ignore haspadar.switchDefault */
+        switch ($status) {
+            case 'active':
+                $this->enable();
+                break;
+        }
+    }
+
+    private function enable(): void {}
+}

--- a/tests/Fixtures/Rules/SwitchDefaultRule/WithDefault.php
+++ b/tests/Fixtures/Rules/SwitchDefaultRule/WithDefault.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\SwitchDefaultRule;
+
+final class WithDefault
+{
+    public function run(string $status): void
+    {
+        switch ($status) {
+            case 'active':
+                $this->enable();
+                break;
+            case 'inactive':
+                $this->disable();
+                break;
+            default:
+                throw new \RuntimeException('Unknown status');
+        }
+    }
+
+    private function enable(): void {}
+
+    private function disable(): void {}
+}

--- a/tests/Unit/Rules/SwitchDefaultRule/SwitchDefaultRuleTest.php
+++ b/tests/Unit/Rules/SwitchDefaultRule/SwitchDefaultRuleTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\SwitchDefaultRule;
+
+use Haspadar\PHPStanRules\Rules\SwitchDefaultRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<SwitchDefaultRule> */
+final class SwitchDefaultRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new SwitchDefaultRule();
+    }
+
+    #[Test]
+    public function reportsWhenSwitchHasNoDefaultCase(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/SwitchDefaultRule/NoDefault.php'],
+            [
+                [
+                    'Switch statement must have a default case.',
+                    11,
+                ],
+            ],
+        );
+    }
+
+    #[Test]
+    public function reportsWhenDefaultIsNotLastCase(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/SwitchDefaultRule/DefaultNotLast.php'],
+            [
+                [
+                    'Default case must be the last case in a switch statement.',
+                    15,
+                ],
+            ],
+        );
+    }
+
+    #[Test]
+    public function passesWhenSwitchHasDefaultAsLastCase(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/SwitchDefaultRule/WithDefault.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function passesWhenSwitchIsEmpty(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/SwitchDefaultRule/EmptySwitch.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function passesWhenSwitchHasOnlyDefault(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/SwitchDefaultRule/DefaultOnly.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function suppressesViolationWhenPhpstanIgnorePresent(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/SwitchDefaultRule/SuppressedClass.php'],
+            [],
+        );
+    }
+}

--- a/tests/Unit/RulesTest.php
+++ b/tests/Unit/RulesTest.php
@@ -74,6 +74,7 @@ use Haspadar\PHPStanRules\Rules\NestedForDepthRule;
 use Haspadar\PHPStanRules\Rules\NestedIfDepthRule;
 use Haspadar\PHPStanRules\Rules\NestedTryDepthRule;
 use Haspadar\PHPStanRules\Rules\RequireIgnoreReasonRule;
+use Haspadar\PHPStanRules\Rules\SwitchDefaultRule;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -153,6 +154,7 @@ final class RulesTest extends TestCase
                 NestedIfDepthRule::class,
                 NestedForDepthRule::class,
                 NestedTryDepthRule::class,
+                SwitchDefaultRule::class,
             ],
             (new Rules())->all(),
             'Rules::all() must list every registered rule class',


### PR DESCRIPTION
## Summary

- Added `SwitchDefaultRule` that reports switch statements without a `default` case and those with `default` not as the last case
- Registered rule in `Rules::all()` and `rules.neon` (no configurable parameters)
- Added fixtures covering: no default, default not last, valid switch, empty switch, default-only, suppressed
- Added unit tests for all cases

Closes #178