### PR TITLE
PHPDoc Long Type Alias Rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ includes:
 | `ProtectedMethodInFinalClassRule` | Final classes must not have `protected` methods                                    |
 | `ProhibitStaticMethodsRule`       | Classes must not declare `static` methods, all visibility by default               |
 | `ProhibitStaticPropertiesRule`    | Classes must not declare `static` properties of any visibility                     |
+| `ProhibitLongTypeAliasRule`       | PHPDoc must not use long type aliases: `integer`, `boolean`, `double`, `real`      |
 | `ConstructorInitializationRule`   | Constructor must only assign `$this->property` or call `parent::__construct()`     |
 | `BeImmutableRule`                | All non-static properties must be `readonly`                                       |
 | `KeepInterfacesShortRule`        | Interfaces must not declare too many methods (default: 10)                         |
@@ -139,6 +140,9 @@ parameters:
             onlyPublic: true
         prohibitStaticMethods:
             onlyPublic: true
+        prohibitLongTypeAlias:
+            allowedAliases:
+                - Integer  # user-defined class that conflicts with the built-in alias
         parameterNumber:
             maxParameters: 5
             ignoreOverridden: false

--- a/rules.neon
+++ b/rules.neon
@@ -186,6 +186,8 @@ parameters:
             maxThrows: 1
         prohibitStaticMethods:
             onlyPublic: false
+        prohibitLongTypeAlias:
+            allowedAliases: []
     exceptions:
         check:
             missingCheckedExceptionInThrows: false
@@ -359,6 +361,9 @@ parametersSchema:
         prohibitStaticMethods: structure([
             onlyPublic: bool(),
         ]),
+        prohibitLongTypeAlias: structure([
+            allowedAliases: listOf(string()),
+        ]),
     ])
 
 services:
@@ -464,6 +469,12 @@ services:
             - phpstan.rules.rule
     -
         class: Haspadar\PHPStanRules\Rules\ProhibitStaticPropertiesRule
+        tags:
+            - phpstan.rules.rule
+    -
+        class: Haspadar\PHPStanRules\Rules\ProhibitLongTypeAliasRule
+        arguments:
+            allowedAliases: %haspadar.prohibitLongTypeAlias.allowedAliases%
         tags:
             - phpstan.rules.rule
     -

--- a/src/Rules.php
+++ b/src/Rules.php
@@ -26,6 +26,7 @@ final class Rules
         Rules\ProtectedMethodInFinalClassRule::class,
         Rules\ProhibitStaticMethodsRule::class,
         Rules\ProhibitStaticPropertiesRule::class,
+        Rules\ProhibitLongTypeAliasRule::class,
         Rules\ConstructorInitializationRule::class,
         Rules\NoParameterReassignmentRule::class,
         Rules\IllegalCatchRule::class,

--- a/src/Rules/PhpDocDescriptionChecker.php
+++ b/src/Rules/PhpDocDescriptionChecker.php
@@ -14,10 +14,10 @@ use PHPStan\PhpDocParser\ParserConfig;
 use PHPStan\ShouldNotHappenException;
 
 /**
- * Parses PHPDoc blocks and checks whether tag descriptions start with a capital letter.
- * Shared by ReturnDescriptionCapitalRule and ParamDescriptionCapitalRule.
- * Uses PHPStan PhpDocParser to correctly handle generic types with spaces
- * (e.g. array<int, string>).
+ * Parses PHPDoc blocks into AST nodes and provides tag inspection helpers.
+ * Shared by ReturnDescriptionCapitalRule, ParamDescriptionCapitalRule, PhpDocMissingParamRule,
+ * PhpDocParamOrderRule, PhpDocParamDescriptionRule, and ProhibitLongTypeAliasRule.
+ * Uses PHPStan PhpDocParser to correctly handle generic types with spaces (e.g. array<int, string>).
  */
 final readonly class PhpDocDescriptionChecker
 {

--- a/src/Rules/PhpDocDescriptionChecker.php
+++ b/src/Rules/PhpDocDescriptionChecker.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Haspadar\PHPStanRules\Rules;
 
+use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocNode;
 use PHPStan\PhpDocParser\Lexer\Lexer;
 use PHPStan\PhpDocParser\Parser\ConstExprParser;
 use PHPStan\PhpDocParser\Parser\PhpDocParser;
@@ -36,6 +37,19 @@ final readonly class PhpDocDescriptionChecker
         $typeParser = new TypeParser($config, $constExprParser);
         $this->lexer = new Lexer($config);
         $this->phpDocParser = new PhpDocParser($config, $typeParser, $constExprParser);
+    }
+
+    /**
+     * Parses a raw PHPDoc block text and returns the AST node.
+     *
+     * @param string $docText Raw PHPDoc block text with the opening and closing delimiters.
+     * @throws ShouldNotHappenException
+     */
+    public function parse(string $docText): PhpDocNode
+    {
+        $tokens = new TokenIterator($this->lexer->tokenize($docText));
+
+        return $this->phpDocParser->parse($tokens);
     }
 
     /**

--- a/src/Rules/ProhibitLongTypeAliasRule.php
+++ b/src/Rules/ProhibitLongTypeAliasRule.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Rules;
+
+use Override;
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Analyser\Scope;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\IntersectionTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\NullableTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
+use PHPStan\PhpDocParser\Ast\Type\UnionTypeNode;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\ShouldNotHappenException;
+
+/**
+ * Checks that PHPDoc tags do not use long built-in type aliases.
+ * Disallows `integer`, `boolean`, `double`, and `real` in favour of their canonical short forms
+ * (`int`, `bool`, `float`). Aliases listed in `allowedAliases` are excluded from the check,
+ * which allows projects that define user classes named `Integer` or `Boolean` to opt out
+ * for those specific names. Types nested inside union and intersection types are checked recursively.
+ *
+ * @implements Rule<ClassMethod>
+ */
+final readonly class ProhibitLongTypeAliasRule implements Rule
+{
+    private const array ALIAS_MAP = [
+        'integer' => 'int',
+        'boolean' => 'bool',
+        'double' => 'float',
+        'real' => 'float',
+    ];
+
+    private PhpDocDescriptionChecker $checker;
+
+    /**
+     * Constructs the rule with an optional list of allowed alias names.
+     *
+     * @param list<string> $allowedAliases Type names to exclude from the check (e.g. ['Integer']).
+     * @throws ShouldNotHappenException
+     */
+    public function __construct(private array $allowedAliases = [])
+    {
+        $this->checker = new PhpDocDescriptionChecker();
+    }
+
+    #[Override]
+    public function getNodeType(): string
+    {
+        return ClassMethod::class;
+    }
+
+    /**
+     * Analyses the method PHPDoc for long type aliases and returns one error per occurrence.
+     *
+     * @psalm-param ClassMethod $node
+     * @throws ShouldNotHappenException
+     * @return list<IdentifierRuleError>
+     */
+    #[Override]
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $docComment = $node->getDocComment();
+
+        if ($scope->getClassReflection() === null || $docComment === null) {
+            return [];
+        }
+
+        $phpDocNode = $this->checker->parse($docComment->getText());
+        $errors = [];
+
+        foreach ($phpDocNode->getTags() as $tag) {
+            $type = $this->extractType($tag->value);
+
+            if ($type === null) {
+                continue;
+            }
+
+            foreach ($this->collectAliases($type) as $alias) {
+                $errors[] = RuleErrorBuilder::message(
+                    sprintf(
+                        'PHPDoc contains long type alias "%s", use "%s" instead.',
+                        $alias,
+                        self::ALIAS_MAP[strtolower($alias)],
+                    ),
+                )
+                    ->identifier('haspadar.prohibitLongTypeAlias')
+                    ->build();
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * Extracts the TypeNode from a tag value node that carries a `type` property, or null otherwise.
+     *
+     * @param object $tagValue Tag value node from the parsed PHPDoc.
+     */
+    private function extractType(object $tagValue): ?TypeNode
+    {
+        if (property_exists($tagValue, 'type') && $tagValue->type instanceof TypeNode) {
+            return $tagValue->type;
+        }
+
+        return null;
+    }
+
+    /**
+     * Recursively collects long alias names found anywhere inside the type tree.
+     *
+     * @return list<string>
+     */
+    private function collectAliases(TypeNode $type): array
+    {
+        if ($type instanceof IdentifierTypeNode) {
+            $lower = strtolower($type->name);
+
+            if (array_key_exists($lower, self::ALIAS_MAP) && !in_array($type->name, $this->allowedAliases, true)) {
+                return [$type->name];
+            }
+
+            return [];
+        }
+
+        if ($type instanceof UnionTypeNode || $type instanceof IntersectionTypeNode) {
+            $found = [];
+
+            foreach ($type->types as $child) {
+                foreach ($this->collectAliases($child) as $alias) {
+                    $found[] = $alias;
+                }
+            }
+
+            return $found;
+        }
+
+        if ($type instanceof NullableTypeNode) {
+            return $this->collectAliases($type->type);
+        }
+
+        return [];
+    }
+}

--- a/src/Rules/ProhibitLongTypeAliasRule.php
+++ b/src/Rules/ProhibitLongTypeAliasRule.php
@@ -7,6 +7,7 @@ namespace Haspadar\PHPStanRules\Rules;
 use Override;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Property;
 use PHPStan\Analyser\Scope;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\IntersectionTypeNode;
@@ -21,11 +22,12 @@ use PHPStan\ShouldNotHappenException;
 /**
  * Checks that PHPDoc tags do not use long built-in type aliases.
  * Disallows `integer`, `boolean`, `double`, and `real` in favour of their canonical short forms
- * (`int`, `bool`, `float`). Aliases listed in `allowedAliases` are excluded from the check,
- * which allows projects that define user classes named `Integer` or `Boolean` to opt out
- * for those specific names. Types nested inside union and intersection types are checked recursively.
+ * (`int`, `bool`, `float`). Covers @param, @return, @throws in methods and @var on properties.
+ * Aliases listed in `allowedAliases` are excluded from the check, which allows projects that
+ * define user classes named `Integer` or `Boolean` to opt out for those specific names.
+ * Types nested inside union and intersection types are checked recursively.
  *
- * @implements Rule<ClassMethod>
+ * @implements Rule<Node>
  */
 final readonly class ProhibitLongTypeAliasRule implements Rule
 {
@@ -52,19 +54,22 @@ final readonly class ProhibitLongTypeAliasRule implements Rule
     #[Override]
     public function getNodeType(): string
     {
-        return ClassMethod::class;
+        return Node::class;
     }
 
     /**
-     * Analyses the method PHPDoc for long type aliases and returns one error per occurrence.
+     * Analyses the PHPDoc of a class method or property for long type aliases.
      *
-     * @psalm-param ClassMethod $node
      * @throws ShouldNotHappenException
      * @return list<IdentifierRuleError>
      */
     #[Override]
     public function processNode(Node $node, Scope $scope): array
     {
+        if (!$node instanceof ClassMethod && !$node instanceof Property) {
+            return [];
+        }
+
         $docComment = $node->getDocComment();
 
         if ($scope->getClassReflection() === null || $docComment === null) {

--- a/tests/Fixtures/Rules/ProhibitLongTypeAliasRule/ClassWithAllowedAlias.php
+++ b/tests/Fixtures/Rules/ProhibitLongTypeAliasRule/ClassWithAllowedAlias.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ProhibitLongTypeAliasRule;
+
+final class ClassWithAllowedAlias
+{
+    /**
+     * Wraps a value.
+     *
+     * @param Integer $n User-defined class.
+     * @return Integer Result.
+     */
+    public function wrap(object $n): object
+    {
+        return $n;
+    }
+}

--- a/tests/Fixtures/Rules/ProhibitLongTypeAliasRule/ClassWithDoubleAndReal.php
+++ b/tests/Fixtures/Rules/ProhibitLongTypeAliasRule/ClassWithDoubleAndReal.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ProhibitLongTypeAliasRule;
+
+final class ClassWithDoubleAndReal
+{
+    /**
+     * Computes ratio.
+     *
+     * @param double $a First.
+     * @param real $b Second.
+     * @return float Result.
+     */
+    public function ratio(float $a, float $b): float
+    {
+        return $a / $b;
+    }
+}

--- a/tests/Fixtures/Rules/ProhibitLongTypeAliasRule/ClassWithIntersectionLongType.php
+++ b/tests/Fixtures/Rules/ProhibitLongTypeAliasRule/ClassWithIntersectionLongType.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ProhibitLongTypeAliasRule;
+
+final class ClassWithIntersectionLongType
+{
+    /**
+     * Merges two values.
+     *
+     * @param integer $a First.
+     * @param integer $b Second.
+     * @return int Result.
+     */
+    public function merge(int $a, int $b): int
+    {
+        return $a + $b;
+    }
+}

--- a/tests/Fixtures/Rules/ProhibitLongTypeAliasRule/ClassWithLongTypeInParam.php
+++ b/tests/Fixtures/Rules/ProhibitLongTypeAliasRule/ClassWithLongTypeInParam.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ProhibitLongTypeAliasRule;
+
+final class ClassWithLongTypeInParam
+{
+    /**
+     * Adds a number.
+     *
+     * @param integer $n Value.
+     * @return int Result.
+     */
+    public function add(int $n): int
+    {
+        return $n + 1;
+    }
+}

--- a/tests/Fixtures/Rules/ProhibitLongTypeAliasRule/ClassWithLongTypeInReturn.php
+++ b/tests/Fixtures/Rules/ProhibitLongTypeAliasRule/ClassWithLongTypeInReturn.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ProhibitLongTypeAliasRule;
+
+final class ClassWithLongTypeInReturn
+{
+    /**
+     * Checks a flag.
+     *
+     * @return boolean Result.
+     */
+    public function check(): bool
+    {
+        return true;
+    }
+}

--- a/tests/Fixtures/Rules/ProhibitLongTypeAliasRule/ClassWithLongTypeInThrows.php
+++ b/tests/Fixtures/Rules/ProhibitLongTypeAliasRule/ClassWithLongTypeInThrows.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ProhibitLongTypeAliasRule;
+
+final class ClassWithLongTypeInThrows
+{
+    /**
+     * Divides two numbers.
+     *
+     * @param int $a Dividend.
+     * @param int $b Divisor.
+     * @return float Result.
+     * @throws integer When division fails.
+     */
+    public function divide(int $a, int $b): float
+    {
+        return $a / $b;
+    }
+}

--- a/tests/Fixtures/Rules/ProhibitLongTypeAliasRule/ClassWithLongTypeInVar.php
+++ b/tests/Fixtures/Rules/ProhibitLongTypeAliasRule/ClassWithLongTypeInVar.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ProhibitLongTypeAliasRule;
+
+final class ClassWithLongTypeInVar
+{
+    /** @var integer */
+    private int $value = 0;
+
+    /**
+     * Returns the value.
+     *
+     * @return int Value.
+     */
+    public function value(): int
+    {
+        return $this->value;
+    }
+}

--- a/tests/Fixtures/Rules/ProhibitLongTypeAliasRule/ClassWithMultipleLongTypeParams.php
+++ b/tests/Fixtures/Rules/ProhibitLongTypeAliasRule/ClassWithMultipleLongTypeParams.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ProhibitLongTypeAliasRule;
 
-final class ClassWithIntersectionLongType
+final class ClassWithMultipleLongTypeParams
 {
     /**
      * Merges two values.

--- a/tests/Fixtures/Rules/ProhibitLongTypeAliasRule/ClassWithNoDocComment.php
+++ b/tests/Fixtures/Rules/ProhibitLongTypeAliasRule/ClassWithNoDocComment.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ProhibitLongTypeAliasRule;
+
+final class ClassWithNoDocComment
+{
+    public function add(int $n): int
+    {
+        return $n + 1;
+    }
+}

--- a/tests/Fixtures/Rules/ProhibitLongTypeAliasRule/ClassWithShortTypes.php
+++ b/tests/Fixtures/Rules/ProhibitLongTypeAliasRule/ClassWithShortTypes.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ProhibitLongTypeAliasRule;
+
+final class ClassWithShortTypes
+{
+    /**
+     * Adds a number.
+     *
+     * @param int $n Value.
+     * @return bool Result.
+     */
+    public function check(int $n): bool
+    {
+        return $n > 0;
+    }
+}

--- a/tests/Fixtures/Rules/ProhibitLongTypeAliasRule/ClassWithUnionLongType.php
+++ b/tests/Fixtures/Rules/ProhibitLongTypeAliasRule/ClassWithUnionLongType.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ProhibitLongTypeAliasRule;
+
+final class ClassWithUnionLongType
+{
+    /**
+     * Formats a value.
+     *
+     * @param integer|string $value Input.
+     * @return string Result.
+     */
+    public function format(int|string $value): string
+    {
+        return (string) $value;
+    }
+}

--- a/tests/Fixtures/Rules/ProhibitLongTypeAliasRule/ClassWithUppercaseAlias.php
+++ b/tests/Fixtures/Rules/ProhibitLongTypeAliasRule/ClassWithUppercaseAlias.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ProhibitLongTypeAliasRule;
+
+final class ClassWithUppercaseAlias
+{
+    /**
+     * Checks a value.
+     *
+     * @param INTEGER $n Value.
+     * @return int Result.
+     */
+    public function check(int $n): int
+    {
+        return $n;
+    }
+}

--- a/tests/Fixtures/Rules/ProhibitLongTypeAliasRule/SuppressedLongTypeAlias.php
+++ b/tests/Fixtures/Rules/ProhibitLongTypeAliasRule/SuppressedLongTypeAlias.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ProhibitLongTypeAliasRule;
+
+final class SuppressedLongTypeAlias
+{
+    /**
+     * Adds a number.
+     *
+     * @param integer $n Value.
+     * @return int Result.
+     * @phpstan-ignore haspadar.prohibitLongTypeAlias
+     */
+    public function add(int $n): int
+    {
+        return $n + 1;
+    }
+}

--- a/tests/Unit/Rules/ProhibitLongTypeAliasRule/ProhibitLongTypeAliasRuleAllowedAliasTest.php
+++ b/tests/Unit/Rules/ProhibitLongTypeAliasRule/ProhibitLongTypeAliasRuleAllowedAliasTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\ProhibitLongTypeAliasRule;
+
+use Haspadar\PHPStanRules\Rules\ProhibitLongTypeAliasRule;
+use Override;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<ProhibitLongTypeAliasRule> */
+final class ProhibitLongTypeAliasRuleAllowedAliasTest extends RuleTestCase
+{
+    #[Override]
+    protected function getRule(): Rule
+    {
+        return new ProhibitLongTypeAliasRule(['Integer']);
+    }
+
+    #[Test]
+    public function passesWhenAliasIsAllowed(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ProhibitLongTypeAliasRule/ClassWithAllowedAlias.php'],
+            [],
+            '"Integer" listed in allowedAliases must not produce an error',
+        );
+    }
+
+    #[Test]
+    public function stillReportsOtherAliasesWhenOneIsAllowed(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ProhibitLongTypeAliasRule/ClassWithLongTypeInReturn.php'],
+            [
+                ['PHPDoc contains long type alias "boolean", use "bool" instead.', 14],
+            ],
+            'Allowing "Integer" must not suppress errors for "boolean"',
+        );
+    }
+}

--- a/tests/Unit/Rules/ProhibitLongTypeAliasRule/ProhibitLongTypeAliasRuleTest.php
+++ b/tests/Unit/Rules/ProhibitLongTypeAliasRule/ProhibitLongTypeAliasRuleTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\ProhibitLongTypeAliasRule;
+
+use Haspadar\PHPStanRules\Rules\ProhibitLongTypeAliasRule;
+use Override;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<ProhibitLongTypeAliasRule> */
+final class ProhibitLongTypeAliasRuleTest extends RuleTestCase
+{
+    #[Override]
+    protected function getRule(): Rule
+    {
+        return new ProhibitLongTypeAliasRule();
+    }
+
+    #[Test]
+    public function reportsIntegerAlias(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ProhibitLongTypeAliasRule/ClassWithLongTypeInParam.php'],
+            [
+                ['PHPDoc contains long type alias "integer", use "int" instead.', 15],
+            ],
+            '"integer" in @param must produce an error',
+        );
+    }
+
+    #[Test]
+    public function reportsBooleanAlias(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ProhibitLongTypeAliasRule/ClassWithLongTypeInReturn.php'],
+            [
+                ['PHPDoc contains long type alias "boolean", use "bool" instead.', 14],
+            ],
+            '"boolean" in @return must produce an error',
+        );
+    }
+
+    #[Test]
+    public function reportsDoubleAndRealAliases(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ProhibitLongTypeAliasRule/ClassWithDoubleAndReal.php'],
+            [
+                ['PHPDoc contains long type alias "double", use "float" instead.', 16],
+                ['PHPDoc contains long type alias "real", use "float" instead.', 16],
+            ],
+            '"double" and "real" in @param must each produce an error',
+        );
+    }
+
+    #[Test]
+    public function reportsAliasInsideUnionType(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ProhibitLongTypeAliasRule/ClassWithUnionLongType.php'],
+            [
+                ['PHPDoc contains long type alias "integer", use "int" instead.', 15],
+            ],
+            '"integer" nested in a union type must produce an error',
+        );
+    }
+
+    #[Test]
+    public function passesWhenOnlyShortTypesUsed(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ProhibitLongTypeAliasRule/ClassWithShortTypes.php'],
+            [],
+            'Short type forms must not produce any errors',
+        );
+    }
+
+    #[Test]
+    public function passesWhenErrorIsSuppressed(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ProhibitLongTypeAliasRule/SuppressedLongTypeAlias.php'],
+            [],
+            '@phpstan-ignore haspadar.prohibitLongTypeAlias must silence the error',
+        );
+    }
+
+    #[Test]
+    public function passesWhenMethodHasNoDocComment(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ProhibitLongTypeAliasRule/ClassWithNoDocComment.php'],
+            [],
+            'A method without a PHPDoc block must not produce any errors',
+        );
+    }
+
+    #[Test]
+    public function reportsMultipleAliasesInSameMethod(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ProhibitLongTypeAliasRule/ClassWithIntersectionLongType.php'],
+            [
+                ['PHPDoc contains long type alias "integer", use "int" instead.', 16],
+                ['PHPDoc contains long type alias "integer", use "int" instead.', 16],
+            ],
+            'Two @param tags with "integer" must each produce a separate error',
+        );
+    }
+
+    #[Test]
+    public function reportsUppercaseAlias(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ProhibitLongTypeAliasRule/ClassWithUppercaseAlias.php'],
+            [
+                ['PHPDoc contains long type alias "INTEGER", use "int" instead.', 15],
+            ],
+            '"INTEGER" in uppercase must be reported with the correct short form',
+        );
+    }
+}

--- a/tests/Unit/Rules/ProhibitLongTypeAliasRule/ProhibitLongTypeAliasRuleTest.php
+++ b/tests/Unit/Rules/ProhibitLongTypeAliasRule/ProhibitLongTypeAliasRuleTest.php
@@ -20,7 +20,7 @@ final class ProhibitLongTypeAliasRuleTest extends RuleTestCase
     }
 
     #[Test]
-    public function reportsIntegerAlias(): void
+    public function reportsErrorWhenIntegerUsedInParam(): void
     {
         $this->analyse(
             [__DIR__ . '/../../../Fixtures/Rules/ProhibitLongTypeAliasRule/ClassWithLongTypeInParam.php'],
@@ -32,7 +32,7 @@ final class ProhibitLongTypeAliasRuleTest extends RuleTestCase
     }
 
     #[Test]
-    public function reportsBooleanAlias(): void
+    public function reportsErrorWhenBooleanUsedInReturn(): void
     {
         $this->analyse(
             [__DIR__ . '/../../../Fixtures/Rules/ProhibitLongTypeAliasRule/ClassWithLongTypeInReturn.php'],
@@ -44,7 +44,7 @@ final class ProhibitLongTypeAliasRuleTest extends RuleTestCase
     }
 
     #[Test]
-    public function reportsDoubleAndRealAliases(): void
+    public function reportsErrorWhenDoubleAndRealUsed(): void
     {
         $this->analyse(
             [__DIR__ . '/../../../Fixtures/Rules/ProhibitLongTypeAliasRule/ClassWithDoubleAndReal.php'],
@@ -57,7 +57,7 @@ final class ProhibitLongTypeAliasRuleTest extends RuleTestCase
     }
 
     #[Test]
-    public function reportsAliasInsideUnionType(): void
+    public function reportsErrorWhenAliasInsideUnionType(): void
     {
         $this->analyse(
             [__DIR__ . '/../../../Fixtures/Rules/ProhibitLongTypeAliasRule/ClassWithUnionLongType.php'],
@@ -65,6 +65,30 @@ final class ProhibitLongTypeAliasRuleTest extends RuleTestCase
                 ['PHPDoc contains long type alias "integer", use "int" instead.', 15],
             ],
             '"integer" nested in a union type must produce an error',
+        );
+    }
+
+    #[Test]
+    public function reportsErrorWhenIntegerUsedInThrows(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ProhibitLongTypeAliasRule/ClassWithLongTypeInThrows.php'],
+            [
+                ['PHPDoc contains long type alias "integer", use "int" instead.', 17],
+            ],
+            '"integer" in @throws must produce an error',
+        );
+    }
+
+    #[Test]
+    public function reportsErrorWhenIntegerUsedInVar(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ProhibitLongTypeAliasRule/ClassWithLongTypeInVar.php'],
+            [
+                ['PHPDoc contains long type alias "integer", use "int" instead.', 10],
+            ],
+            '"integer" in @var on a property must produce an error',
         );
     }
 
@@ -99,10 +123,10 @@ final class ProhibitLongTypeAliasRuleTest extends RuleTestCase
     }
 
     #[Test]
-    public function reportsMultipleAliasesInSameMethod(): void
+    public function reportsErrorWhenMultipleAliasesInSameMethod(): void
     {
         $this->analyse(
-            [__DIR__ . '/../../../Fixtures/Rules/ProhibitLongTypeAliasRule/ClassWithIntersectionLongType.php'],
+            [__DIR__ . '/../../../Fixtures/Rules/ProhibitLongTypeAliasRule/ClassWithMultipleLongTypeParams.php'],
             [
                 ['PHPDoc contains long type alias "integer", use "int" instead.', 16],
                 ['PHPDoc contains long type alias "integer", use "int" instead.', 16],
@@ -112,7 +136,7 @@ final class ProhibitLongTypeAliasRuleTest extends RuleTestCase
     }
 
     #[Test]
-    public function reportsUppercaseAlias(): void
+    public function reportsErrorWhenUppercaseAliasUsed(): void
     {
         $this->analyse(
             [__DIR__ . '/../../../Fixtures/Rules/ProhibitLongTypeAliasRule/ClassWithUppercaseAlias.php'],

--- a/tests/Unit/RulesTest.php
+++ b/tests/Unit/RulesTest.php
@@ -43,6 +43,7 @@ use Haspadar\PHPStanRules\Rules\NoLineCommentBeforeDeclarationRule;
 use Haspadar\PHPStanRules\Rules\NoPhpDocForOverriddenRule;
 use Haspadar\PHPStanRules\Rules\ParamDescriptionCapitalRule;
 use Haspadar\PHPStanRules\Rules\ReturnDescriptionCapitalRule;
+use Haspadar\PHPStanRules\Rules\ProhibitLongTypeAliasRule;
 use Haspadar\PHPStanRules\Rules\ProhibitStaticMethodsRule;
 use Haspadar\PHPStanRules\Rules\ProhibitStaticPropertiesRule;
 use Haspadar\PHPStanRules\Rules\ReturnCountRule;
@@ -106,6 +107,7 @@ final class RulesTest extends TestCase
                 ProtectedMethodInFinalClassRule::class,
                 ProhibitStaticMethodsRule::class,
                 ProhibitStaticPropertiesRule::class,
+                ProhibitLongTypeAliasRule::class,
                 ConstructorInitializationRule::class,
                 NoParameterReassignmentRule::class,
                 IllegalCatchRule::class,


### PR DESCRIPTION
- Added ProhibitLongTypeAliasRule disallowing integer, boolean, double, real in PHPDoc
- Added allowedAliases config option for user-defined classes sharing names with built-in aliases
- Added coverage for @param, @return, @throws in methods and @var on properties
- Updated PhpDocDescriptionChecker with a public parse() method reused by the new rule

Closes #196