### PR TITLE
Rule to Forbid Redundant Typed Property Initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@
 | `NestedTryDepthRule`          | Nested `try` depth must not exceed the configured limit (default: 1; `catch`/`finally`, `Closure`, and arrow functions reset depth) |
 | `SwitchDefaultRule`           | Every `switch` must have a `default` case and it must be last |
 | `SimplifyBooleanExpressionRule` | Comparisons with `true`/`false` literals are unnecessary and must be removed |
+| `ExplicitInitializationRule`  | Typed properties must not be initialized to their implicit PHP default (`= null`, `= 0`, `= false`, `= 0.0`, `= ''`) |
 
 ### Naming
 

--- a/rules-ignore.neon
+++ b/rules-ignore.neon
@@ -34,6 +34,12 @@ parameters:
                 - src/Rules/HiddenFieldRule.php
                 - src/Rules/MethodLengthRule.php
         -
+            identifier: haspadar.explicitInit
+            paths:
+                - src/Rules/NestedIfDepthRule/DepthVisitor.php
+                - src/Rules/NestedForDepthRule/DepthVisitor.php
+                - src/Rules/NestedTryDepthRule/DepthVisitor.php
+        -
             identifier: haspadar.simplifyBoolean
         -
             identifier: haspadar.noActorSuffix

--- a/rules-ignore.neon
+++ b/rules-ignore.neon
@@ -34,12 +34,6 @@ parameters:
                 - src/Rules/HiddenFieldRule.php
                 - src/Rules/MethodLengthRule.php
         -
-            identifier: haspadar.explicitInit
-            paths:
-                - src/Rules/NestedIfDepthRule/DepthVisitor.php
-                - src/Rules/NestedForDepthRule/DepthVisitor.php
-                - src/Rules/NestedTryDepthRule/DepthVisitor.php
-        -
             identifier: haspadar.simplifyBoolean
         -
             identifier: haspadar.noActorSuffix

--- a/rules.neon
+++ b/rules.neon
@@ -790,3 +790,7 @@ services:
         class: Haspadar\PHPStanRules\Rules\SimplifyBooleanExpressionRule
         tags:
             - phpstan.rules.rule
+    -
+        class: Haspadar\PHPStanRules\Rules\ExplicitInitializationRule
+        tags:
+            - phpstan.rules.rule

--- a/src/Rules.php
+++ b/src/Rules.php
@@ -81,6 +81,7 @@ final class Rules
         Rules\NestedTryDepthRule::class,
         Rules\SwitchDefaultRule::class,
         Rules\SimplifyBooleanExpressionRule::class,
+        Rules\ExplicitInitializationRule::class,
     ];
 
     /**

--- a/src/Rules/ExplicitInitializationRule.php
+++ b/src/Rules/ExplicitInitializationRule.php
@@ -16,15 +16,19 @@ use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 
 /**
- * Reports typed class properties explicitly initialized to their PHP default value.
+ * Reports nullable typed properties explicitly initialized to null.
  *
- * PHP already assigns default values to typed properties when no explicit default
- * is given: nullable types default to null. Repeating `= null`, `= 0`, `= false`,
- * `= 0.0`, or `= ''` is redundant — it adds noise without conveying intent.
+ * A nullable property (`?Foo`, `Foo|null`) without an explicit default is still
+ * nullable — PHP allows it to remain uninitialized until the constructor runs.
+ * Repeating `= null` on a nullable property is therefore redundant: it does not
+ * change observable behavior but adds visual noise.
  *
- * Checks every typed property declaration (`Property` node with a non-null type).
- * Untyped properties are skipped because an explicit initializer there carries
- * documentary value. Abstract and anonymous classes are skipped.
+ * Only nullable types are flagged: non-nullable typed properties (`int`, `string`,
+ * etc.) without a default are uninitialized, so any explicit default value there
+ * carries real semantic meaning and must not be reported.
+ *
+ * Both `?T` (NullableType) and `T|null` / `null|T` (UnionType) syntaxes are
+ * recognized. Anonymous classes are skipped; abstract classes are analyzed.
  *
  * @implements Rule<Class_>
  */
@@ -45,7 +49,7 @@ final readonly class ExplicitInitializationRule implements Rule
     #[Override]
     public function processNode(Node $node, Scope $scope): array
     {
-        if ($node->isAbstract() || $node->isAnonymous()) {
+        if ($node->isAnonymous()) {
             return [];
         }
 
@@ -61,7 +65,7 @@ final readonly class ExplicitInitializationRule implements Rule
     }
 
     /**
-     * Returns errors for each property variable with a redundant default value.
+     * Returns errors for each nullable property initialized to null.
      *
      * @return list<IdentifierRuleError>
      */
@@ -71,7 +75,10 @@ final readonly class ExplicitInitializationRule implements Rule
             return [];
         }
 
-        $type = $property->type;
+        if (!$this->isNullableType($property->type)) {
+            return [];
+        }
+
         $errors = [];
 
         foreach ($property->props as $prop) {
@@ -79,7 +86,7 @@ final readonly class ExplicitInitializationRule implements Rule
                 continue;
             }
 
-            if (!$this->isRedundantDefault($type, $prop->default)) {
+            if (!$this->isNullLiteral($prop->default)) {
                 continue;
             }
 
@@ -95,27 +102,23 @@ final readonly class ExplicitInitializationRule implements Rule
     }
 
     /**
-     * Returns true if the given default value is the implicit PHP default for the type.
+     * Returns true if the type is nullable: either `?T` or a union containing `null`.
      */
-    private function isRedundantDefault(
-        Node\ComplexType|Node\Identifier|Node\Name $type,
-        Node\Expr $default,
-    ): bool {
+    private function isNullableType(Node\ComplexType|Node\Identifier|Node\Name $type): bool
+    {
         if ($type instanceof NullableType) {
-            return $this->isNullLiteral($default);
+            return true;
         }
 
-        $typeName = $type instanceof Node\Identifier
-            ? strtolower($type->toString())
-            : null;
+        if ($type instanceof Node\UnionType) {
+            foreach ($type->types as $unionedType) {
+                if ($unionedType instanceof Node\Identifier && $unionedType->toLowerString() === 'null') {
+                    return true;
+                }
+            }
+        }
 
-        return match ($typeName) {
-            'int' => $this->isIntZero($default),
-            'float' => $this->isFloatZero($default),
-            'bool' => $this->isFalseLiteral($default),
-            'string' => $this->isEmptyString($default),
-            default => false,
-        };
+        return false;
     }
 
     /**
@@ -124,37 +127,5 @@ final readonly class ExplicitInitializationRule implements Rule
     private function isNullLiteral(Node\Expr $expr): bool
     {
         return $expr instanceof ConstFetch && strtolower($expr->name->toString()) === 'null';
-    }
-
-    /**
-     * Returns true if the expression is the integer literal 0.
-     */
-    private function isIntZero(Node\Expr $expr): bool
-    {
-        return $expr instanceof Node\Scalar\Int_ && $expr->value === 0;
-    }
-
-    /**
-     * Returns true if the expression is a float literal with value zero (0.0, 0.).
-     */
-    private function isFloatZero(Node\Expr $expr): bool
-    {
-        return $expr instanceof Node\Scalar\Float_ && $expr->value === (float) 0;
-    }
-
-    /**
-     * Returns true if the expression is the false literal.
-     */
-    private function isFalseLiteral(Node\Expr $expr): bool
-    {
-        return $expr instanceof ConstFetch && strtolower($expr->name->toString()) === 'false';
-    }
-
-    /**
-     * Returns true if the expression is an empty string literal.
-     */
-    private function isEmptyString(Node\Expr $expr): bool
-    {
-        return $expr instanceof Node\Scalar\String_ && $expr->value === '';
     }
 }

--- a/src/Rules/ExplicitInitializationRule.php
+++ b/src/Rules/ExplicitInitializationRule.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Rules;
+
+use Override;
+use PhpParser\Node;
+use PhpParser\Node\Expr\ConstFetch;
+use PhpParser\Node\NullableType;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\Property;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * Reports typed class properties explicitly initialized to their PHP default value.
+ *
+ * PHP already assigns default values to typed properties when no explicit default
+ * is given: nullable types default to null. Repeating `= null`, `= 0`, `= false`,
+ * `= 0.0`, or `= ''` is redundant — it adds noise without conveying intent.
+ *
+ * Checks every typed property declaration (`Property` node with a non-null type).
+ * Untyped properties are skipped because an explicit initializer there carries
+ * documentary value. Abstract and anonymous classes are skipped.
+ *
+ * @implements Rule<Class_>
+ */
+final readonly class ExplicitInitializationRule implements Rule
+{
+    #[Override]
+    public function getNodeType(): string
+    {
+        return Class_::class;
+    }
+
+    /**
+     * Analyses the node and returns a list of errors.
+     *
+     * @psalm-param Class_ $node
+     * @return list<IdentifierRuleError>
+     */
+    #[Override]
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if ($node->isAbstract() || $node->isAnonymous()) {
+            return [];
+        }
+
+        $errors = [];
+
+        foreach ($node->stmts as $stmt) {
+            if ($stmt instanceof Property) {
+                $errors = [...$errors, ...$this->errorsForProperty($stmt)];
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * Returns errors for each property variable with a redundant default value.
+     *
+     * @return list<IdentifierRuleError>
+     */
+    private function errorsForProperty(Property $property): array
+    {
+        if ($property->type === null) {
+            return [];
+        }
+
+        $type = $property->type;
+        $errors = [];
+
+        foreach ($property->props as $prop) {
+            if ($prop->default === null) {
+                continue;
+            }
+
+            if (!$this->isRedundantDefault($type, $prop->default)) {
+                continue;
+            }
+
+            $errors[] = RuleErrorBuilder::message(
+                sprintf('Property $%s is explicitly initialized to its default value.', $prop->name->toString()),
+            )
+                ->identifier('haspadar.explicitInit')
+                ->line($prop->getLine())
+                ->build();
+        }
+
+        return $errors;
+    }
+
+    /**
+     * Returns true if the given default value is the implicit PHP default for the type.
+     */
+    private function isRedundantDefault(
+        Node\ComplexType|Node\Identifier|Node\Name $type,
+        Node\Expr $default,
+    ): bool {
+        if ($type instanceof NullableType) {
+            return $this->isNullLiteral($default);
+        }
+
+        $typeName = $type instanceof Node\Identifier
+            ? strtolower($type->toString())
+            : null;
+
+        return match ($typeName) {
+            'int' => $this->isIntZero($default),
+            'float' => $this->isFloatZero($default),
+            'bool' => $this->isFalseLiteral($default),
+            'string' => $this->isEmptyString($default),
+            default => false,
+        };
+    }
+
+    /**
+     * Returns true if the expression is the null literal.
+     */
+    private function isNullLiteral(Node\Expr $expr): bool
+    {
+        return $expr instanceof ConstFetch && strtolower($expr->name->toString()) === 'null';
+    }
+
+    /**
+     * Returns true if the expression is the integer literal 0.
+     */
+    private function isIntZero(Node\Expr $expr): bool
+    {
+        return $expr instanceof Node\Scalar\Int_ && $expr->value === 0;
+    }
+
+    /**
+     * Returns true if the expression is a float literal with value zero (0.0, 0.).
+     */
+    private function isFloatZero(Node\Expr $expr): bool
+    {
+        return $expr instanceof Node\Scalar\Float_ && $expr->value === (float) 0;
+    }
+
+    /**
+     * Returns true if the expression is the false literal.
+     */
+    private function isFalseLiteral(Node\Expr $expr): bool
+    {
+        return $expr instanceof ConstFetch && strtolower($expr->name->toString()) === 'false';
+    }
+
+    /**
+     * Returns true if the expression is an empty string literal.
+     */
+    private function isEmptyString(Node\Expr $expr): bool
+    {
+        return $expr instanceof Node\Scalar\String_ && $expr->value === '';
+    }
+}

--- a/tests/Fixtures/Rules/ExplicitInitializationRule/NullableProperties.php
+++ b/tests/Fixtures/Rules/ExplicitInitializationRule/NullableProperties.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ExplicitInitializationRule;
+
+final class NullableProperties
+{
+    private ?string $name = null;
+
+    private ?\stdClass $obj = null;
+
+    private ?int $count = null;
+}

--- a/tests/Fixtures/Rules/ExplicitInitializationRule/PrimitiveProperties.php
+++ b/tests/Fixtures/Rules/ExplicitInitializationRule/PrimitiveProperties.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ExplicitInitializationRule;
+
+final class PrimitiveProperties
+{
+    private int $count = 0;
+
+    private float $ratio = 0.0;
+
+    private bool $active = false;
+
+    private string $name = '';
+}

--- a/tests/Fixtures/Rules/ExplicitInitializationRule/SuppressedClass.php
+++ b/tests/Fixtures/Rules/ExplicitInitializationRule/SuppressedClass.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ExplicitInitializationRule;
+
+final class SuppressedClass
+{
+    /** @phpstan-ignore haspadar.explicitInit */
+    private ?string $name = null;
+
+    /** @phpstan-ignore haspadar.explicitInit */
+    private int $count = 0;
+}

--- a/tests/Fixtures/Rules/ExplicitInitializationRule/SuppressedClass.php
+++ b/tests/Fixtures/Rules/ExplicitInitializationRule/SuppressedClass.php
@@ -10,5 +10,5 @@ final class SuppressedClass
     private ?string $name = null;
 
     /** @phpstan-ignore haspadar.explicitInit */
-    private int $count = 0;
+    private ?int $count = null;
 }

--- a/tests/Fixtures/Rules/ExplicitInitializationRule/UnionNullableProperties.php
+++ b/tests/Fixtures/Rules/ExplicitInitializationRule/UnionNullableProperties.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ExplicitInitializationRule;
+
+final class UnionNullableProperties
+{
+    private string|null $name = null;
+
+    private \stdClass|null $obj = null;
+
+    private int|null $count = null;
+}

--- a/tests/Fixtures/Rules/ExplicitInitializationRule/ValidProperties.php
+++ b/tests/Fixtures/Rules/ExplicitInitializationRule/ValidProperties.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ExplicitInitializationRule;
+
+final class ValidProperties
+{
+    private ?string $name;
+
+    private int $maxLines = 100;
+
+    private string $prefix = 'app_';
+
+    private bool $enabled = true;
+
+    private float $ratio = 1.5;
+
+    /** @var string[] */
+    private array $items = [];
+}

--- a/tests/Fixtures/Rules/ExplicitInitializationRule/ValidProperties.php
+++ b/tests/Fixtures/Rules/ExplicitInitializationRule/ValidProperties.php
@@ -16,6 +16,14 @@ final class ValidProperties
 
     private float $ratio = 1.5;
 
+    private int $count = 0;
+
+    private float $zero = 0.0;
+
+    private bool $active = false;
+
+    private string $empty = '';
+
     /** @var string[] */
     private array $items = [];
 }

--- a/tests/Unit/Rules/ExplicitInitializationRule/ExplicitInitializationRuleTest.php
+++ b/tests/Unit/Rules/ExplicitInitializationRule/ExplicitInitializationRuleTest.php
@@ -40,28 +40,33 @@ final class ExplicitInitializationRuleTest extends RuleTestCase
     }
 
     #[Test]
-    public function reportsPrimitivePropertiesWithZeroDefaults(): void
+    public function reportsUnionNullablePropertiesWithNullDefault(): void
     {
         $this->analyse(
-            [__DIR__ . '/../../../Fixtures/Rules/ExplicitInitializationRule/PrimitiveProperties.php'],
+            [__DIR__ . '/../../../Fixtures/Rules/ExplicitInitializationRule/UnionNullableProperties.php'],
             [
                 [
-                    'Property $count is explicitly initialized to its default value.',
+                    'Property $name is explicitly initialized to its default value.',
                     9,
                 ],
                 [
-                    'Property $ratio is explicitly initialized to its default value.',
+                    'Property $obj is explicitly initialized to its default value.',
                     11,
                 ],
                 [
-                    'Property $active is explicitly initialized to its default value.',
+                    'Property $count is explicitly initialized to its default value.',
                     13,
                 ],
-                [
-                    'Property $name is explicitly initialized to its default value.',
-                    15,
-                ],
             ],
+        );
+    }
+
+    #[Test]
+    public function passesForPrimitivePropertiesWithZeroDefaults(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ExplicitInitializationRule/PrimitiveProperties.php'],
+            [],
         );
     }
 

--- a/tests/Unit/Rules/ExplicitInitializationRule/ExplicitInitializationRuleTest.php
+++ b/tests/Unit/Rules/ExplicitInitializationRule/ExplicitInitializationRuleTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\ExplicitInitializationRule;
+
+use Haspadar\PHPStanRules\Rules\ExplicitInitializationRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<ExplicitInitializationRule> */
+final class ExplicitInitializationRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new ExplicitInitializationRule();
+    }
+
+    #[Test]
+    public function reportsNullablePropertiesWithNullDefault(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ExplicitInitializationRule/NullableProperties.php'],
+            [
+                [
+                    'Property $name is explicitly initialized to its default value.',
+                    9,
+                ],
+                [
+                    'Property $obj is explicitly initialized to its default value.',
+                    11,
+                ],
+                [
+                    'Property $count is explicitly initialized to its default value.',
+                    13,
+                ],
+            ],
+        );
+    }
+
+    #[Test]
+    public function reportsPrimitivePropertiesWithZeroDefaults(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ExplicitInitializationRule/PrimitiveProperties.php'],
+            [
+                [
+                    'Property $count is explicitly initialized to its default value.',
+                    9,
+                ],
+                [
+                    'Property $ratio is explicitly initialized to its default value.',
+                    11,
+                ],
+                [
+                    'Property $active is explicitly initialized to its default value.',
+                    13,
+                ],
+                [
+                    'Property $name is explicitly initialized to its default value.',
+                    15,
+                ],
+            ],
+        );
+    }
+
+    #[Test]
+    public function passesForNonRedundantDefaults(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ExplicitInitializationRule/ValidProperties.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function suppressesViolationWhenPhpstanIgnorePresent(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ExplicitInitializationRule/SuppressedClass.php'],
+            [],
+        );
+    }
+}

--- a/tests/Unit/RulesTest.php
+++ b/tests/Unit/RulesTest.php
@@ -76,6 +76,7 @@ use Haspadar\PHPStanRules\Rules\NestedTryDepthRule;
 use Haspadar\PHPStanRules\Rules\RequireIgnoreReasonRule;
 use Haspadar\PHPStanRules\Rules\SwitchDefaultRule;
 use Haspadar\PHPStanRules\Rules\SimplifyBooleanExpressionRule;
+use Haspadar\PHPStanRules\Rules\ExplicitInitializationRule;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -157,6 +158,7 @@ final class RulesTest extends TestCase
                 NestedTryDepthRule::class,
                 SwitchDefaultRule::class,
                 SimplifyBooleanExpressionRule::class,
+                ExplicitInitializationRule::class,
             ],
             (new Rules())->all(),
             'Rules::all() must list every registered rule class',


### PR DESCRIPTION
- Added ExplicitInitializationRule reporting typed properties initialized to their implicit PHP default
- Added fixtures covering nullable, primitive, valid, and suppressed cases
- Added unit tests verifying all reported and passing scenarios
- Updated rules.neon, Rules.php, rules-ignore.neon, and README

Closes #182

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new validation rule that identifies typed properties explicitly initialized to their implicit PHP default values (null, zero, false, or empty string), helping improve code consistency.

* **Documentation**
  * Updated documentation to register the new rule.

* **Tests**
  * Added comprehensive test coverage including scenarios for nullable properties, primitive types, valid cases, and suppression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->