### PR TITLE
PascalCase Detection Instead of Allowlist for Long Type Aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ includes:
 | `ProtectedMethodInFinalClassRule` | Final classes must not have `protected` methods                                    |
 | `ProhibitStaticMethodsRule`       | Classes must not declare `static` methods, all visibility by default               |
 | `ProhibitStaticPropertiesRule`    | Classes must not declare `static` properties of any visibility                     |
-| `ProhibitLongTypeAliasRule`       | PHPDoc must not use long type aliases: `integer`, `boolean`, `double`, `real`      |
+| `ProhibitLongTypeAliasRule`       | PHPDoc must not use long type aliases (`integer`, `boolean`, `double`, `real`) or non-PascalCase variants (`INTEGER`) |
 | `ConstructorInitializationRule`   | Constructor must only assign `$this->property` or call `parent::__construct()`     |
 | `BeImmutableRule`                | All non-static properties must be `readonly`                                       |
 | `KeepInterfacesShortRule`        | Interfaces must not declare too many methods (default: 10)                         |
@@ -140,9 +140,6 @@ parameters:
             onlyPublic: true
         prohibitStaticMethods:
             onlyPublic: true
-        prohibitLongTypeAlias:
-            allowedAliases:
-                - Integer  # user-defined class that conflicts with the built-in alias
         parameterNumber:
             maxParameters: 5
             ignoreOverridden: false

--- a/rules.neon
+++ b/rules.neon
@@ -186,8 +186,6 @@ parameters:
             maxThrows: 1
         prohibitStaticMethods:
             onlyPublic: false
-        prohibitLongTypeAlias:
-            allowedAliases: []
     exceptions:
         check:
             missingCheckedExceptionInThrows: false
@@ -361,9 +359,6 @@ parametersSchema:
         prohibitStaticMethods: structure([
             onlyPublic: bool(),
         ]),
-        prohibitLongTypeAlias: structure([
-            allowedAliases: listOf(string()),
-        ]),
     ])
 
 services:
@@ -473,8 +468,6 @@ services:
             - phpstan.rules.rule
     -
         class: Haspadar\PHPStanRules\Rules\ProhibitLongTypeAliasRule
-        arguments:
-            allowedAliases: %haspadar.prohibitLongTypeAlias.allowedAliases%
         tags:
             - phpstan.rules.rule
     -

--- a/src/Rules/ProhibitLongTypeAliasRule.php
+++ b/src/Rules/ProhibitLongTypeAliasRule.php
@@ -21,10 +21,10 @@ use PHPStan\ShouldNotHappenException;
 
 /**
  * Checks that PHPDoc tags do not use long built-in type aliases.
- * Disallows `integer`, `boolean`, `double`, and `real` in favour of their canonical short forms
- * (`int`, `bool`, `float`). Covers @param, @return, @throws in methods and @var on properties.
- * Aliases listed in `allowedAliases` are excluded from the check, which allows projects that
- * define user classes named `Integer` or `Boolean` to opt out for those specific names.
+ * Disallows `integer`, `boolean`, `double`, and `real` (and any non-PascalCase variant such as
+ * `INTEGER`) in favour of their canonical short forms (`int`, `bool`, `float`).
+ * PascalCase names like `Integer` or `Boolean` are treated as user-defined classes and allowed.
+ * Covers @param, @return, @throws in methods and @var on properties.
  * Types nested inside union and intersection types are checked recursively.
  *
  * @implements Rule<Node>
@@ -41,12 +41,11 @@ final readonly class ProhibitLongTypeAliasRule implements Rule
     private PhpDocDescriptionChecker $checker;
 
     /**
-     * Constructs the rule with an optional list of allowed alias names.
+     * Constructs the rule and initialises the shared PHPDoc parser.
      *
-     * @param list<string> $allowedAliases Type names to exclude from the check (e.g. ['Integer']).
      * @throws ShouldNotHappenException
      */
-    public function __construct(private array $allowedAliases = [])
+    public function __construct()
     {
         $this->checker = new PhpDocDescriptionChecker();
     }
@@ -126,7 +125,7 @@ final readonly class ProhibitLongTypeAliasRule implements Rule
         if ($type instanceof IdentifierTypeNode) {
             $lower = strtolower($type->name);
 
-            if (array_key_exists($lower, self::ALIAS_MAP) && !in_array($type->name, $this->allowedAliases, true)) {
+            if (array_key_exists($lower, self::ALIAS_MAP) && $type->name !== ucfirst($lower)) {
                 return [$type->name];
             }
 

--- a/tests/Unit/Rules/ProhibitLongTypeAliasRule/ProhibitLongTypeAliasRuleAllowedAliasTest.php
+++ b/tests/Unit/Rules/ProhibitLongTypeAliasRule/ProhibitLongTypeAliasRuleAllowedAliasTest.php
@@ -16,28 +16,28 @@ final class ProhibitLongTypeAliasRuleAllowedAliasTest extends RuleTestCase
     #[Override]
     protected function getRule(): Rule
     {
-        return new ProhibitLongTypeAliasRule(['Integer']);
+        return new ProhibitLongTypeAliasRule();
     }
 
     #[Test]
-    public function passesWhenAliasIsAllowed(): void
+    public function passesWhenPascalCaseClassUsed(): void
     {
         $this->analyse(
             [__DIR__ . '/../../../Fixtures/Rules/ProhibitLongTypeAliasRule/ClassWithAllowedAlias.php'],
             [],
-            '"Integer" listed in allowedAliases must not produce an error',
+            '"Integer" in PascalCase must be treated as a user-defined class and allowed',
         );
     }
 
     #[Test]
-    public function stillReportsOtherAliasesWhenOneIsAllowed(): void
+    public function reportsErrorWhenUppercaseAliasUsed(): void
     {
         $this->analyse(
-            [__DIR__ . '/../../../Fixtures/Rules/ProhibitLongTypeAliasRule/ClassWithLongTypeInReturn.php'],
+            [__DIR__ . '/../../../Fixtures/Rules/ProhibitLongTypeAliasRule/ClassWithUppercaseAlias.php'],
             [
-                ['PHPDoc contains long type alias "boolean", use "bool" instead.', 14],
+                ['PHPDoc contains long type alias "INTEGER", use "int" instead.', 15],
             ],
-            'Allowing "Integer" must not suppress errors for "boolean"',
+            '"INTEGER" must be reported as a long alias despite uppercase spelling',
         );
     }
 }

--- a/tests/Unit/Rules/ProhibitLongTypeAliasRule/ProhibitLongTypeAliasRuleTest.php
+++ b/tests/Unit/Rules/ProhibitLongTypeAliasRule/ProhibitLongTypeAliasRuleTest.php
@@ -135,15 +135,4 @@ final class ProhibitLongTypeAliasRuleTest extends RuleTestCase
         );
     }
 
-    #[Test]
-    public function reportsErrorWhenUppercaseAliasUsed(): void
-    {
-        $this->analyse(
-            [__DIR__ . '/../../../Fixtures/Rules/ProhibitLongTypeAliasRule/ClassWithUppercaseAlias.php'],
-            [
-                ['PHPDoc contains long type alias "INTEGER", use "int" instead.', 15],
-            ],
-            '"INTEGER" in uppercase must be reported with the correct short form',
-        );
-    }
 }


### PR DESCRIPTION
- Removed allowedAliases config option in favour of automatic PascalCase detection
- Refactored alias check to allow Integer/Boolean as user-defined classes without configuration
- Updated tests to cover PascalCase pass-through and uppercase rejection
- Removed allowedAliases from README and rules.neon

Closes #196

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated `ProhibitLongTypeAliasRule` documentation to reflect detection of all long type aliases including non-PascalCase variants.

* **Changes**
  * Removed `allowedAliases` configuration option from `ProhibitLongTypeAliasRule`; the rule now applies uniformly without exceptions.
  * PascalCase type variants (e.g., `Integer`, `Boolean`) are treated as user-defined classes and permitted.

* **Tests**
  * Updated test coverage to reflect new rule behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/phpstan-rules/pull/198)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->