### PR TITLE
NestedSwitchRule to Forbid Nested Switch Statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ includes:
 | `ExplicitInitializationRule`  | Nullable typed properties (`?T`, `T\|null`, `null\|T`) must not be initialized to `= null` |
 | `ThrowsCountRule`             | Methods must not declare more `@throws` types than the configured maximum (default: 1) |
 | `IfThenThrowElseRule`         | `else`/`elseif` after an `if` block that ends with `throw` is forbidden |
+| `NestedSwitchRule`            | `switch` statements must not be nested inside another `switch` |
 
 ### Naming
 

--- a/rules-ignore.neon
+++ b/rules-ignore.neon
@@ -22,6 +22,7 @@ parameters:
                 - src/Rules/NestedIfDepthRule/DepthVisitor.php
                 - src/Rules/NestedForDepthRule/DepthVisitor.php
                 - src/Rules/NestedTryDepthRule/DepthVisitor.php
+                - src/Rules/NestedSwitchRule/NestedSwitchVisitor.php
         -
             identifier: haspadar.nestedForDepth
             paths:

--- a/rules.neon
+++ b/rules.neon
@@ -809,3 +809,7 @@ services:
         class: Haspadar\PHPStanRules\Rules\IfThenThrowElseRule
         tags:
             - phpstan.rules.rule
+    -
+        class: Haspadar\PHPStanRules\Rules\NestedSwitchRule
+        tags:
+            - phpstan.rules.rule

--- a/src/Rules.php
+++ b/src/Rules.php
@@ -84,6 +84,7 @@ final class Rules
         Rules\ExplicitInitializationRule::class,
         Rules\ThrowsCountRule::class,
         Rules\IfThenThrowElseRule::class,
+        Rules\NestedSwitchRule::class,
     ];
 
     /**

--- a/src/Rules/NestedSwitchRule.php
+++ b/src/Rules/NestedSwitchRule.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Rules;
+
+use Haspadar\PHPStanRules\Rules\NestedSwitchRule\NestedSwitchVisitor;
+use Override;
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\NodeTraverser;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\ShouldNotHappenException;
+
+/**
+ * Reports switch statements nested inside another switch statement.
+ *
+ * A switch inside another switch hides flow of control behind two levels of
+ * branching and almost always signals that the enclosing method is doing too
+ * much. Extract the inner switch into its own method instead.
+ *
+ * Mirrors Checkstyle's NestedIfDepth, NestedForDepth and NestedTryDepth modules.
+ * Closure and arrow-function bodies reset the scope — a switch inside a nested
+ * closure is not considered nested relative to the outer switch.
+ *
+ * @implements Rule<ClassMethod>
+ */
+final readonly class NestedSwitchRule implements Rule
+{
+    #[Override]
+    public function getNodeType(): string
+    {
+        return ClassMethod::class;
+    }
+
+    /**
+     * Analyses the method and returns errors for every nested switch.
+     *
+     * @psalm-param ClassMethod $node
+     * @throws ShouldNotHappenException
+     * @return list<IdentifierRuleError>
+     */
+    #[Override]
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if ($node->stmts === null) {
+            return [];
+        }
+
+        $visitor = new NestedSwitchVisitor();
+        $traverser = new NodeTraverser($visitor);
+        $traverser->traverse($node->stmts);
+
+        return $visitor->errors();
+    }
+}

--- a/src/Rules/NestedSwitchRule/NestedSwitchVisitor.php
+++ b/src/Rules/NestedSwitchRule/NestedSwitchVisitor.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Rules\NestedSwitchRule;
+
+use Override;
+use PhpParser\Node;
+use PhpParser\Node\Expr\ArrowFunction;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Stmt\Switch_;
+use PhpParser\NodeVisitorAbstract;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * Tracks switch nesting depth across an AST traversal and records violations.
+ *
+ * Each `Stmt\Switch_` entered raises the depth counter. When a nested switch
+ * (depth > 0) is encountered, an error is recorded. `Closure` and
+ * `ArrowFunction` bodies are counted separately — switches inside them do not
+ * contribute to the outer depth.
+ */
+final class NestedSwitchVisitor extends NodeVisitorAbstract
+{
+    /** @var int Current nesting level of switch statements outside any closure scope */
+    private int $depth = 0;
+
+    /** @var int How many nested Closure/ArrowFunction scopes are currently entered */
+    private int $closureDepth = 0;
+
+    /** @var list<IdentifierRuleError> */
+    private array $errors = [];
+
+    /**
+     * Increments the relevant counter when a tracked node is entered.
+     */
+    #[Override]
+    public function enterNode(Node $node): null
+    {
+        if ($node instanceof Closure || $node instanceof ArrowFunction) {
+            ++$this->closureDepth;
+
+            return null;
+        }
+
+        if ($this->closureDepth > 0) {
+            return null;
+        }
+
+        if ($node instanceof Switch_) {
+            if ($this->depth > 0) {
+                $this->errors[] = RuleErrorBuilder::message(
+                    'Nested switch statements are forbidden — extract the inner switch into a separate method.',
+                )
+                    ->identifier('haspadar.nestedSwitch')
+                    ->line($node->getStartLine())
+                    ->build();
+            }
+
+            ++$this->depth;
+        }
+
+        return null;
+    }
+
+    /**
+     * Decrements the relevant counter when a tracked node is exited.
+     */
+    #[Override]
+    public function leaveNode(Node $node): null
+    {
+        if ($node instanceof Closure || $node instanceof ArrowFunction) {
+            --$this->closureDepth;
+
+            return null;
+        }
+
+        if ($this->closureDepth > 0) {
+            return null;
+        }
+
+        if ($node instanceof Switch_) {
+            --$this->depth;
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns the list of errors found during traversal.
+     *
+     * @return list<IdentifierRuleError>
+     */
+    public function errors(): array
+    {
+        return $this->errors;
+    }
+}

--- a/tests/Fixtures/Rules/NestedSwitchRule/NestedSwitch.php
+++ b/tests/Fixtures/Rules/NestedSwitchRule/NestedSwitch.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedSwitchRule;
+
+final class NestedSwitch
+{
+    public function run(string $type, string $subType): string
+    {
+        switch ($type) {
+            case 'foo':
+                switch ($subType) {
+                    case 'bar':
+                        return 'foo-bar';
+                    default:
+                        return 'foo-other';
+                }
+            default:
+                return 'other';
+        }
+    }
+}

--- a/tests/Fixtures/Rules/NestedSwitchRule/SingleSwitch.php
+++ b/tests/Fixtures/Rules/NestedSwitchRule/SingleSwitch.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedSwitchRule;
+
+final class SingleSwitch
+{
+    public function run(string $type): string
+    {
+        switch ($type) {
+            case 'foo':
+                return 'foo';
+            default:
+                return 'other';
+        }
+    }
+}

--- a/tests/Fixtures/Rules/NestedSwitchRule/SuppressedClass.php
+++ b/tests/Fixtures/Rules/NestedSwitchRule/SuppressedClass.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedSwitchRule;
+
+final class SuppressedClass
+{
+    public function run(string $type, string $subType): string
+    {
+        switch ($type) {
+            case 'foo':
+                /** @phpstan-ignore haspadar.nestedSwitch */
+                switch ($subType) {
+                    case 'bar':
+                        return 'foo-bar';
+                    default:
+                        return 'foo-other';
+                }
+            default:
+                return 'other';
+        }
+    }
+}

--- a/tests/Fixtures/Rules/NestedSwitchRule/SwitchInClosure.php
+++ b/tests/Fixtures/Rules/NestedSwitchRule/SwitchInClosure.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\NestedSwitchRule;
+
+final class SwitchInClosure
+{
+    public function run(string $type): \Closure
+    {
+        switch ($type) {
+            case 'foo':
+                return static function (string $subType): string {
+                    switch ($subType) {
+                        case 'bar':
+                            return 'foo-bar';
+                        default:
+                            return 'foo-other';
+                    }
+                };
+            default:
+                return static fn(): string => 'other';
+        }
+    }
+}

--- a/tests/Unit/Rules/NestedSwitchRule/NestedSwitchRuleTest.php
+++ b/tests/Unit/Rules/NestedSwitchRule/NestedSwitchRuleTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\NestedSwitchRule;
+
+use Haspadar\PHPStanRules\Rules\NestedSwitchRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<NestedSwitchRule> */
+final class NestedSwitchRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new NestedSwitchRule();
+    }
+
+    #[Test]
+    public function reportsNestedSwitchStatement(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NestedSwitchRule/NestedSwitch.php'],
+            [
+                [
+                    'Nested switch statements are forbidden — extract the inner switch into a separate method.',
+                    13,
+                ],
+            ],
+        );
+    }
+
+    #[Test]
+    public function passesWhenSwitchIsNotNested(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NestedSwitchRule/SingleSwitch.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function passesWhenSwitchIsInsideClosure(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NestedSwitchRule/SwitchInClosure.php'],
+            [],
+        );
+    }
+
+    #[Test]
+    public function suppressesViolationWhenPhpstanIgnorePresent(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/NestedSwitchRule/SuppressedClass.php'],
+            [],
+        );
+    }
+}

--- a/tests/Unit/RulesTest.php
+++ b/tests/Unit/RulesTest.php
@@ -79,6 +79,7 @@ use Haspadar\PHPStanRules\Rules\SimplifyBooleanExpressionRule;
 use Haspadar\PHPStanRules\Rules\ExplicitInitializationRule;
 use Haspadar\PHPStanRules\Rules\ThrowsCountRule;
 use Haspadar\PHPStanRules\Rules\IfThenThrowElseRule;
+use Haspadar\PHPStanRules\Rules\NestedSwitchRule;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -163,6 +164,7 @@ final class RulesTest extends TestCase
                 ExplicitInitializationRule::class,
                 ThrowsCountRule::class,
                 IfThenThrowElseRule::class,
+                NestedSwitchRule::class,
             ],
             (new Rules())->all(),
             'Rules::all() must list every registered rule class',


### PR DESCRIPTION
## Summary

- Added `NestedSwitchVisitor` to track switch nesting depth during AST traversal
- Added `NestedSwitchRule` to report switch statements nested inside another switch
- Registered the rule in `Rules.php`, `rules.neon`, and `RulesTest`
- Covered all branches with fixtures and unit tests

Closes #190

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new PHPStan rule that detects and reports nested switch statements in PHP code, helping maintain code clarity.

* **Documentation**
  * Updated documentation to include the new nested switch detection rule.

* **Tests**
  * Added comprehensive test suite covering nested switch detection, valid single switches, suppression handling, and closures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->