### PR TITLE
Forbid Unnecessary Boolean Literal Comparisons With SimplifyBooleanExpressionRule

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@
 | `NestedForDepthRule`          | Nested loop depth (`for`/`foreach`/`while`/`do-while`) must not exceed the configured limit (default: 1; `Closure` and arrow functions reset depth) |
 | `NestedTryDepthRule`          | Nested `try` depth must not exceed the configured limit (default: 1; `catch`/`finally`, `Closure`, and arrow functions reset depth) |
 | `SwitchDefaultRule`           | Every `switch` must have a `default` case and it must be last |
+| `SimplifyBooleanExpressionRule` | Comparisons with `true`/`false` literals are unnecessary and must be removed |
 
 ### Naming
 

--- a/rules-ignore.neon
+++ b/rules-ignore.neon
@@ -34,6 +34,8 @@ parameters:
                 - src/Rules/HiddenFieldRule.php
                 - src/Rules/MethodLengthRule.php
         -
+            identifier: haspadar.simplifyBoolean
+        -
             identifier: haspadar.noActorSuffix
             paths:
                 - src/Collectors/ClassDependencyCollector.php

--- a/rules.neon
+++ b/rules.neon
@@ -786,3 +786,7 @@ services:
         class: Haspadar\PHPStanRules\Rules\SwitchDefaultRule
         tags:
             - phpstan.rules.rule
+    -
+        class: Haspadar\PHPStanRules\Rules\SimplifyBooleanExpressionRule
+        tags:
+            - phpstan.rules.rule

--- a/src/Rules.php
+++ b/src/Rules.php
@@ -80,6 +80,7 @@ final class Rules
         Rules\NestedForDepthRule::class,
         Rules\NestedTryDepthRule::class,
         Rules\SwitchDefaultRule::class,
+        Rules\SimplifyBooleanExpressionRule::class,
     ];
 
     /**

--- a/src/Rules/SimplifyBooleanExpressionRule.php
+++ b/src/Rules/SimplifyBooleanExpressionRule.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Rules;
+
+use Override;
+use PhpParser\Node;
+use PhpParser\Node\Expr\BinaryOp\Equal;
+use PhpParser\Node\Expr\BinaryOp\Identical;
+use PhpParser\Node\Expr\BinaryOp\NotEqual;
+use PhpParser\Node\Expr\BinaryOp\NotIdentical;
+use PhpParser\Node\Expr\ConstFetch;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\NodeFinder;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\ShouldNotHappenException;
+
+/**
+ * Detects unnecessary comparisons of expressions with boolean literals.
+ *
+ * Comparisons like `$x == true`, `$x === false`, `$x != true`, `$x !== false`
+ * do not add information: the expression itself already evaluates to a boolean
+ * in a boolean context. Removing the comparison improves readability and avoids
+ * subtle loose-comparison bugs (e.g. `0 == false` is true in PHP).
+ *
+ * Checks all four binary operators (==, ===, !=, !==) against the literals
+ * `true` and `false`. Does not flag comparisons with `null`.
+ *
+ * @implements Rule<ClassMethod>
+ */
+final readonly class SimplifyBooleanExpressionRule implements Rule
+{
+    #[Override]
+    public function getNodeType(): string
+    {
+        return ClassMethod::class;
+    }
+
+    /**
+     * Analyses the method and returns errors for every boolean literal comparison.
+     *
+     * @param ClassMethod $node
+     * @throws ShouldNotHappenException
+     * @return list<IdentifierRuleError>
+     */
+    #[Override]
+    public function processNode(Node $node, Scope $scope): array
+    {
+        /** @var list<Equal|Identical|NotEqual|NotIdentical> $comparisons */
+        $comparisons = (new NodeFinder())->find(
+            $node->stmts ?? [],
+            static fn(Node $n): bool => $n instanceof Equal
+                || $n instanceof Identical
+                || $n instanceof NotEqual
+                || $n instanceof NotIdentical,
+        );
+
+        $errors = [];
+
+        foreach ($comparisons as $comparison) {
+            if (!$this->involvesBooleanLiteral($comparison)) {
+                continue;
+            }
+
+            $errors[] = RuleErrorBuilder::message(
+                'Avoid unnecessary comparison with boolean literal. Use the expression directly.',
+            )
+                ->identifier('haspadar.simplifyBoolean')
+                ->line($comparison->getStartLine())
+                ->build();
+        }
+
+        return $errors;
+    }
+
+    /**
+     * Returns true if either operand of the comparison is a boolean literal (true or false).
+     */
+    private function involvesBooleanLiteral(Equal|Identical|NotEqual|NotIdentical $node): bool
+    {
+        return $this->isBooleanLiteral($node->left) || $this->isBooleanLiteral($node->right);
+    }
+
+    /**
+     * Returns true if the expression is a ConstFetch resolving to true or false.
+     */
+    private function isBooleanLiteral(Node\Expr $expr): bool
+    {
+        if (!$expr instanceof ConstFetch) {
+            return false;
+        }
+
+        $name = strtolower($expr->name->toString());
+
+        return $name === 'true' || $name === 'false';
+    }
+}

--- a/tests/Fixtures/Rules/SimplifyBooleanExpressionRule/BooleanLiteralOnLeft.php
+++ b/tests/Fixtures/Rules/SimplifyBooleanExpressionRule/BooleanLiteralOnLeft.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\SimplifyBooleanExpressionRule;
+
+final class BooleanLiteralOnLeft
+{
+    public function run(): void
+    {
+        if (true === $this->isActive()) {
+            $this->enable();
+        }
+
+        if (false == $this->hasErrors()) {
+            $this->save();
+        }
+    }
+
+    private function isActive(): bool
+    {
+        return true;
+    }
+
+    private function hasErrors(): bool
+    {
+        return false;
+    }
+
+    private function enable(): void {}
+
+    private function save(): void {}
+}

--- a/tests/Fixtures/Rules/SimplifyBooleanExpressionRule/CompareWithFalse.php
+++ b/tests/Fixtures/Rules/SimplifyBooleanExpressionRule/CompareWithFalse.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\SimplifyBooleanExpressionRule;
+
+final class CompareWithFalse
+{
+    public function run(): void
+    {
+        if ($this->hasErrors() == false) {
+            $this->save();
+        }
+
+        if ($this->hasErrors() === false) {
+            $this->save();
+        }
+    }
+
+    private function hasErrors(): bool
+    {
+        return false;
+    }
+
+    private function save(): void {}
+}

--- a/tests/Fixtures/Rules/SimplifyBooleanExpressionRule/CompareWithTrue.php
+++ b/tests/Fixtures/Rules/SimplifyBooleanExpressionRule/CompareWithTrue.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\SimplifyBooleanExpressionRule;
+
+final class CompareWithTrue
+{
+    public function run(): void
+    {
+        if ($this->isActive() == true) {
+            $this->enable();
+        }
+
+        if ($this->isActive() === true) {
+            $this->enable();
+        }
+    }
+
+    private function isActive(): bool
+    {
+        return true;
+    }
+
+    private function enable(): void {}
+}

--- a/tests/Fixtures/Rules/SimplifyBooleanExpressionRule/NotEqualBoolean.php
+++ b/tests/Fixtures/Rules/SimplifyBooleanExpressionRule/NotEqualBoolean.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\SimplifyBooleanExpressionRule;
+
+final class NotEqualBoolean
+{
+    public function run(): void
+    {
+        if ($this->isActive() != true) {
+            $this->disable();
+        }
+
+        if ($this->isActive() !== false) {
+            $this->enable();
+        }
+    }
+
+    private function isActive(): bool
+    {
+        return true;
+    }
+
+    private function enable(): void {}
+
+    private function disable(): void {}
+}

--- a/tests/Fixtures/Rules/SimplifyBooleanExpressionRule/SuppressedClass.php
+++ b/tests/Fixtures/Rules/SimplifyBooleanExpressionRule/SuppressedClass.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\SimplifyBooleanExpressionRule;
+
+final class SuppressedClass
+{
+    public function run(): void
+    {
+        /** @phpstan-ignore haspadar.simplifyBoolean */
+        if ($this->isActive() == true) {
+            $this->enable();
+        }
+    }
+
+    private function isActive(): bool
+    {
+        return true;
+    }
+
+    private function enable(): void {}
+}

--- a/tests/Fixtures/Rules/SimplifyBooleanExpressionRule/ValidComparisons.php
+++ b/tests/Fixtures/Rules/SimplifyBooleanExpressionRule/ValidComparisons.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\SimplifyBooleanExpressionRule;
+
+final class ValidComparisons
+{
+    public function run(mixed $value, string $status): void
+    {
+        if ($value === null) {
+            return;
+        }
+
+        if ($status === 'active') {
+            $this->enable();
+        }
+
+        if ($this->isActive()) {
+            $this->enable();
+        }
+
+        if (!$this->hasErrors()) {
+            $this->save();
+        }
+    }
+
+    private function isActive(): bool
+    {
+        return true;
+    }
+
+    private function hasErrors(): bool
+    {
+        return false;
+    }
+
+    private function enable(): void {}
+
+    private function save(): void {}
+}

--- a/tests/Unit/Rules/SimplifyBooleanExpressionRule/SimplifyBooleanExpressionRuleTest.php
+++ b/tests/Unit/Rules/SimplifyBooleanExpressionRule/SimplifyBooleanExpressionRuleTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\SimplifyBooleanExpressionRule;
+
+use Haspadar\PHPStanRules\Rules\SimplifyBooleanExpressionRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<SimplifyBooleanExpressionRule> */
+final class SimplifyBooleanExpressionRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new SimplifyBooleanExpressionRule();
+    }
+
+    #[Test]
+    public function reportsComparisonWithTrue(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/SimplifyBooleanExpressionRule/CompareWithTrue.php'],
+            [
+                [
+                    'Avoid unnecessary comparison with boolean literal. Use the expression directly.',
+                    11,
+                ],
+                [
+                    'Avoid unnecessary comparison with boolean literal. Use the expression directly.',
+                    15,
+                ],
+            ],
+        );
+    }
+
+    #[Test]
+    public function reportsComparisonWithFalse(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/SimplifyBooleanExpressionRule/CompareWithFalse.php'],
+            [
+                [
+                    'Avoid unnecessary comparison with boolean literal. Use the expression directly.',
+                    11,
+                ],
+                [
+                    'Avoid unnecessary comparison with boolean literal. Use the expression directly.',
+                    15,
+                ],
+            ],
+        );
+    }
+
+    #[Test]
+    public function reportsNotEqualBooleanComparisons(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/SimplifyBooleanExpressionRule/NotEqualBoolean.php'],
+            [
+                [
+                    'Avoid unnecessary comparison with boolean literal. Use the expression directly.',
+                    11,
+                ],
+                [
+                    'Avoid unnecessary comparison with boolean literal. Use the expression directly.',
+                    15,
+                ],
+            ],
+        );
+    }
+
+    #[Test]
+    public function reportsBooleanLiteralOnLeftSide(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/SimplifyBooleanExpressionRule/BooleanLiteralOnLeft.php'],
+            [
+                [
+                    'Avoid unnecessary comparison with boolean literal. Use the expression directly.',
+                    11,
+                ],
+                [
+                    'Avoid unnecessary comparison with boolean literal. Use the expression directly.',
+                    15,
+                ],
+            ],
+        );
+    }
+
+    #[Test]
+    public function passesForValidComparisons(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/SimplifyBooleanExpressionRule/ValidComparisons.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function suppressesViolationWhenPhpstanIgnorePresent(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/SimplifyBooleanExpressionRule/SuppressedClass.php'],
+            [],
+        );
+    }
+}

--- a/tests/Unit/RulesTest.php
+++ b/tests/Unit/RulesTest.php
@@ -75,6 +75,7 @@ use Haspadar\PHPStanRules\Rules\NestedIfDepthRule;
 use Haspadar\PHPStanRules\Rules\NestedTryDepthRule;
 use Haspadar\PHPStanRules\Rules\RequireIgnoreReasonRule;
 use Haspadar\PHPStanRules\Rules\SwitchDefaultRule;
+use Haspadar\PHPStanRules\Rules\SimplifyBooleanExpressionRule;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -155,6 +156,7 @@ final class RulesTest extends TestCase
                 NestedForDepthRule::class,
                 NestedTryDepthRule::class,
                 SwitchDefaultRule::class,
+                SimplifyBooleanExpressionRule::class,
             ],
             (new Rules())->all(),
             'Rules::all() must list every registered rule class',


### PR DESCRIPTION
## Summary

- Added `SimplifyBooleanExpressionRule` that reports comparisons like `$x == true`, `$x === false`, `$x != true`, `$x !== false` — the expression already evaluates to boolean, the literal comparison is redundant
- Registered rule in `Rules::all()` and `rules.neon` (no configurable parameters)
- Added global suppress in `rules-ignore.neon` for existing violations in project source
- Added fixtures covering: compare with true, compare with false, not-equal operators, literal on left side, valid comparisons, suppressed
- Added unit tests for all cases

Closes #180