### PR TITLE
Rule to Forbid else After if Ending With throw

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ includes:
 | `SimplifyBooleanExpressionRule` | Comparisons with `true`/`false` literals are unnecessary and must be removed |
 | `ExplicitInitializationRule`  | Nullable typed properties (`?T`, `T\|null`, `null\|T`) must not be initialized to `= null` |
 | `ThrowsCountRule`             | Methods must not declare more `@throws` types than the configured maximum (default: 1) |
+| `IfThenThrowElseRule`         | `else`/`elseif` after an `if` block that ends with `throw` is forbidden |
 
 ### Naming
 

--- a/rules.neon
+++ b/rules.neon
@@ -805,3 +805,7 @@ services:
             maxThrows: %haspadar.throwsCount.maxThrows%
         tags:
             - phpstan.rules.rule
+    -
+        class: Haspadar\PHPStanRules\Rules\IfThenThrowElseRule
+        tags:
+            - phpstan.rules.rule

--- a/src/Rules.php
+++ b/src/Rules.php
@@ -83,6 +83,7 @@ final class Rules
         Rules\SimplifyBooleanExpressionRule::class,
         Rules\ExplicitInitializationRule::class,
         Rules\ThrowsCountRule::class,
+        Rules\IfThenThrowElseRule::class,
     ];
 
     /**

--- a/src/Rules/IfThenThrowElseRule.php
+++ b/src/Rules/IfThenThrowElseRule.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Rules;
+
+use Override;
+use PhpParser\Node;
+use PhpParser\Node\Expr\Throw_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Expression;
+use PhpParser\Node\Stmt\If_;
+use PhpParser\NodeFinder;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\ShouldNotHappenException;
+
+/**
+ * Reports if statements whose then-branch ends with a throw and still have an else or elseif branch.
+ *
+ * When the then-branch unconditionally throws, control never reaches the code
+ * after the if/else pair. The else keyword adds no information and only deepens
+ * nesting. Remove the else and leave the alternative body at the original
+ * indentation level (guard-clause / early-throw pattern).
+ *
+ * Only throw is checked — return is handled separately by ReturnCountRule.
+ * Closure and arrow-function bodies are scanned independently; a throw inside
+ * a nested closure does not trigger this rule for the outer if statement.
+ *
+ * @implements Rule<ClassMethod>
+ */
+final readonly class IfThenThrowElseRule implements Rule
+{
+    #[Override]
+    public function getNodeType(): string
+    {
+        return ClassMethod::class;
+    }
+
+    /**
+     * Analyses the method and returns errors for every if/throw/else pattern.
+     *
+     * @psalm-param ClassMethod $node
+     * @throws ShouldNotHappenException
+     * @return list<IdentifierRuleError>
+     */
+    #[Override]
+    public function processNode(Node $node, Scope $scope): array
+    {
+        /** @var list<If_> $ifNodes */
+        $ifNodes = (new NodeFinder())->find(
+            $node->stmts ?? [],
+            static fn(Node $n): bool => $n instanceof If_,
+        );
+
+        $errors = [];
+
+        foreach ($ifNodes as $ifNode) {
+            if (!$this->thenEndsWithThrow($ifNode)) {
+                continue;
+            }
+
+            if ($ifNode->else === null && $ifNode->elseifs === []) {
+                continue;
+            }
+
+            $errors[] = RuleErrorBuilder::message(
+                'Remove the else branch — the if block always throws.',
+            )
+                ->identifier('haspadar.ifThenThrowElse')
+                ->line($ifNode->getStartLine())
+                ->build();
+        }
+
+        return $errors;
+    }
+
+    /**
+     * Returns true if the last statement in the if-branch is a throw expression statement.
+     */
+    private function thenEndsWithThrow(If_ $node): bool
+    {
+        if ($node->stmts === []) {
+            return false;
+        }
+
+        $last = $node->stmts[count($node->stmts) - 1];
+
+        return $last instanceof Expression && $last->expr instanceof Throw_;
+    }
+}

--- a/tests/Fixtures/Rules/IfThenThrowElseRule/ElseAfterReturn.php
+++ b/tests/Fixtures/Rules/IfThenThrowElseRule/ElseAfterReturn.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\IfThenThrowElseRule;
+
+final class ElseAfterReturn
+{
+    public function run(int $value): string
+    {
+        if ($value < 0) {
+            return 'negative';
+        } else {
+            return 'non-negative';
+        }
+    }
+}

--- a/tests/Fixtures/Rules/IfThenThrowElseRule/ElseAfterThrow.php
+++ b/tests/Fixtures/Rules/IfThenThrowElseRule/ElseAfterThrow.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\IfThenThrowElseRule;
+
+final class ElseAfterThrow
+{
+    public function run(int $value): string
+    {
+        if ($value < 0) {
+            throw new \InvalidArgumentException('negative');
+        } else {
+            return 'ok';
+        }
+    }
+}

--- a/tests/Fixtures/Rules/IfThenThrowElseRule/ElseIfAfterThrow.php
+++ b/tests/Fixtures/Rules/IfThenThrowElseRule/ElseIfAfterThrow.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\IfThenThrowElseRule;
+
+final class ElseIfAfterThrow
+{
+    public function run(int $value): string
+    {
+        if ($value < 0) {
+            throw new \InvalidArgumentException('negative');
+        } elseif ($value === 0) {
+            return 'zero';
+        }
+
+        return 'positive';
+    }
+}

--- a/tests/Fixtures/Rules/IfThenThrowElseRule/NoElse.php
+++ b/tests/Fixtures/Rules/IfThenThrowElseRule/NoElse.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\IfThenThrowElseRule;
+
+final class NoElse
+{
+    public function run(int $value): string
+    {
+        if ($value < 0) {
+            throw new \InvalidArgumentException('negative');
+        }
+
+        return 'ok';
+    }
+}

--- a/tests/Fixtures/Rules/IfThenThrowElseRule/SuppressedClass.php
+++ b/tests/Fixtures/Rules/IfThenThrowElseRule/SuppressedClass.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\IfThenThrowElseRule;
+
+final class SuppressedClass
+{
+    public function run(int $value): string
+    {
+        /** @phpstan-ignore haspadar.ifThenThrowElse */
+        if ($value < 0) {
+            throw new \InvalidArgumentException('negative');
+        } else {
+            return 'ok';
+        }
+    }
+}

--- a/tests/Unit/Rules/IfThenThrowElseRule/IfThenThrowElseRuleTest.php
+++ b/tests/Unit/Rules/IfThenThrowElseRule/IfThenThrowElseRuleTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\IfThenThrowElseRule;
+
+use Haspadar\PHPStanRules\Rules\IfThenThrowElseRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<IfThenThrowElseRule> */
+final class IfThenThrowElseRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new IfThenThrowElseRule();
+    }
+
+    #[Test]
+    public function reportsElseBranchAfterThrow(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/IfThenThrowElseRule/ElseAfterThrow.php'],
+            [
+                [
+                    'Remove the else branch — the if block always throws.',
+                    11,
+                ],
+            ],
+        );
+    }
+
+    #[Test]
+    public function reportsElseIfBranchAfterThrow(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/IfThenThrowElseRule/ElseIfAfterThrow.php'],
+            [
+                [
+                    'Remove the else branch — the if block always throws.',
+                    11,
+                ],
+            ],
+        );
+    }
+
+    #[Test]
+    public function passesWhenNoElseAfterThrow(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/IfThenThrowElseRule/NoElse.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function passesWhenElseAfterReturn(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/IfThenThrowElseRule/ElseAfterReturn.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function suppressesViolationWhenPhpstanIgnorePresent(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/IfThenThrowElseRule/SuppressedClass.php'],
+            [],
+        );
+    }
+}

--- a/tests/Unit/RulesTest.php
+++ b/tests/Unit/RulesTest.php
@@ -78,6 +78,7 @@ use Haspadar\PHPStanRules\Rules\SwitchDefaultRule;
 use Haspadar\PHPStanRules\Rules\SimplifyBooleanExpressionRule;
 use Haspadar\PHPStanRules\Rules\ExplicitInitializationRule;
 use Haspadar\PHPStanRules\Rules\ThrowsCountRule;
+use Haspadar\PHPStanRules\Rules\IfThenThrowElseRule;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -161,6 +162,7 @@ final class RulesTest extends TestCase
                 SimplifyBooleanExpressionRule::class,
                 ExplicitInitializationRule::class,
                 ThrowsCountRule::class,
+                IfThenThrowElseRule::class,
             ],
             (new Rules())->all(),
             'Rules::all() must list every registered rule class',


### PR DESCRIPTION
- Added IfThenThrowElseRule reporting if blocks ending with throw that still have an else or elseif branch
- Added fixtures covering else-after-throw, elseif-after-throw, no-else, else-after-return, and suppressed cases
- Added unit tests verifying all reported and passing scenarios
- Updated rules.neon, Rules.php, RulesTest, and README

Closes #188