### PR TITLE
Allow Named Constructors As Opt-In Exception To Static Method Ban

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ includes:
 | `MutableExceptionRule`            | Exception classes must not have non-readonly properties                            |
 | `ReturnCountRule`                 | Method must not have more than 1 `return` statement (default: 1)                   |
 | `ProtectedMethodInFinalClassRule` | Final classes must not have `protected` methods                                    |
-| `ProhibitStaticMethodsRule`       | Classes must not declare `static` methods, all visibility by default               |
+| `ProhibitStaticMethodsRule`       | Classes must not declare `static` methods, all visibility by default; opt-in `allowNamedConstructors` permits `static fromX(): self { return new self(...); }` |
 | `ProhibitStaticPropertiesRule`    | Classes must not declare `static` properties of any visibility                     |
 | `ConstructorInitializationRule`   | Constructor must only assign `$this->property` or call `parent::__construct()`     |
 | `BeImmutableRule`                | All non-static properties must be `readonly`                                       |
@@ -139,6 +139,7 @@ parameters:
             onlyPublic: true
         prohibitStaticMethods:
             onlyPublic: true
+            allowNamedConstructors: true
         parameterNumber:
             maxParameters: 5
             ignoreOverridden: false

--- a/rules.neon
+++ b/rules.neon
@@ -186,6 +186,7 @@ parameters:
             maxThrows: 1
         prohibitStaticMethods:
             onlyPublic: false
+            allowNamedConstructors: false
     exceptions:
         check:
             missingCheckedExceptionInThrows: false
@@ -358,6 +359,7 @@ parametersSchema:
         ]),
         prohibitStaticMethods: structure([
             onlyPublic: bool(),
+            allowNamedConstructors: bool(),
         ]),
     ])
 
@@ -460,6 +462,7 @@ services:
         arguments:
             options:
                 onlyPublic: %haspadar.prohibitStaticMethods.onlyPublic%
+                allowNamedConstructors: %haspadar.prohibitStaticMethods.allowNamedConstructors%
         tags:
             - phpstan.rules.rule
     -

--- a/src/Rules/ProhibitStaticMethodsRule.php
+++ b/src/Rules/ProhibitStaticMethodsRule.php
@@ -6,7 +6,10 @@ namespace Haspadar\PHPStanRules\Rules;
 
 use Override;
 use PhpParser\Node;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Return_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\Rule;
@@ -22,20 +25,29 @@ use PHPStan\ShouldNotHappenException;
  * When `onlyPublic` option is true, only public static methods are reported — mirroring Qulice's
  * `ProhibitPublicStaticMethods` behaviour and allowing private/protected static helpers.
  *
+ * When `allowNamedConstructors` option is true, a static method is allowed if and only if it is a
+ * named constructor: return type `self` or `static`, body consisting of exactly one
+ * `return new self(...)` or `return new static(...)` statement. Static methods that return
+ * `self`/`static` but contain any other logic are reported as invalid named constructors —
+ * enforcing the cactoos "one primary constructor" principle.
+ *
  * @implements Rule<ClassMethod>
  */
 final readonly class ProhibitStaticMethodsRule implements Rule
 {
     private bool $onlyPublic;
 
+    private bool $allowNamedConstructors;
+
     /**
      * Constructs the rule with the given options.
      *
-     * @param array{onlyPublic?: bool} $options When onlyPublic is true, only public static methods are reported
+     * @param array{onlyPublic?: bool, allowNamedConstructors?: bool} $options Rule options: `onlyPublic` restricts checks to public static methods; `allowNamedConstructors` permits named constructors
      */
     public function __construct(array $options = [])
     {
         $this->onlyPublic = $options['onlyPublic'] ?? false;
+        $this->allowNamedConstructors = $options['allowNamedConstructors'] ?? false;
     }
 
     #[Override]
@@ -66,17 +78,86 @@ final readonly class ProhibitStaticMethodsRule implements Rule
         $className = $reflection === null || $reflection->isAnonymous()
             ? 'class@anonymous'
             : $reflection->getName();
+        $methodName = $node->name->toString();
+
+        if ($this->allowNamedConstructors && $this->returnsSelfOrStatic($node)) {
+            if ($this->isNamedConstructorBody($node)) {
+                return [];
+            }
+
+            return [
+                RuleErrorBuilder::message(
+                    sprintf(
+                        'Method %s::%s() is not a valid named constructor: body must be a single `return new self(...)` or `return new static(...)`. Move logic to the primary __construct().',
+                        $className,
+                        $methodName,
+                    ),
+                )
+                    ->identifier('haspadar.namedConstructorBody')
+                    ->build(),
+            ];
+        }
 
         return [
             RuleErrorBuilder::message(
                 sprintf(
                     'Method %s::%s() is static. Static methods are prohibited.',
                     $className,
-                    $node->name->toString(),
+                    $methodName,
                 ),
             )
                 ->identifier('haspadar.staticMethod')
                 ->build(),
         ];
+    }
+
+    /**
+     * Checks whether the method's return type is declared as `self` or `static`.
+     *
+     * @param ClassMethod $node Analysed method
+     * @return bool True when the return type is `self` or `static`
+     */
+    private function returnsSelfOrStatic(ClassMethod $node): bool
+    {
+        $returnType = $node->returnType;
+
+        if (!$returnType instanceof Name) {
+            return false;
+        }
+
+        $name = $returnType->toLowerString();
+
+        return $name === 'self' || $name === 'static';
+    }
+
+    /**
+     * Checks whether the method body is exactly one `return new self(...)` or `return new static(...)`.
+     *
+     * @param ClassMethod $node Analysed method
+     * @return bool True when the body matches the strict named-constructor shape
+     */
+    private function isNamedConstructorBody(ClassMethod $node): bool
+    {
+        $stmts = $node->stmts;
+
+        if ($stmts === null || count($stmts) !== 1) {
+            return false;
+        }
+
+        $only = $stmts[0];
+
+        if (!$only instanceof Return_ || !$only->expr instanceof New_) {
+            return false;
+        }
+
+        $class = $only->expr->class;
+
+        if ($class instanceof Name) {
+            $name = $class->toLowerString();
+
+            return $name === 'self' || $name === 'static';
+        }
+
+        return false;
     }
 }

--- a/src/Rules/ProhibitStaticMethodsRule.php
+++ b/src/Rules/ProhibitStaticMethodsRule.php
@@ -8,6 +8,7 @@ use Override;
 use PhpParser\Node;
 use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Name;
+use PhpParser\Node\NullableType;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Return_;
 use PHPStan\Analyser\Scope;
@@ -112,14 +113,18 @@ final readonly class ProhibitStaticMethodsRule implements Rule
     }
 
     /**
-     * Checks whether the method's return type is declared as `self` or `static`.
+     * Checks whether the method's return type is declared as `self`, `static`, `?self`, or `?static`.
      *
      * @param ClassMethod $node Analysed method
-     * @return bool True when the return type is `self` or `static`
+     * @return bool True when the return type (possibly nullable) is `self` or `static`
      */
     private function returnsSelfOrStatic(ClassMethod $node): bool
     {
         $returnType = $node->returnType;
+
+        if ($returnType instanceof NullableType) {
+            $returnType = $returnType->type;
+        }
 
         if (!$returnType instanceof Name) {
             return false;

--- a/tests/Fixtures/Rules/ProhibitStaticMethodsRule/NamedConstructorNullableSelf.php
+++ b/tests/Fixtures/Rules/ProhibitStaticMethodsRule/NamedConstructorNullableSelf.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ProhibitStaticMethodsRule;
+
+final class NamedConstructorNullableSelf
+{
+    public function __construct(private readonly int $id)
+    {
+    }
+
+    public static function fromId(int $id): ?self
+    {
+        $cached = null;
+
+        return $cached ?? new self($id);
+    }
+}

--- a/tests/Fixtures/Rules/ProhibitStaticMethodsRule/NamedConstructorValid.php
+++ b/tests/Fixtures/Rules/ProhibitStaticMethodsRule/NamedConstructorValid.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ProhibitStaticMethodsRule;
+
+final class NamedConstructorValid
+{
+    public function __construct(private readonly int $id)
+    {
+    }
+
+    public static function fromId(int $id): self
+    {
+        return new self($id);
+    }
+}

--- a/tests/Fixtures/Rules/ProhibitStaticMethodsRule/NamedConstructorValidStatic.php
+++ b/tests/Fixtures/Rules/ProhibitStaticMethodsRule/NamedConstructorValidStatic.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ProhibitStaticMethodsRule;
+
+class NamedConstructorValidStatic
+{
+    public function __construct(protected readonly int $id)
+    {
+    }
+
+    public static function fromId(int $id): static
+    {
+        return new static($id);
+    }
+}

--- a/tests/Fixtures/Rules/ProhibitStaticMethodsRule/NamedConstructorWithFqnSelf.php
+++ b/tests/Fixtures/Rules/ProhibitStaticMethodsRule/NamedConstructorWithFqnSelf.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ProhibitStaticMethodsRule;
+
+final class NamedConstructorWithFqnSelf
+{
+    public function __construct(private readonly int $id)
+    {
+    }
+
+    public static function fromId(int $id): self
+    {
+        return new \Haspadar\PHPStanRules\Tests\Fixtures\Rules\ProhibitStaticMethodsRule\NamedConstructorWithFqnSelf($id);
+    }
+}

--- a/tests/Fixtures/Rules/ProhibitStaticMethodsRule/NamedConstructorWithIfElse.php
+++ b/tests/Fixtures/Rules/ProhibitStaticMethodsRule/NamedConstructorWithIfElse.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ProhibitStaticMethodsRule;
+
+final class NamedConstructorWithIfElse
+{
+    public function __construct(private readonly int $id)
+    {
+    }
+
+    public static function fromMixed(int|string $id): self
+    {
+        if (is_int($id)) {
+            return new self($id);
+        }
+
+        return new self((int) $id);
+    }
+}

--- a/tests/Fixtures/Rules/ProhibitStaticMethodsRule/NamedConstructorWithLogic.php
+++ b/tests/Fixtures/Rules/ProhibitStaticMethodsRule/NamedConstructorWithLogic.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ProhibitStaticMethodsRule;
+
+final class NamedConstructorWithLogic
+{
+    public function __construct(private readonly int $id)
+    {
+    }
+
+    public static function fromArray(array $row): self
+    {
+        $id = (int) $row['id'];
+
+        return new self($id);
+    }
+}

--- a/tests/Fixtures/Rules/ProhibitStaticMethodsRule/PublicNamedConstructorWithPrivateStaticHelper.php
+++ b/tests/Fixtures/Rules/ProhibitStaticMethodsRule/PublicNamedConstructorWithPrivateStaticHelper.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ProhibitStaticMethodsRule;
+
+final class PublicNamedConstructorWithPrivateStaticHelper
+{
+    public function __construct(private readonly int $id)
+    {
+    }
+
+    public static function fromId(int $id): self
+    {
+        return new self($id);
+    }
+
+    private static function helper(): string
+    {
+        return 'h';
+    }
+}

--- a/tests/Fixtures/Rules/ProhibitStaticMethodsRule/StaticReturningSelfButNotNew.php
+++ b/tests/Fixtures/Rules/ProhibitStaticMethodsRule/StaticReturningSelfButNotNew.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Fixtures\Rules\ProhibitStaticMethodsRule;
+
+final class StaticReturningSelfButNotNew
+{
+    private static self $instance;
+
+    public function __construct(private readonly int $id)
+    {
+    }
+
+    public static function shared(): self
+    {
+        return self::$instance;
+    }
+}

--- a/tests/Unit/Rules/ProhibitStaticMethodsRule/ProhibitStaticMethodsRuleAllowNamedConstructorsTest.php
+++ b/tests/Unit/Rules/ProhibitStaticMethodsRule/ProhibitStaticMethodsRuleAllowNamedConstructorsTest.php
@@ -83,4 +83,49 @@ final class ProhibitStaticMethodsRuleAllowNamedConstructorsTest extends RuleTest
             'Static method without self/static return type must still trigger the standard prohibition',
         );
     }
+
+    #[Test]
+    public function reportsNamedConstructorWithNullableSelfWhenBodyHasLogic(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ProhibitStaticMethodsRule/NamedConstructorNullableSelf.php'],
+            [
+                [
+                    'Method Haspadar\PHPStanRules\Tests\Fixtures\Rules\ProhibitStaticMethodsRule\NamedConstructorNullableSelf::fromId() is not a valid named constructor: body must be a single `return new self(...)` or `return new static(...)`. Move logic to the primary __construct().',
+                    13,
+                ],
+            ],
+            'Nullable self/static return types must be normalized so named-constructor validation applies the same way',
+        );
+    }
+
+    #[Test]
+    public function reportsNamedConstructorWithIfElseBranches(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ProhibitStaticMethodsRule/NamedConstructorWithIfElse.php'],
+            [
+                [
+                    'Method Haspadar\PHPStanRules\Tests\Fixtures\Rules\ProhibitStaticMethodsRule\NamedConstructorWithIfElse::fromMixed() is not a valid named constructor: body must be a single `return new self(...)` or `return new static(...)`. Move logic to the primary __construct().',
+                    13,
+                ],
+            ],
+            'Branching via if/else with multiple new self statements is not a single delegation',
+        );
+    }
+
+    #[Test]
+    public function reportsNamedConstructorWithFqnSelfInstead(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ProhibitStaticMethodsRule/NamedConstructorWithFqnSelf.php'],
+            [
+                [
+                    'Method Haspadar\PHPStanRules\Tests\Fixtures\Rules\ProhibitStaticMethodsRule\NamedConstructorWithFqnSelf::fromId() is not a valid named constructor: body must be a single `return new self(...)` or `return new static(...)`. Move logic to the primary __construct().',
+                    13,
+                ],
+            ],
+            'Fully-qualified self-referencing class name is not recognised as `new self` and must be reported',
+        );
+    }
 }

--- a/tests/Unit/Rules/ProhibitStaticMethodsRule/ProhibitStaticMethodsRuleAllowNamedConstructorsTest.php
+++ b/tests/Unit/Rules/ProhibitStaticMethodsRule/ProhibitStaticMethodsRuleAllowNamedConstructorsTest.php
@@ -128,4 +128,30 @@ final class ProhibitStaticMethodsRuleAllowNamedConstructorsTest extends RuleTest
             'Fully-qualified self-referencing class name is not recognised as `new self` and must be reported',
         );
     }
+
+    #[Test]
+    public function tagsEveryInvalidNamedConstructorWithDedicatedIdentifier(): void
+    {
+        $errors = $this->gatherAnalyserErrors([
+            __DIR__ . '/../../../Fixtures/Rules/ProhibitStaticMethodsRule/NamedConstructorWithLogic.php',
+            __DIR__ . '/../../../Fixtures/Rules/ProhibitStaticMethodsRule/StaticReturningSelfButNotNew.php',
+            __DIR__ . '/../../../Fixtures/Rules/ProhibitStaticMethodsRule/NamedConstructorNullableSelf.php',
+            __DIR__ . '/../../../Fixtures/Rules/ProhibitStaticMethodsRule/NamedConstructorWithIfElse.php',
+            __DIR__ . '/../../../Fixtures/Rules/ProhibitStaticMethodsRule/NamedConstructorWithFqnSelf.php',
+        ]);
+
+        $identifiers = array_map(static fn ($error): ?string => $error->getIdentifier(), $errors);
+
+        self::assertSame(
+            [
+                'haspadar.namedConstructorBody',
+                'haspadar.namedConstructorBody',
+                'haspadar.namedConstructorBody',
+                'haspadar.namedConstructorBody',
+                'haspadar.namedConstructorBody',
+            ],
+            $identifiers,
+            'Every invalid named-constructor case must be tagged with the dedicated haspadar.namedConstructorBody identifier',
+        );
+    }
 }

--- a/tests/Unit/Rules/ProhibitStaticMethodsRule/ProhibitStaticMethodsRuleAllowNamedConstructorsTest.php
+++ b/tests/Unit/Rules/ProhibitStaticMethodsRule/ProhibitStaticMethodsRuleAllowNamedConstructorsTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\ProhibitStaticMethodsRule;
+
+use Haspadar\PHPStanRules\Rules\ProhibitStaticMethodsRule;
+use Override;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<ProhibitStaticMethodsRule> */
+final class ProhibitStaticMethodsRuleAllowNamedConstructorsTest extends RuleTestCase
+{
+    #[Override]
+    protected function getRule(): Rule
+    {
+        return new ProhibitStaticMethodsRule(['allowNamedConstructors' => true]);
+    }
+
+    #[Test]
+    public function passesWhenNamedConstructorReturnsNewSelf(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ProhibitStaticMethodsRule/NamedConstructorValid.php'],
+            [],
+            'Static method returning self with a single `return new self(...)` is a valid named constructor',
+        );
+    }
+
+    #[Test]
+    public function passesWhenNamedConstructorReturnsNewStatic(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ProhibitStaticMethodsRule/NamedConstructorValidStatic.php'],
+            [],
+            'Static method returning static with a single `return new static(...)` is a valid named constructor',
+        );
+    }
+
+    #[Test]
+    public function reportsNamedConstructorWithExtraLogic(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ProhibitStaticMethodsRule/NamedConstructorWithLogic.php'],
+            [
+                [
+                    'Method Haspadar\PHPStanRules\Tests\Fixtures\Rules\ProhibitStaticMethodsRule\NamedConstructorWithLogic::fromArray() is not a valid named constructor: body must be a single `return new self(...)` or `return new static(...)`. Move logic to the primary __construct().',
+                    13,
+                ],
+            ],
+            'Static method returning self but containing extra statements must be flagged as invalid named constructor',
+        );
+    }
+
+    #[Test]
+    public function reportsStaticReturningSelfWithoutNew(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ProhibitStaticMethodsRule/StaticReturningSelfButNotNew.php'],
+            [
+                [
+                    'Method Haspadar\PHPStanRules\Tests\Fixtures\Rules\ProhibitStaticMethodsRule\StaticReturningSelfButNotNew::shared() is not a valid named constructor: body must be a single `return new self(...)` or `return new static(...)`. Move logic to the primary __construct().',
+                    15,
+                ],
+            ],
+            'Static method returning self via cached instance is not a named constructor',
+        );
+    }
+
+    #[Test]
+    public function reportsStaticWithoutSelfReturnAsStandardViolation(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ProhibitStaticMethodsRule/ClassWithPrivateStaticMethod.php'],
+            [
+                [
+                    'Method Haspadar\PHPStanRules\Tests\Fixtures\Rules\ProhibitStaticMethodsRule\ClassWithPrivateStaticMethod::helper() is static. Static methods are prohibited.',
+                    9,
+                ],
+            ],
+            'Static method without self/static return type must still trigger the standard prohibition',
+        );
+    }
+}

--- a/tests/Unit/Rules/ProhibitStaticMethodsRule/ProhibitStaticMethodsRuleOnlyPublicAndNamedConstructorsTest.php
+++ b/tests/Unit/Rules/ProhibitStaticMethodsRule/ProhibitStaticMethodsRuleOnlyPublicAndNamedConstructorsTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haspadar\PHPStanRules\Tests\Unit\Rules\ProhibitStaticMethodsRule;
+
+use Haspadar\PHPStanRules\Rules\ProhibitStaticMethodsRule;
+use Override;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<ProhibitStaticMethodsRule> */
+final class ProhibitStaticMethodsRuleOnlyPublicAndNamedConstructorsTest extends RuleTestCase
+{
+    #[Override]
+    protected function getRule(): Rule
+    {
+        return new ProhibitStaticMethodsRule([
+            'onlyPublic' => true,
+            'allowNamedConstructors' => true,
+        ]);
+    }
+
+    #[Test]
+    public function passesWhenPublicNamedConstructorAndPrivateStaticHelperCoexist(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ProhibitStaticMethodsRule/PublicNamedConstructorWithPrivateStaticHelper.php'],
+            [],
+            'onlyPublic must exempt private static helpers and allowNamedConstructors must permit the public named constructor',
+        );
+    }
+
+    #[Test]
+    public function reportsPublicStaticHelperWhenNotNamedConstructor(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../Fixtures/Rules/ProhibitStaticMethodsRule/ClassWithPublicStaticMethod.php'],
+            [],
+            'Public static method whose body is `return new self()` is a valid named constructor and must pass',
+        );
+    }
+}


### PR DESCRIPTION
- Added `allowNamedConstructors` option to `ProhibitStaticMethodsRule` permitting static methods whose body is exactly `return new self(...)` or `return new static(...)` with `self`/`static` return type (nullable forms normalized)
- Added `haspadar.namedConstructorBody` identifier reporting static methods that return `self`/`static` but contain extra statements, branches, or non-`new self`/`new static` returns
- Added fixtures and tests covering valid named constructors, body with logic, cached-instance return, nullable return type, if/else branching, FQN self-reference, and orthogonality with `onlyPublic`

Closes #203

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in allowNamedConstructors option allowing legitimate named-constructor-style static methods (single direct return of a new instance) to be permitted.

* **Documentation**
  * Updated README and configuration examples to show and document the new option and how to enable it by default.

* **Tests**
  * Added comprehensive tests and fixtures covering accepted and rejected named-constructor patterns and related behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/phpstan-rules/pull/204)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->