### PR TITLE
Rule to Enforce @throws Declaration Count Limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@
 | `SwitchDefaultRule`           | Every `switch` must have a `default` case and it must be last |
 | `SimplifyBooleanExpressionRule` | Comparisons with `true`/`false` literals are unnecessary and must be removed |
 | `ExplicitInitializationRule`  | Typed properties must not be initialized to their implicit PHP default (`= null`, `= 0`, `= false`, `= 0.0`, `= ''`) |
+| `ThrowsCountRule`             | `maxThrows=1` | Methods must not declare more `@throws` types than the configured maximum |
 
 ### Naming
 

--- a/rules-ignore.neon
+++ b/rules-ignore.neon
@@ -34,6 +34,12 @@ parameters:
                 - src/Rules/HiddenFieldRule.php
                 - src/Rules/MethodLengthRule.php
         -
+            identifier: haspadar.throwsCount
+            paths:
+                - src/Rules/IllegalThrowsRule.php
+                - src/Rules/MissingThrowsRule.php
+                - src/Rules/ThrowsCountRule.php
+        -
             identifier: haspadar.simplifyBoolean
         -
             identifier: haspadar.noActorSuffix

--- a/rules.neon
+++ b/rules.neon
@@ -182,6 +182,8 @@ parameters:
             maxDepth: 1
         nestedTryDepth:
             maxDepth: 1
+        throwsCount:
+            maxThrows: 1
     exceptions:
         check:
             missingCheckedExceptionInThrows: false
@@ -348,6 +350,9 @@ parametersSchema:
         ]),
         nestedTryDepth: structure([
             maxDepth: int(),
+        ]),
+        throwsCount: structure([
+            maxThrows: int(),
         ]),
     ])
 
@@ -792,5 +797,11 @@ services:
             - phpstan.rules.rule
     -
         class: Haspadar\PHPStanRules\Rules\ExplicitInitializationRule
+        tags:
+            - phpstan.rules.rule
+    -
+        class: Haspadar\PHPStanRules\Rules\ThrowsCountRule
+        arguments:
+            maxThrows: %haspadar.throwsCount.maxThrows%
         tags:
             - phpstan.rules.rule

--- a/src/Rules.php
+++ b/src/Rules.php
@@ -82,6 +82,7 @@ final class Rules
         Rules\SwitchDefaultRule::class,
         Rules\SimplifyBooleanExpressionRule::class,
         Rules\ExplicitInitializationRule::class,
+        Rules\ThrowsCountRule::class,
     ];
 
     /**

--- a/src/Rules/ThrowsCountRule.php
+++ b/src/Rules/ThrowsCountRule.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Rules;
+
+use Override;
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\ShouldNotHappenException;
+
+/**
+ * Reports class methods with more @throws PHPDoc tags than the configured maximum.
+ *
+ * A method declaring many exception types violates the Single Responsibility
+ * Principle — each distinct @throws tag signals a different failure mode, which
+ * in turn implies a different concern handled by the method. The default limit
+ * of 1 enforces one category of error per method.
+ *
+ * Counts distinct @throws lines in the PHPDoc block. Union types on a single
+ * line (e.g. `@throws FooException|BarException`) count as one declaration.
+ * Methods without a PHPDoc block or without any @throws tag are not reported.
+ *
+ * @implements Rule<ClassMethod>
+ */
+final readonly class ThrowsCountRule implements Rule
+{
+    /**
+     * Constructs the rule with the given maximum number of @throws declarations.
+     *
+     * @param int $maxThrows Maximum number of @throws tags allowed per method
+     */
+    public function __construct(private int $maxThrows = 1) {}
+
+    #[Override]
+    public function getNodeType(): string
+    {
+        return ClassMethod::class;
+    }
+
+    /**
+     * Analyses the node and returns a list of errors.
+     *
+     * @psalm-param ClassMethod $node
+     * @throws ShouldNotHappenException
+     * @return list<IdentifierRuleError>
+     */
+    #[Override]
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $docComment = $node->getDocComment();
+
+        if ($docComment === null) {
+            return [];
+        }
+
+        $count = $this->countThrowsTags($docComment->getText());
+
+        if ($count <= $this->maxThrows) {
+            return [];
+        }
+
+        $methodName = $node->name->toString();
+
+        return [
+            RuleErrorBuilder::message(
+                sprintf(
+                    'Method %s() declares %d @throws types. Maximum allowed is %d.',
+                    $methodName,
+                    $count,
+                    $this->maxThrows,
+                ),
+            )
+                ->identifier('haspadar.throwsCount')
+                ->build(),
+        ];
+    }
+
+    /**
+     * Returns the number of @throws lines in the given PHPDoc comment text.
+     */
+    private function countThrowsTags(string $docComment): int
+    {
+        $count = 0;
+
+        foreach (explode("\n", $docComment) as $line) {
+            if (preg_match('/@throws\s+\S+/', $line) === 1) {
+                $count++;
+            }
+        }
+
+        return $count;
+    }
+}

--- a/tests/Fixtures/Rules/ThrowsCountRule/DefaultLimit.php
+++ b/tests/Fixtures/Rules/ThrowsCountRule/DefaultLimit.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ThrowsCountRule;
+
+final class DefaultLimit
+{
+    /**
+     * @throws \InvalidArgumentException
+     * @throws \RuntimeException
+     */
+    public function run(): void {}
+}

--- a/tests/Fixtures/Rules/ThrowsCountRule/ExactThrows.php
+++ b/tests/Fixtures/Rules/ThrowsCountRule/ExactThrows.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ThrowsCountRule;
+
+final class ExactThrows
+{
+    /**
+     * @throws \InvalidArgumentException
+     * @throws \RuntimeException
+     */
+    public function run(): void {}
+}

--- a/tests/Fixtures/Rules/ThrowsCountRule/FewThrows.php
+++ b/tests/Fixtures/Rules/ThrowsCountRule/FewThrows.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ThrowsCountRule;
+
+final class FewThrows
+{
+    /**
+     * @throws \InvalidArgumentException
+     */
+    public function run(): void {}
+}

--- a/tests/Fixtures/Rules/ThrowsCountRule/NoThrows.php
+++ b/tests/Fixtures/Rules/ThrowsCountRule/NoThrows.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ThrowsCountRule;
+
+final class NoThrows
+{
+    /**
+     * Does not throw anything.
+     */
+    public function run(): void {}
+
+    public function runWithoutDoc(): void {}
+}

--- a/tests/Fixtures/Rules/ThrowsCountRule/SuppressedClass.php
+++ b/tests/Fixtures/Rules/ThrowsCountRule/SuppressedClass.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ThrowsCountRule;
+
+final class SuppressedClass
+{
+    /**
+     * @phpstan-ignore haspadar.throwsCount
+     * @throws \InvalidArgumentException
+     * @throws \RuntimeException
+     */
+    public function run(): void {}
+}

--- a/tests/Fixtures/Rules/ThrowsCountRule/TooManyThrows.php
+++ b/tests/Fixtures/Rules/ThrowsCountRule/TooManyThrows.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ThrowsCountRule;
+
+final class TooManyThrows
+{
+    /**
+     * @throws \InvalidArgumentException
+     * @throws \RuntimeException
+     * @throws \LogicException
+     */
+    public function run(): void {}
+}

--- a/tests/Unit/Rules/ThrowsCountRule/ThrowsCountRuleDefaultLimitTest.php
+++ b/tests/Unit/Rules/ThrowsCountRule/ThrowsCountRuleDefaultLimitTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\ThrowsCountRule;
+
+use Haspadar\PHPStanRules\Rules\ThrowsCountRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<ThrowsCountRule> */
+final class ThrowsCountRuleDefaultLimitTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new ThrowsCountRule();
+    }
+
+    #[Test]
+    public function reportsWhenMethodExceedsDefaultLimit(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ThrowsCountRule/DefaultLimit.php'],
+            [
+                [
+                    'Method run() declares 2 @throws types. Maximum allowed is 1.',
+                    13,
+                ],
+            ],
+        );
+    }
+}

--- a/tests/Unit/Rules/ThrowsCountRule/ThrowsCountRuleTest.php
+++ b/tests/Unit/Rules/ThrowsCountRule/ThrowsCountRuleTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\ThrowsCountRule;
+
+use Haspadar\PHPStanRules\Rules\ThrowsCountRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<ThrowsCountRule> */
+final class ThrowsCountRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new ThrowsCountRule(2);
+    }
+
+    #[Test]
+    public function passesWhenThrowsCountIsBelowLimit(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ThrowsCountRule/FewThrows.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function passesWhenThrowsCountIsExactlyAtLimit(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ThrowsCountRule/ExactThrows.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function reportsWhenThrowsCountExceedsLimit(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ThrowsCountRule/TooManyThrows.php'],
+            [
+                [
+                    'Method run() declares 3 @throws types. Maximum allowed is 2.',
+                    14,
+                ],
+            ],
+        );
+    }
+
+    #[Test]
+    public function passesWhenNoThrowsPresent(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ThrowsCountRule/NoThrows.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function suppressesViolationWhenPhpstanIgnorePresent(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ThrowsCountRule/SuppressedClass.php'],
+            [],
+        );
+    }
+}

--- a/tests/Unit/RulesTest.php
+++ b/tests/Unit/RulesTest.php
@@ -77,6 +77,7 @@ use Haspadar\PHPStanRules\Rules\RequireIgnoreReasonRule;
 use Haspadar\PHPStanRules\Rules\SwitchDefaultRule;
 use Haspadar\PHPStanRules\Rules\SimplifyBooleanExpressionRule;
 use Haspadar\PHPStanRules\Rules\ExplicitInitializationRule;
+use Haspadar\PHPStanRules\Rules\ThrowsCountRule;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -159,6 +160,7 @@ final class RulesTest extends TestCase
                 SwitchDefaultRule::class,
                 SimplifyBooleanExpressionRule::class,
                 ExplicitInitializationRule::class,
+                ThrowsCountRule::class,
             ],
             (new Rules())->all(),
             'Rules::all() must list every registered rule class',


### PR DESCRIPTION
- Added ThrowsCountRule reporting methods that declare more @throws types than the configured maximum
- Added fixtures covering too-many, exact, few, no-throws, and suppressed cases
- Added unit tests for custom limit and default limit (maxThrows=1)
- Updated rules.neon, Rules.php, rules-ignore.neon, and README

Closes #184