### PR TITLE
Add onlyPublic Option to ProhibitStaticMethodsRule

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ includes:
 | `MutableExceptionRule`            | Exception classes must not have non-readonly properties                            |
 | `ReturnCountRule`                 | Method must not have more than 1 `return` statement (default: 1)                   |
 | `ProtectedMethodInFinalClassRule` | Final classes must not have `protected` methods                                    |
-| `ProhibitStaticMethodsRule`       | Classes must not declare `static` methods of any visibility                        |
+| `ProhibitStaticMethodsRule`       | Classes must not declare `static` methods, all visibility by default               |
 | `ProhibitStaticPropertiesRule`    | Classes must not declare `static` properties of any visibility                     |
 | `ConstructorInitializationRule`   | Constructor must only assign `$this->property` or call `parent::__construct()`     |
 | `BeImmutableRule`                | All non-static properties must be `readonly`                                       |
@@ -136,6 +136,8 @@ parameters:
             maxLines: 500
         tooManyMethods:
             maxMethods: 10
+            onlyPublic: true
+        prohibitStaticMethods:
             onlyPublic: true
         parameterNumber:
             maxParameters: 5

--- a/rules-ignore.neon
+++ b/rules-ignore.neon
@@ -23,6 +23,7 @@ parameters:
                 - src/Rules/NestedForDepthRule/DepthVisitor.php
                 - src/Rules/NestedTryDepthRule/DepthVisitor.php
                 - src/Rules/NestedSwitchRule/NestedSwitchVisitor.php
+                - src/Rules/ProhibitStaticMethodsRule.php
         -
             identifier: haspadar.nestedForDepth
             paths:

--- a/rules-ignore.neon
+++ b/rules-ignore.neon
@@ -23,7 +23,6 @@ parameters:
                 - src/Rules/NestedForDepthRule/DepthVisitor.php
                 - src/Rules/NestedTryDepthRule/DepthVisitor.php
                 - src/Rules/NestedSwitchRule/NestedSwitchVisitor.php
-                - src/Rules/ProhibitStaticMethodsRule.php
         -
             identifier: haspadar.nestedForDepth
             paths:

--- a/rules.neon
+++ b/rules.neon
@@ -184,6 +184,8 @@ parameters:
             maxDepth: 1
         throwsCount:
             maxThrows: 1
+        prohibitStaticMethods:
+            onlyPublic: false
     exceptions:
         check:
             missingCheckedExceptionInThrows: false
@@ -354,6 +356,9 @@ parametersSchema:
         throwsCount: structure([
             maxThrows: int(),
         ]),
+        prohibitStaticMethods: structure([
+            onlyPublic: bool(),
+        ]),
     ])
 
 services:
@@ -452,6 +457,9 @@ services:
             - phpstan.rules.rule
     -
         class: Haspadar\PHPStanRules\Rules\ProhibitStaticMethodsRule
+        arguments:
+            options:
+                onlyPublic: %haspadar.prohibitStaticMethods.onlyPublic%
         tags:
             - phpstan.rules.rule
     -

--- a/src/Rules/ProhibitStaticMethodsRule.php
+++ b/src/Rules/ProhibitStaticMethodsRule.php
@@ -24,7 +24,7 @@ use PHPStan\ShouldNotHappenException;
  *
  * @implements Rule<ClassMethod>
  */
-final class ProhibitStaticMethodsRule implements Rule
+final readonly class ProhibitStaticMethodsRule implements Rule
 {
     private bool $onlyPublic;
 

--- a/src/Rules/ProhibitStaticMethodsRule.php
+++ b/src/Rules/ProhibitStaticMethodsRule.php
@@ -14,15 +14,30 @@ use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\ShouldNotHappenException;
 
 /**
- * Detects static method declarations and reports an error for each one regardless of visibility.
+ * Detects static method declarations and reports an error for each one.
  * Static methods are not polymorphic, cannot work with object state, and create hard dependencies
  * that make code difficult to test. Private and protected static helpers are treated the same as
  * public ones because they still encode procedural logic that bypasses the object lifecycle.
  *
+ * When `onlyPublic` option is true, only public static methods are reported — mirroring Qulice's
+ * `ProhibitPublicStaticMethods` behaviour and allowing private/protected static helpers.
+ *
  * @implements Rule<ClassMethod>
  */
-final readonly class ProhibitStaticMethodsRule implements Rule
+final class ProhibitStaticMethodsRule implements Rule
 {
+    private bool $onlyPublic;
+
+    /**
+     * Constructs the rule with the given options.
+     *
+     * @param array{onlyPublic?: bool} $options When onlyPublic is true, only public static methods are reported
+     */
+    public function __construct(array $options = [])
+    {
+        $this->onlyPublic = $options['onlyPublic'] ?? false;
+    }
+
     #[Override]
     public function getNodeType(): string
     {
@@ -40,6 +55,10 @@ final readonly class ProhibitStaticMethodsRule implements Rule
     {
         /** @var ClassMethod $node */
         if (!$node->isStatic()) {
+            return [];
+        }
+
+        if ($this->onlyPublic && !$node->isPublic()) {
             return [];
         }
 

--- a/tests/Unit/Rules/ProhibitStaticMethodsRule/ProhibitStaticMethodsRuleOnlyPublicTest.php
+++ b/tests/Unit/Rules/ProhibitStaticMethodsRule/ProhibitStaticMethodsRuleOnlyPublicTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\ProhibitStaticMethodsRule;
+
+use Haspadar\PHPStanRules\Rules\ProhibitStaticMethodsRule;
+use Override;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<ProhibitStaticMethodsRule> */
+final class ProhibitStaticMethodsRuleOnlyPublicTest extends RuleTestCase
+{
+    #[Override]
+    protected function getRule(): Rule
+    {
+        return new ProhibitStaticMethodsRule(['onlyPublic' => true]);
+    }
+
+    #[Test]
+    public function reportsPublicStaticMethod(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ProhibitStaticMethodsRule/ClassWithPublicStaticMethod.php'],
+            [
+                [
+                    'Method Haspadar\PHPStanRules\Tests\Fixtures\Rules\ProhibitStaticMethodsRule\ClassWithPublicStaticMethod::create() is static. Static methods are prohibited.',
+                    9,
+                ],
+            ],
+            'Public static methods must still be reported when onlyPublic=true',
+        );
+    }
+
+    #[Test]
+    public function passesWhenPrivateStaticMethod(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ProhibitStaticMethodsRule/ClassWithPrivateStaticMethod.php'],
+            [],
+            'Private static methods must be allowed when onlyPublic=true',
+        );
+    }
+
+    #[Test]
+    public function passesWhenProtectedStaticMethod(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ProhibitStaticMethodsRule/ClassWithProtectedStaticMethod.php'],
+            [],
+            'Protected static methods must be allowed when onlyPublic=true',
+        );
+    }
+}

--- a/tests/Unit/Rules/ProhibitStaticMethodsRule/ProhibitStaticMethodsRuleOnlyPublicTest.php
+++ b/tests/Unit/Rules/ProhibitStaticMethodsRule/ProhibitStaticMethodsRuleOnlyPublicTest.php
@@ -30,7 +30,6 @@ final class ProhibitStaticMethodsRuleOnlyPublicTest extends RuleTestCase
                     9,
                 ],
             ],
-            'Public static methods must still be reported when onlyPublic=true',
         );
     }
 
@@ -40,7 +39,6 @@ final class ProhibitStaticMethodsRuleOnlyPublicTest extends RuleTestCase
         $this->analyse(
             [__DIR__ . '/../../../Fixtures/Rules/ProhibitStaticMethodsRule/ClassWithPrivateStaticMethod.php'],
             [],
-            'Private static methods must be allowed when onlyPublic=true',
         );
     }
 
@@ -50,7 +48,6 @@ final class ProhibitStaticMethodsRuleOnlyPublicTest extends RuleTestCase
         $this->analyse(
             [__DIR__ . '/../../../Fixtures/Rules/ProhibitStaticMethodsRule/ClassWithProtectedStaticMethod.php'],
             [],
-            'Protected static methods must be allowed when onlyPublic=true',
         );
     }
 }


### PR DESCRIPTION
## Summary

- Added `onlyPublic` option to `ProhibitStaticMethodsRule` via `array $options` constructor parameter
- Registered parameter, schema, and service argument in `rules.neon`
- Suppressed `haspadar.immutable` for mutable `$onlyPublic` property in `rules-ignore.neon`
- Added `ProhibitStaticMethodsRuleOnlyPublicTest` covering public/private/protected behaviour

Closes #192

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `onlyPublic` configuration option to restrict static method violation reports to public methods only (default: disabled).

* **Tests**
  * Added test coverage for the new configuration option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->