### PR TITLE
Extend ProhibitLongTypeAliasRule with scalar, mixed, resource Pseudo-Types

### DIFF
--- a/src/Rules/ProhibitLongTypeAliasRule.php
+++ b/src/Rules/ProhibitLongTypeAliasRule.php
@@ -126,6 +126,27 @@ final readonly class ProhibitLongTypeAliasRule implements Rule
     }
 
     /**
+     * Checks a single identifier type node against alias and pseudo-type lists.
+     *
+     * @return list<string>
+     */
+    private function checkIdentifier(IdentifierTypeNode $type): array
+    {
+        $lower = strtolower($type->name);
+        $pascal = ucfirst($lower);
+
+        if (array_key_exists($lower, self::ALIAS_MAP) && $type->name !== $pascal) {
+            return [$type->name];
+        }
+
+        if (in_array($lower, self::PSEUDO_TYPES, true) && $type->name !== $lower && $type->name !== $pascal) {
+            return [$type->name];
+        }
+
+        return [];
+    }
+
+    /**
      * Recursively collects long alias names found anywhere inside the type tree.
      *
      * @return list<string>
@@ -133,17 +154,7 @@ final readonly class ProhibitLongTypeAliasRule implements Rule
     private function collectAliases(TypeNode $type): array
     {
         if ($type instanceof IdentifierTypeNode) {
-            $lower = strtolower($type->name);
-
-            if (array_key_exists($lower, self::ALIAS_MAP) && $type->name !== ucfirst($lower)) {
-                return [$type->name];
-            }
-
-            if (in_array($lower, self::PSEUDO_TYPES, true) && $type->name !== $lower && $type->name !== ucfirst($lower)) {
-                return [$type->name];
-            }
-
-            return [];
+            return $this->checkIdentifier($type);
         }
 
         if ($type instanceof UnionTypeNode || $type instanceof IntersectionTypeNode) {

--- a/src/Rules/ProhibitLongTypeAliasRule.php
+++ b/src/Rules/ProhibitLongTypeAliasRule.php
@@ -20,10 +20,12 @@ use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\ShouldNotHappenException;
 
 /**
- * Checks that PHPDoc tags do not use long built-in type aliases.
- * Disallows `integer`, `boolean`, `double`, and `real` (and any non-PascalCase variant such as
- * `INTEGER`) in favour of their canonical short forms (`int`, `bool`, `float`).
- * PascalCase names like `Integer` or `Boolean` are treated as user-defined classes and allowed.
+ * Checks that PHPDoc tags do not use long built-in type aliases or miscase built-in pseudo-types.
+ * Disallows `integer`, `boolean`, `double`, and `real` in favour of their canonical short forms
+ * (`int`, `bool`, `float`). Also disallows non-lowercase `scalar`, `mixed`, and `resource`
+ * (and any non-PascalCase variant such as `INTEGER` or `SCALAR`) since these are built-in
+ * pseudo-types with no shorter alias.
+ * PascalCase names like `Integer`, `Scalar`, or `Mixed` are treated as user-defined classes and allowed.
  * Covers @param, @return, @throws in methods and @var on properties.
  * Types nested inside union and intersection types are checked recursively.
  *
@@ -36,6 +38,9 @@ final readonly class ProhibitLongTypeAliasRule implements Rule
         'boolean' => 'bool',
         'double' => 'float',
         'real' => 'float',
+        'scalar' => 'scalar',
+        'mixed' => 'mixed',
+        'resource' => 'resource',
     ];
 
     private PhpDocDescriptionChecker $checker;

--- a/src/Rules/ProhibitLongTypeAliasRule.php
+++ b/src/Rules/ProhibitLongTypeAliasRule.php
@@ -23,7 +23,7 @@ use PHPStan\ShouldNotHappenException;
  * Checks that PHPDoc tags do not use long built-in type aliases or miscase built-in pseudo-types.
  * Disallows `integer`, `boolean`, `double`, and `real` in favour of their canonical short forms
  * (`int`, `bool`, `float`). Also disallows non-lowercase `scalar`, `mixed`, and `resource`
- * (and any non-PascalCase variant such as `INTEGER` or `SCALAR`) since these are built-in
+ * (and any non-lowercase, non-PascalCase variant such as `INTEGER` or `SCALAR`) since these are built-in
  * pseudo-types with no shorter alias.
  * PascalCase names like `Integer`, `Scalar`, or `Mixed` are treated as user-defined classes and allowed.
  * Covers @param, @return, @throws in methods and @var on properties.
@@ -38,9 +38,12 @@ final readonly class ProhibitLongTypeAliasRule implements Rule
         'boolean' => 'bool',
         'double' => 'float',
         'real' => 'float',
-        'scalar' => 'scalar',
-        'mixed' => 'mixed',
-        'resource' => 'resource',
+    ];
+
+    private const array PSEUDO_TYPES = [
+        'scalar',
+        'mixed',
+        'resource',
     ];
 
     private PhpDocDescriptionChecker $checker;
@@ -91,11 +94,13 @@ final readonly class ProhibitLongTypeAliasRule implements Rule
             }
 
             foreach ($this->collectAliases($type) as $alias) {
+                $lower = strtolower($alias);
+                $canonical = self::ALIAS_MAP[$lower] ?? $lower;
                 $errors[] = RuleErrorBuilder::message(
                     sprintf(
                         'PHPDoc contains long type alias "%s", use "%s" instead.',
                         $alias,
-                        self::ALIAS_MAP[strtolower($alias)],
+                        $canonical,
                     ),
                 )
                     ->identifier('haspadar.prohibitLongTypeAlias')
@@ -131,6 +136,10 @@ final readonly class ProhibitLongTypeAliasRule implements Rule
             $lower = strtolower($type->name);
 
             if (array_key_exists($lower, self::ALIAS_MAP) && $type->name !== ucfirst($lower)) {
+                return [$type->name];
+            }
+
+            if (in_array($lower, self::PSEUDO_TYPES, true) && $type->name !== $lower && $type->name !== ucfirst($lower)) {
                 return [$type->name];
             }
 

--- a/tests/Fixtures/Rules/ProhibitLongTypeAliasRule/ClassWithAllowedPseudoTypes.php
+++ b/tests/Fixtures/Rules/ProhibitLongTypeAliasRule/ClassWithAllowedPseudoTypes.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ProhibitLongTypeAliasRule;
+
+final class ClassWithAllowedPseudoTypes
+{
+    /**
+     * Processes a value.
+     *
+     * @param Scalar $a User-defined class.
+     * @param Mixed $b User-defined class.
+     * @param Resource $c User-defined class.
+     * @return void
+     */
+    public function process(object $a, object $b, object $c): void
+    {
+    }
+}

--- a/tests/Fixtures/Rules/ProhibitLongTypeAliasRule/ClassWithMiscasedPseudoTypes.php
+++ b/tests/Fixtures/Rules/ProhibitLongTypeAliasRule/ClassWithMiscasedPseudoTypes.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ProhibitLongTypeAliasRule;
+
+final class ClassWithMiscasedPseudoTypes
+{
+    /**
+     * Processes a value.
+     *
+     * @param SCALAR $a Input value.
+     * @param MIXED $b Mixed value.
+     * @param RESOURCE $c Resource handle.
+     * @return void
+     */
+    public function process(mixed $a, mixed $b, mixed $c): void
+    {
+    }
+}

--- a/tests/Fixtures/Rules/ProhibitLongTypeAliasRule/ClassWithShortTypes.php
+++ b/tests/Fixtures/Rules/ProhibitLongTypeAliasRule/ClassWithShortTypes.php
@@ -16,4 +16,16 @@ final class ClassWithShortTypes
     {
         return $n > 0;
     }
+
+    /**
+     * Processes a value.
+     *
+     * @param scalar $a Scalar value.
+     * @param mixed $b Mixed value.
+     * @param resource $c Resource handle.
+     * @return void
+     */
+    public function process(mixed $a, mixed $b, mixed $c): void
+    {
+    }
 }

--- a/tests/Unit/Rules/ProhibitLongTypeAliasRule/ProhibitLongTypeAliasRuleAllowedAliasTest.php
+++ b/tests/Unit/Rules/ProhibitLongTypeAliasRule/ProhibitLongTypeAliasRuleAllowedAliasTest.php
@@ -30,6 +30,16 @@ final class ProhibitLongTypeAliasRuleAllowedAliasTest extends RuleTestCase
     }
 
     #[Test]
+    public function passesWhenPascalCasePseudoTypeUsed(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ProhibitLongTypeAliasRule/ClassWithAllowedPseudoTypes.php'],
+            [],
+            '"Scalar", "Mixed", "Resource" in PascalCase must be treated as user-defined classes and allowed',
+        );
+    }
+
+    #[Test]
     public function reportsErrorWhenUppercaseAliasUsed(): void
     {
         $this->analyse(

--- a/tests/Unit/Rules/ProhibitLongTypeAliasRule/ProhibitLongTypeAliasRuleTest.php
+++ b/tests/Unit/Rules/ProhibitLongTypeAliasRule/ProhibitLongTypeAliasRuleTest.php
@@ -135,4 +135,18 @@ final class ProhibitLongTypeAliasRuleTest extends RuleTestCase
         );
     }
 
+    #[Test]
+    public function reportsErrorWhenScalarMixedResourceUsedInWrongCase(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ProhibitLongTypeAliasRule/ClassWithMiscasedPseudoTypes.php'],
+            [
+                ['PHPDoc contains long type alias "MIXED", use "mixed" instead.', 17],
+                ['PHPDoc contains long type alias "RESOURCE", use "resource" instead.', 17],
+                ['PHPDoc contains long type alias "SCALAR", use "scalar" instead.', 17],
+            ],
+            '"SCALAR", "MIXED", "RESOURCE" in all-caps must be reported',
+        );
+    }
+
 }

--- a/tests/Unit/Rules/ProhibitLongTypeAliasRule/ProhibitLongTypeAliasRuleTest.php
+++ b/tests/Unit/Rules/ProhibitLongTypeAliasRule/ProhibitLongTypeAliasRuleTest.php
@@ -136,7 +136,7 @@ final class ProhibitLongTypeAliasRuleTest extends RuleTestCase
     }
 
     #[Test]
-    public function reportsErrorWhenScalarMixedResourceUsedInWrongCase(): void
+    public function reportsErrorWhenAllCapsPseudoTypesUsedInParam(): void
     {
         $this->analyse(
             [__DIR__ . '/../../../Fixtures/Rules/ProhibitLongTypeAliasRule/ClassWithMiscasedPseudoTypes.php'],
@@ -145,7 +145,17 @@ final class ProhibitLongTypeAliasRuleTest extends RuleTestCase
                 ['PHPDoc contains long type alias "RESOURCE", use "resource" instead.', 17],
                 ['PHPDoc contains long type alias "SCALAR", use "scalar" instead.', 17],
             ],
-            '"SCALAR", "MIXED", "RESOURCE" in all-caps must be reported',
+            '"SCALAR", "MIXED", "RESOURCE" in all-caps in @param must each produce an error with lowercase suggestion',
+        );
+    }
+
+    #[Test]
+    public function passesWhenLowercasePseudoTypesUsed(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ProhibitLongTypeAliasRule/ClassWithShortTypes.php'],
+            [],
+            'Lowercase scalar/mixed/resource in @param must not produce any errors',
         );
     }
 


### PR DESCRIPTION
- Extended rule to flag non-lowercase scalar, mixed, and resource in PHPDoc
- Added PSEUDO_TYPES constant to distinguish pseudo-types (no short alias) from long aliases
- Added fixtures and tests for all-caps and PascalCase variants of new pseudo-types
- Added test to verify lowercase scalar/mixed/resource passes without errors

Closes #199